### PR TITLE
Upgrade minimum version of Auth0 allowed to fix CVE 2018-7307

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -353,12 +353,12 @@
       "dev": true
     },
     "auth0-js": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/auth0-js/-/auth0-js-9.1.0.tgz",
-      "integrity": "sha1-Gevm5NX3jbH3dw+BOlYSiKGeqw8=",
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/auth0-js/-/auth0-js-9.3.2.tgz",
+      "integrity": "sha1-5sang4A+WXYpZGbTFPhmtz5ZfA8=",
       "dev": true,
       "requires": {
-        "base64-js": "1.2.1",
+        "base64-js": "1.2.3",
         "idtoken-verifier": "1.1.1",
         "qs": "6.5.1",
         "superagent": "3.8.2",
@@ -1235,9 +1235,9 @@
       }
     },
     "base64-js": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
-      "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.3.tgz",
+      "integrity": "sha512-MsAhsUW1GxCdgYSO6tAfZrNapmUKk7mWx/k5mFY/A1gBtkaCaNapTg+FExCw1r9yeaZhqx/xPg43xgTFH6KL5w==",
       "dev": true
     },
     "binary-extensions": {
@@ -1626,9 +1626,9 @@
       "dev": true
     },
     "combined-stream": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "dev": true,
       "requires": {
         "delayed-stream": "1.0.0"
@@ -2762,14 +2762,14 @@
       }
     },
     "form-data": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "dev": true,
       "requires": {
         "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
-        "mime-types": "2.1.17"
+        "combined-stream": "1.0.6",
+        "mime-types": "2.1.18"
       }
     },
     "formatio": {
@@ -2782,9 +2782,9 @@
       }
     },
     "formidable": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.1.1.tgz",
-      "integrity": "sha1-lriIb3w8NQi5Mta9cMTTqI818ak=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.0.tgz",
+      "integrity": "sha512-hr9aT30rAi7kf8Q2aaTpSP7xGMhlJ+MdrUDVZs3rxbD3L/K46A86s2VY7qC2D2kGYGBtiT/3j6wTx1eeUq5xAQ==",
       "dev": true
     },
     "fragment-cache": {
@@ -3948,7 +3948,7 @@
       "integrity": "sha512-G4pyuWg4hDV4V4n354OqfsQ6xfLUka8MCBKzhlDr8IyztfcZBRhZdt8TrHB5Ps+8wbdp7v+Q6CFYBA6/LfAYyA==",
       "dev": true,
       "requires": {
-        "base64-js": "1.2.1",
+        "base64-js": "1.2.3",
         "crypto-js": "3.1.9-1",
         "jsbn": "0.1.1",
         "superagent": "3.8.2",
@@ -4700,18 +4700,18 @@
       "dev": true
     },
     "mime-db": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.17",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "dev": true,
       "requires": {
-        "mime-db": "1.30.0"
+        "mime-db": "1.33.0"
       }
     },
     "mimic-fn": {
@@ -7975,8 +7975,8 @@
         "cookiejar": "2.1.1",
         "debug": "3.1.0",
         "extend": "3.0.1",
-        "form-data": "2.3.1",
-        "formidable": "1.1.1",
+        "form-data": "2.3.2",
+        "formidable": "1.2.0",
         "methods": "1.1.2",
         "mime": "1.6.0",
         "qs": "6.5.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url-parse": "^1.2.0"
   },
   "devDependencies": {
-    "auth0-js": "^9.0.0",
+    "auth0-js": "^9.3.0",
     "axios": "~0.17.0",
     "babel-eslint": "^8.2.1",
     "babel-plugin-external-helpers": "^6.22.0",
@@ -56,7 +56,7 @@
     "sinon-chai": "^2.14.0"
   },
   "peerDependencies": {
-    "auth0-js": "^9.0.0",
+    "auth0-js": "^9.3.0",
     "axios": "~0.17.0"
   }
 }


### PR DESCRIPTION
## Why?
There was a security vulnerability in older versions of Auth0. More information can be found [here](https://github.com/auth0/auth0.js/blob/master/security-incidents.md#security-vulnerability-details-for-auth0js--93) and [here](https://auth0.com/docs/security/bulletins/cve-2018-7307).

## What changed?
- Upgraded peer dependency to require at least version 9.3 of Auth0
- Upgraded dev dependency to require at least version 9.3 of Auth0
