### PR TITLE
Task/allow different tokens by audience

### DIFF
--- a/src/facilities.js
+++ b/src/facilities.js
@@ -1,10 +1,8 @@
-import Request from './request';
-
 const baseUrl = 'https://facilities.api.ndustrial.io/v1';
 
 class Facilities {
-  constructor(sdk) {
-    this._request = new Request(sdk, 'facilities');
+  constructor(sdk, request) {
+    this._request = request;
     this._sdk = sdk;
   }
 

--- a/src/facilities.spec.js
+++ b/src/facilities.spec.js
@@ -1,12 +1,13 @@
 import Facilities from './facilities';
-import Request from './request';
 
 describe('Facilities', function() {
+  let baseRequest;
   let baseSdk;
 
   beforeEach(function() {
     this.sandbox = sandbox.create();
 
+    baseRequest = {};
     baseSdk = {};
   });
 
@@ -18,11 +19,11 @@ describe('Facilities', function() {
     let facilities;
 
     beforeEach(function() {
-      facilities = new Facilities(baseSdk);
+      facilities = new Facilities(baseSdk, baseRequest);
     });
 
-    it('sets an instance of Request', function() {
-      expect(facilities._request).to.be.an.instanceof(Request);
+    it('appends the supplied request module to the class instance', function() {
+      expect(facilities._request).to.equal(baseRequest);
     });
 
     it('appends the supplied sdk to the class instance', function() {
@@ -32,20 +33,22 @@ describe('Facilities', function() {
 
   describe('getAll', function() {
     let expectedFacilities;
-    let get;
     let promise;
+    let request;
 
     beforeEach(function() {
       expectedFacilities = [faker.helpers.createTransaction()];
+      request = {
+        ...baseRequest,
+        get: this.sandbox.stub().resolves({ data: expectedFacilities })
+      };
 
-      const facilities = new Facilities();
-      get = this.sandbox.stub(facilities._request, 'get').resolves({ data: expectedFacilities });
-
+      const facilities = new Facilities(baseSdk, request);
       promise = facilities.getAll();
     });
 
     it('gets a list of facilities from the server', function() {
-      expect(get).to.be.calledWith('https://facilities.api.ndustrial.io/v1/facilities');
+      expect(request.get).to.be.calledWith('https://facilities.api.ndustrial.io/v1/facilities');
     });
 
     it('returns a list of facilities', function() {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import Facilities from './facilities';
+import Request from './request';
 import * as sessionTypes from './sessionTypes';
 
 class ContxtSdk {
@@ -6,7 +7,7 @@ class ContxtSdk {
     this.config = config;
 
     this.auth = this._createAuthSession(sessionType);
-    this.facilities = new Facilities(this);
+    this.facilities = new Facilities(this, this._createRequest('facilities'));
 
     this._decorate(additionalModules);
   }
@@ -21,9 +22,13 @@ class ContxtSdk {
     }
   }
 
+  _createRequest(audienceName) {
+    return new Request(this, audienceName);
+  }
+
   _decorate(modules) {
     Object.keys(modules).forEach((moduleName) => {
-      this[moduleName] = new modules[moduleName].module(this);
+      this[moduleName] = new modules[moduleName].module(this, this._createRequest(moduleName));
     });
   }
 }

--- a/src/request.js
+++ b/src/request.js
@@ -2,8 +2,8 @@ import axios from 'axios';
 
 class Request {
   constructor(sdk, audienceName) {
-    this._sdk = sdk;
     this._audienceName = audienceName;
+    this._sdk = sdk;
     this._axios = axios.create();
 
     this._axios.interceptors.request.use(this._insertHeaders);

--- a/src/request.spec.js
+++ b/src/request.spec.js
@@ -36,12 +36,12 @@ describe('Request', function() {
       request = new Request(baseSdk, expectedAudienceName);
     });
 
-    it('appends the supplied sdk to the class instance', function() {
-      expect(request._sdk).to.equal(baseSdk);
-    });
-
     it('appends the audience name of the parent to the class instance', function() {
       expect(request._audienceName).to.equal(expectedAudienceName);
+    });
+
+    it('appends the supplied sdk to the class instance', function() {
+      expect(request._sdk).to.equal(baseSdk);
     });
 
     it('creates an axios instance and appends it to the class instance', function() {


### PR DESCRIPTION
## Why?
With the web auth process, we generate a JWT for Contxt authorization that can be used across multiple audiences. For machine to machine communication, this JWT is only good for a single audience. We need to accommodate both circumstances.

## What changed?
- Each module is passed it's own copy of the Request module to use
  - Request module is created with the audience name so the name can be passed to the Auth module for each request
  - Auth module can use audience name to get correct JWT
    - For Auth0WebAuth module, it will disregard the audience name since it's JWTs work across multiple audiences
    - For the future machine to machine module, it will use the audience name to grab the correct JWT