### PR TITLE
Release v0.0.4 + Update documentation for auth0WebAuth and machineAuth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,22 @@
-## 0.0.3
+## [v0.0.4](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.4) (2018-03-08)
+
+**Added**
+- MachineAuth SessionType for use on Node.js projects
+
+**Changed**
+- Split API documentation into multiple files for easy reading and navigation
+
+**Fixed**
+- Updated required version of `auth0-js` to fix [CVS-2018-7307](https://auth0.com/docs/security/bulletins/cve-2018-7307)
+
+## v0.0.3 (2018-02-26)
 - Adds documentation!
 - Fixes bug where placement of customModuleConfigs and the chosen environment in the user config did not match up with what was in documentation
 
-## 0.0.2
+## v0.0.2 (2018-02-26)
 - Fixes publication process so that the built files are in the package grabbed from NPM
 
-## 0.0.1
+## v0.0.1 (2018-02-23)
 - Initial release
 - Provides Request, Config and an initial SessionType, Auth0WebAuth
 - Provides Facilities#get and Facilities#getAll

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ npm install --save auth0-js@^9.0.0 axios@~0.17.0
 Once installed, the minimum configuration you need to get going is to include the `clientId` of your application (from Auth0) and a string with the type of authentication you want to use (`auth0WebAuth` or `machineAuth`).
 
 ```
-import ContxtSdk from 'contxt-sdk';
+import ContxtSdk from '@ndustrial/contxt-sdk';
 
 const contxtSdk = new ContxtSdk({
   config: {

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm install --save auth0-js@^9.0.0 axios@~0.17.0
 
 ## Getting Started
 
-Once installed, the minimum configuration you need to get going is to include the `clientId` of your application (from Auth0) and a string with the type of authentication you want to use (`auth0WebAuth` or `machine`).
+Once installed, the minimum configuration you need to get going is to include the `clientId` of your application (from Auth0) and a string with the type of authentication you want to use (`auth0WebAuth` or `machineAuth`).
 
 ```
 import ContxtSdk from 'contxt-sdk';
@@ -35,7 +35,7 @@ contxtSdk.facilities.getAll().then((facilities) => {
 });
 ```
 
-More configuration options are in the [API docs](https://github.com/ndustrialio/contxt-sdk-js/blob/master/docs/ContxtSdk.md).
+Information about using the auth0WebAuth and machineAuth modules is available in the API docs [here (auth0WebAuth)](https://github.com/ndustrialio/contxt-sdk-js/blob/master/docs/Auth0WebAuth.md) and [here (machineAuth)](https://github.com/ndustrialio/contxt-sdk-js/blob/master/docs/MachineAuth.md). Additional information about configuration options can also be found in the [API docs](https://github.com/ndustrialio/contxt-sdk-js/blob/master/docs/ContxtSdk.md).
 
 ## Adding in external modules
 

--- a/docs/Auth0WebAuth.md
+++ b/docs/Auth0WebAuth.md
@@ -2,7 +2,12 @@
 
 ## Auth0WebAuth : [<code>SessionType</code>](./Typedefs.md#SessionType)
 A SessionType that allows the user to initially authenticate with Auth0 and then gain a valid JWT
-from the Contxt Auth service.
+from the Contxt Auth service. This would only be used in web applications. You will need to
+integrate this module's `logIn`, `logOut`, and `handleAuthentication` methods with your UI
+elements. `logIn` would be tied to a UI element to log the user in. `logOut` would be tied to a
+UI element to log the user out. `handleAuthentication` would be tied with your application's
+router and would be called when visting the route defined by `config.authorizationPath` (the
+default is `/callback`).
 
 **Kind**: global class  
 
@@ -32,6 +37,21 @@ from the Contxt Auth service.
 | sdk.config.auth.clientId | <code>string</code> | The Auth0 client id of this application |
 | [sdk.config.auth.onRedirect] | <code>function</code> | Redirect method used when navigating between   Auth0 callbacks |
 
+**Example**  
+```js
+import ContxtSdk from '@ndustrial/contxt-sdk';
+import history from '../services/history';
+
+const contxtSdk = new ContxtSDK({
+  config: {
+    auth: {
+      clientId: '<client id>',
+      onRedirect: (pathname) => history.push(pathname)
+    }
+  },
+  sessionType: 'auth0WebAuth'
+});
+```
 <a name="Auth0WebAuth+getCurrentAccessToken"></a>
 
 ### contxtSdk.auth.getCurrentAccessToken() ⇒ <code>Promise</code>

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -11,5 +11,5 @@ Module that merges user assigned configurations with default configurations.
 | Param | Type | Description |
 | --- | --- | --- |
 | userConfig | [<code>UserConfig</code>](./Typedefs.md#UserConfig) | The user provided configuration options |
-| [externalModules] | <code>Object</code> | User provided external modules that should be treated as   first class citizens |
+| [externalModules] | <code>Object.&lt;string, ExternalModule&gt;</code> | User provided external modules that should be treated as   first class citizens |
 

--- a/docs/ContxtSdk.md
+++ b/docs/ContxtSdk.md
@@ -16,11 +16,11 @@ ContxtSdk constructor
 
 **Example**  
 ```js
-import contxtSdk from 'contxtSdk';
+import ContxtSdk from '@ndustrial/contxt-sdk';
 import ExternalModule1 from './ExternalModule1';
 import history from '../services/history';
 
-const contxtSdk = new ContxtSDK({
+const contxtSdk = new ContxtSdk({
   config: {
     auth: {
       clientId: 'Auth0 client id of the application being built',

--- a/docs/MachineAuth.md
+++ b/docs/MachineAuth.md
@@ -1,7 +1,9 @@
 <a name="MachineAuth"></a>
 
 ## MachineAuth : [<code>SessionType</code>](./Typedefs.md#SessionType)
-A SessionType that allows machine to machine communication between Node.js servers.
+A SessionType that allows machine to machine communication between Node.js servers. This would
+only be used in Node.js applications. This SessionType requires a client id and a client secret,
+which are obtained from Auth0.
 
 **Kind**: global class  
 
@@ -18,6 +20,20 @@ A SessionType that allows machine to machine communication between Node.js serve
 | --- | --- | --- |
 | sdk | <code>Object</code> | An instance of the SDK so the module can communicate with other modules |
 
+**Example**  
+```js
+const ContxtSdk = require('@ndustrial/contxt-sdk');
+
+const contxtSdk = new ContxtSDK({
+  config: {
+    auth: {
+      clientId: '<client id>',
+      clientSecret: '<client secret>'
+    }
+  },
+  sessionType: 'machineAuth'
+});
+```
 <a name="MachineAuth+getCurrentApiToken"></a>
 
 ### contxtSdk.auth.getCurrentApiToken(audienceName) ⇒ <code>Promise</code>

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,12 @@
 <dl>
 <dt><a href="./Auth0WebAuth.md">Auth0WebAuth</a> : <code><a href="./Typedefs.md#SessionType">SessionType</a></code></dt>
 <dd><p>A SessionType that allows the user to initially authenticate with Auth0 and then gain a valid JWT
-from the Contxt Auth service.</p>
+from the Contxt Auth service. This would only be used in web applications. You will need to
+integrate this module&#39;s <code>logIn</code>, <code>logOut</code>, and <code>handleAuthentication</code> methods with your UI
+elements. <code>logIn</code> would be tied to a UI element to log the user in. <code>logOut</code> would be tied to a
+UI element to log the user out. <code>handleAuthentication</code> would be tied with your application&#39;s
+router and would be called when visting the route defined by <code>config.authorizationPath</code> (the
+default is <code>/callback</code>).</p>
 </dd>
 <dt><a href="./Config.md">Config</a></dt>
 <dd><p>Module that merges user assigned configurations with default configurations.</p>
@@ -16,7 +21,9 @@ from the Contxt Auth service.</p>
 of, information about different facilities</p>
 </dd>
 <dt><a href="./MachineAuth.md">MachineAuth</a> : <code><a href="./Typedefs.md#SessionType">SessionType</a></code></dt>
-<dd><p>A SessionType that allows machine to machine communication between Node.js servers.</p>
+<dd><p>A SessionType that allows machine to machine communication between Node.js servers. This would
+only be used in Node.js applications. This SessionType requires a client id and a client secret,
+which are obtained from Auth0.</p>
 </dd>
 <dt><a href="./Request.md">Request</a></dt>
 <dd></dd>

--- a/docs/Typedefs.md
+++ b/docs/Typedefs.md
@@ -134,7 +134,7 @@ User provided configuration options
 | auth | <code>Object</code> |  | User assigned configurations specific for their authentication methods |
 | [auth.authorizationPath] | <code>string</code> |  | Path Auth0WebAuth process should redirect to after a   successful sign in attempt |
 | auth.clientId | <code>string</code> |  | Client Id provided by Auth0 for this application |
-| [auth.clientSecret] | <code>string</code> |  | Client secret provided by Auth0 for this application |
+| [auth.clientSecret] | <code>string</code> |  | Client secret provided by Auth0 for this application. This   is optional for the auth0WebAuth SessionType, but required for the machineAuth SessionType |
 | [auth.customModuleConfigs] | <code>Object.&lt;string, CustomAudience&gt;</code> |  | Custom environment setups   for individual modules. Requires clientId/host or env |
 | [auth.env] | <code>string</code> | <code>&quot;&#x27;production&#x27;&quot;</code> | The environment that every module should use for   their clientId and host |
 | [auth.onRedirect] | <code>function</code> | <code>(pathname) &#x3D;&gt; { window.location &#x3D; pathname; }</code> | A redirect   method used for navigating through Auth0 callbacks in Web applications |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ndustrial/contxt-sdk",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ndustrial/contxt-sdk",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -48,7 +48,8 @@ import defaultConfigs from './defaults';
  * @property {string} [auth.authorizationPath] Path Auth0WebAuth process should redirect to after a
  *   successful sign in attempt
  * @property {string} auth.clientId Client Id provided by Auth0 for this application
- * @property {string} [auth.clientSecret] Client secret provided by Auth0 for this application
+ * @property {string} [auth.clientSecret] Client secret provided by Auth0 for this application. This
+ *   is optional for the auth0WebAuth SessionType, but required for the machineAuth SessionType
  * @property {Object.<string, CustomAudience>} [auth.customModuleConfigs] Custom environment setups
  *   for individual modules. Requires clientId/host or env
  * @property {string} [auth.env = 'production'] The environment that every module should use for
@@ -68,7 +69,7 @@ import defaultConfigs from './defaults';
 class Config {
   /**
    * @param {UserConfig} userConfig The user provided configuration options
-   * @param {Object} [externalModules] User provided external modules that should be treated as
+   * @param {Object.<string, ExternalModule>} [externalModules] User provided external modules that should be treated as
    *   first class citizens
    */
   constructor(userConfig, externalModules) {

--- a/src/index.js
+++ b/src/index.js
@@ -28,11 +28,11 @@ import * as sessionTypes from './sessionTypes';
  * ContxtSdk constructor
  *
  * @example
- * import contxtSdk from 'contxtSdk';
+ * import ContxtSdk from '@ndustrial/contxt-sdk';
  * import ExternalModule1 from './ExternalModule1';
  * import history from '../services/history';
  *
- * const contxtSdk = new ContxtSDK({
+ * const contxtSdk = new ContxtSdk({
  *   config: {
  *     auth: {
  *       clientId: 'Auth0 client id of the application being built',

--- a/src/sessionTypes/auth0WebAuth.js
+++ b/src/sessionTypes/auth0WebAuth.js
@@ -20,11 +20,30 @@ import URL from 'url-parse';
 
 /**
  * A SessionType that allows the user to initially authenticate with Auth0 and then gain a valid JWT
- * from the Contxt Auth service.
+ * from the Contxt Auth service. This would only be used in web applications. You will need to
+ * integrate this module's `logIn`, `logOut`, and `handleAuthentication` methods with your UI
+ * elements. `logIn` would be tied to a UI element to log the user in. `logOut` would be tied to a
+ * UI element to log the user out. `handleAuthentication` would be tied with your application's
+ * router and would be called when visting the route defined by `config.authorizationPath` (the
+ * default is `/callback`).
  *
  * @type SessionType
  *
  * @typicalname contxtSdk.auth
+ *
+ * @example
+ * import ContxtSdk from '@ndustrial/contxt-sdk';
+ * import history from '../services/history';
+ *
+ * const contxtSdk = new ContxtSDK({
+ *   config: {
+ *     auth: {
+ *       clientId: '<client id>',
+ *       onRedirect: (pathname) => history.push(pathname)
+ *     }
+ *   },
+ *   sessionType: 'auth0WebAuth'
+ * });
  */
 class Auth0WebAuth {
   /**

--- a/src/sessionTypes/machineAuth.js
+++ b/src/sessionTypes/machineAuth.js
@@ -7,11 +7,26 @@ import axios from 'axios';
 */
 
 /**
- * A SessionType that allows machine to machine communication between Node.js servers.
+ * A SessionType that allows machine to machine communication between Node.js servers. This would
+ * only be used in Node.js applications. This SessionType requires a client id and a client secret,
+ * which are obtained from Auth0.
  *
  * @type SessionType
  *
  * @typicalname contxtSdk.auth
+ *
+ * @example
+ * const ContxtSdk = require('@ndustrial/contxt-sdk');
+ *
+ * const contxtSdk = new ContxtSDK({
+ *   config: {
+ *     auth: {
+ *       clientId: '<client id>',
+ *       clientSecret: '<client secret>'
+ *     }
+ *   },
+ *   sessionType: 'machineAuth'
+ * });
  */
 class MachineAuth {
   /**


### PR DESCRIPTION
## Why?
1. There were a couple obvious holes in documentation for SessionTypes
2. We need to bump the version to so we can publish

## What changed?
- Updated version + changelog
- Updated examples + description for auth0WebAuth and machineAuth SessionTypes
- Fixed a couple naming problems in existing examples
