### PR TITLE
Add npmignore to make sure build dirs are included

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+.github
+.nyc_output
+coverage

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ndustrial/contxt-sdk",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -8,6 +8,7 @@
     "build": "rollup -c",
     "coverage": "nyc npm run test:js",
     "lint": "eslint --format 'node_modules/eslint-friendly-formatter' '+(src|support)/**/*.js'",
+    "prepare": "npm run build",
     "report": "nyc report",
     "test": "npm run lint && npm run coverage",
     "test:js": "NODE_ENV=test mocha --opts 'support/mocha.opts' 'src/**/*.spec.js'",
@@ -17,7 +18,6 @@
   },
   "author": "ndustrial.io <dev@ndustrial.io> (ndustrial.io)",
   "license": "ISC",
-  "private": true,
   "dependencies": {
     "url-parse": "^1.2.0"
   },


### PR DESCRIPTION
## Why?
An oversight caused the built files to not be published to NPM, which caused the package to not run.

## What changed?
- Added an npmignore file that allows the build dirs to be published to NPM
- Added a `prepare` script so that the package is rebuilt before publishing
