### PR TITLE
Add Facilities#create, Facilities#delete, Facilities#getAllByOrganizationId, Facilities#update

### DIFF
--- a/docs/Facilities.md
+++ b/docs/Facilities.md
@@ -10,6 +10,7 @@ of, information about different facilities
     * [new Facilities(sdk, request)](#new_Facilities_new)
     * [.get(facilityId)](#Facilities+get) ⇒ <code>Promise</code>
     * [.getAll()](#Facilities+getAll) ⇒ <code>Promise</code>
+    * [.getAllByOrganizationId(organizationId)](#Facilities+getAllByOrganizationId) ⇒ <code>Promise</code>
 
 <a name="new_Facilities_new"></a>
 
@@ -56,6 +57,28 @@ Method: GET
 **Example**  
 ```js
 contxtSdk.facilities.getAll()
+  .then((facilities) => console.log(facilities));
+  .catch((err) => console.log(err));
+```
+<a name="Facilities+getAllByOrganizationId"></a>
+
+### contxtSdk.facilities.getAllByOrganizationId(organizationId) ⇒ <code>Promise</code>
+Gets a list of all facilities that belong to a particular organization
+
+API Endpoint: '/organizations/:organizationId/facilities'
+Method: GET
+
+**Kind**: instance method of [<code>Facilities</code>](#Facilities)  
+**Fulfill**: <code>Facility[]</code> Information about all facilities  
+**Reject**: <code>Error</code>  
+
+| Param | Type |
+| --- | --- |
+| organizationId | <code>number</code> \| <code>string</code> | 
+
+**Example**  
+```js
+contxtSdk.facilities.getAllByOrganizationId(25)
   .then((facilities) => console.log(facilities));
   .catch((err) => console.log(err));
 ```

--- a/docs/Facilities.md
+++ b/docs/Facilities.md
@@ -13,6 +13,7 @@ of, information about different facilities
     * [.get(facilityId)](#Facilities+get) ⇒ <code>Promise</code>
     * [.getAll()](#Facilities+getAll) ⇒ <code>Promise</code>
     * [.getAllByOrganizationId(organizationId)](#Facilities+getAllByOrganizationId) ⇒ <code>Promise</code>
+    * [.update(facilityId, update)](#Facilities+update) ⇒ <code>Promise</code>
 
 <a name="new_Facilities_new"></a>
 
@@ -153,3 +154,24 @@ contxtSdk.facilities.getAllByOrganizationId(25)
   .then((facilities) => console.log(facilities));
   .catch((err) => console.log(err));
 ```
+<a name="Facilities+update"></a>
+
+### contxtSdk.facilities.update(facilityId, update) ⇒ <code>Promise</code>
+Updates a facility's specifics
+
+API Endpoint: '/facilities/:facilityId'
+Method: PUT
+
+**Kind**: instance method of [<code>Facilities</code>](#Facilities)  
+**Throws**:
+
+- <code>Error</code> 
+
+**Fulfill**: <code>undefined</code>  
+**Reject**: <code>Error</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| facilityId | <code>number</code> | The id of the facility to update |
+| update | <code>Object</code> | An object containing the updated data for the facility |
+

--- a/docs/Facilities.md
+++ b/docs/Facilities.md
@@ -73,6 +73,10 @@ API Endpoint: '/facilities/:facilityId'
 Method: DELETE
 
 **Kind**: instance method of [<code>Facilities</code>](#Facilities)  
+**Throws**:
+
+- <code>Error</code> 
+
 **Fulfill**: <code>undefined</code>  
 **Reject**: <code>Error</code>  
 
@@ -89,6 +93,10 @@ API Endpoint: '/facilities/:facilityId'
 Method: GET
 
 **Kind**: instance method of [<code>Facilities</code>](#Facilities)  
+**Throws**:
+
+- <code>Error</code> 
+
 **Fulfill**: [<code>Facility</code>](./Typedefs.md#Facility) Information about a facility  
 **Reject**: <code>Error</code>  
 
@@ -128,6 +136,10 @@ API Endpoint: '/organizations/:organizationId/facilities'
 Method: GET
 
 **Kind**: instance method of [<code>Facilities</code>](#Facilities)  
+**Throws**:
+
+- <code>Error</code> 
+
 **Fulfill**: <code>Facility[]</code> Information about all facilities  
 **Reject**: <code>Error</code>  
 

--- a/docs/Facilities.md
+++ b/docs/Facilities.md
@@ -158,6 +158,17 @@ Method: PUT
 | --- | --- | --- |
 | facilityId | <code>number</code> | The id of the facility to update |
 | update | <code>Object</code> | An object containing the updated data for the facility |
+| [update.address1] | <code>string</code> |  |
+| [update.address2] | <code>string</code> |  |
+| [update.city] | <code>string</code> |  |
+| [update.geometryId] | <code>string</code> | UUID corresponding with a geometry |
+| [update.info] | <code>Object</code> | User declared information |
+| [update.name] | <code>string</code> |  |
+| [update.organizationId] | <code>string</code> | UUID corresponding with an organization |
+| [update.state] | <code>string</code> |  |
+| [update.timezone] | <code>string</code> |  |
+| [update.weatherLocationId] | <code>number</code> |  |
+| [update.zip] | <code>string</code> |  |
 
 **Example**  
 ```js

--- a/docs/Facilities.md
+++ b/docs/Facilities.md
@@ -47,7 +47,7 @@ Method: POST
 | [options.city] | <code>string</code> |  |
 | [options.geometryId] | <code>string</code> | UUID corresponding with a geometry |
 | options.name | <code>string</code> |  |
-| options.organizationId | <code>string</code> | UUID corresponding with an organzation |
+| options.organizationId | <code>string</code> | UUID corresponding with an organization |
 | [options.state] | <code>string</code> |  |
 | options.timezone | <code>string</code> |  |
 | [options.weatherLocationId] | <code>number</code> |  |
@@ -145,7 +145,7 @@ Method: GET
 
 | Param | Type | Description |
 | --- | --- | --- |
-| organizationId | <code>string</code> | UUID corresponding with an organzation |
+| organizationId | <code>string</code> | UUID corresponding with an organization |
 
 **Example**  
 ```js

--- a/docs/Facilities.md
+++ b/docs/Facilities.md
@@ -9,6 +9,7 @@ of, information about different facilities
 * [Facilities](#Facilities)
     * [new Facilities(sdk, request)](#new_Facilities_new)
     * [.create(options)](#Facilities+create) ⇒ <code>Promise</code>
+    * [.delete(facilityId)](#Facilities+delete)
     * [.get(facilityId)](#Facilities+get) ⇒ <code>Promise</code>
     * [.getAll()](#Facilities+getAll) ⇒ <code>Promise</code>
     * [.getAllByOrganizationId(organizationId)](#Facilities+getAllByOrganizationId) ⇒ <code>Promise</code>
@@ -63,6 +64,22 @@ contxtSdk.facilities
   .then((facilities) => console.log(facilities));
   .catch((err) => console.log(err));
 ```
+<a name="Facilities+delete"></a>
+
+### contxtSdk.facilities.delete(facilityId)
+Deletes a facility
+
+API Endpoint: '/facilities/:facilityId'
+Method: DELETE
+
+**Kind**: instance method of [<code>Facilities</code>](#Facilities)  
+**Fulfill**: <code>undefined</code>  
+**Reject**: <code>Error</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| facilityId | <code>number</code> | The id of the facility |
+
 <a name="Facilities+get"></a>
 
 ### contxtSdk.facilities.get(facilityId) ⇒ <code>Promise</code>

--- a/docs/Facilities.md
+++ b/docs/Facilities.md
@@ -8,6 +8,7 @@ of, information about different facilities
 
 * [Facilities](#Facilities)
     * [new Facilities(sdk, request)](#new_Facilities_new)
+    * [.create(options)](#Facilities+create) ⇒ <code>Promise</code>
     * [.get(facilityId)](#Facilities+get) ⇒ <code>Promise</code>
     * [.getAll()](#Facilities+getAll) ⇒ <code>Promise</code>
     * [.getAllByOrganizationId(organizationId)](#Facilities+getAllByOrganizationId) ⇒ <code>Promise</code>
@@ -21,6 +22,47 @@ of, information about different facilities
 | sdk | <code>Object</code> | An instance of the SDK so the module can communicate with other modules |
 | request | <code>Object</code> | An instance of the request module tied to this module's audience. |
 
+<a name="Facilities+create"></a>
+
+### contxtSdk.facilities.create(options) ⇒ <code>Promise</code>
+Creates a new facility
+
+API Endpoint: '/facilities'
+Method: POST
+
+**Kind**: instance method of [<code>Facilities</code>](#Facilities)  
+**Throws**:
+
+- <code>Error</code> 
+
+**Fulfill**: [<code>Facility</code>](./Typedefs.md#Facility) Information about the new facility  
+**Reject**: <code>Error</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| options | <code>Object</code> |  |
+| [options.address1] | <code>string</code> |  |
+| [options.address2] | <code>string</code> |  |
+| [options.city] | <code>string</code> |  |
+| [options.geometryId] | <code>string</code> | UUID corresponding with a geometry |
+| options.name | <code>string</code> |  |
+| options.organizationId | <code>string</code> | UUID corresponding with an organzation |
+| [options.state] | <code>string</code> |  |
+| options.timezone | <code>string</code> |  |
+| [options.weatherLocationId] | <code>number</code> |  |
+| [options.zip] | <code>string</code> |  |
+
+**Example**  
+```js
+contxtSdk.facilities
+  .create({
+    address: '221 B Baker St, London, England',
+    name: 'Sherlock Homes Museum',
+    organizationId: 25
+  })
+  .then((facilities) => console.log(facilities));
+  .catch((err) => console.log(err));
+```
 <a name="Facilities+get"></a>
 
 ### contxtSdk.facilities.get(facilityId) ⇒ <code>Promise</code>
@@ -35,7 +77,7 @@ Method: GET
 
 | Param | Type | Description |
 | --- | --- | --- |
-| facilityId | <code>number</code> \| <code>string</code> | The id of the facility |
+| facilityId | <code>number</code> | The id of the facility |
 
 **Example**  
 ```js
@@ -72,9 +114,9 @@ Method: GET
 **Fulfill**: <code>Facility[]</code> Information about all facilities  
 **Reject**: <code>Error</code>  
 
-| Param | Type |
-| --- | --- |
-| organizationId | <code>number</code> \| <code>string</code> | 
+| Param | Type | Description |
+| --- | --- | --- |
+| organizationId | <code>string</code> | UUID corresponding with an organzation |
 
 **Example**  
 ```js

--- a/docs/Facilities.md
+++ b/docs/Facilities.md
@@ -33,10 +33,6 @@ API Endpoint: '/facilities'
 Method: POST
 
 **Kind**: instance method of [<code>Facilities</code>](#Facilities)  
-**Throws**:
-
-- <code>Error</code> 
-
 **Fulfill**: [<code>Facility</code>](./Typedefs.md#Facility) Information about the new facility  
 **Reject**: <code>Error</code>  
 
@@ -74,10 +70,6 @@ API Endpoint: '/facilities/:facilityId'
 Method: DELETE
 
 **Kind**: instance method of [<code>Facilities</code>](#Facilities)  
-**Throws**:
-
-- <code>Error</code> 
-
 **Fulfill**: <code>undefined</code>  
 **Reject**: <code>Error</code>  
 
@@ -85,6 +77,10 @@ Method: DELETE
 | --- | --- | --- |
 | facilityId | <code>number</code> | The id of the facility |
 
+**Example**  
+```js
+contxtSdk.facilities.delete(25)
+```
 <a name="Facilities+get"></a>
 
 ### contxtSdk.facilities.get(facilityId) ⇒ <code>Promise</code>
@@ -94,10 +90,6 @@ API Endpoint: '/facilities/:facilityId'
 Method: GET
 
 **Kind**: instance method of [<code>Facilities</code>](#Facilities)  
-**Throws**:
-
-- <code>Error</code> 
-
 **Fulfill**: [<code>Facility</code>](./Typedefs.md#Facility) Information about a facility  
 **Reject**: <code>Error</code>  
 
@@ -137,10 +129,6 @@ API Endpoint: '/organizations/:organizationId/facilities'
 Method: GET
 
 **Kind**: instance method of [<code>Facilities</code>](#Facilities)  
-**Throws**:
-
-- <code>Error</code> 
-
 **Fulfill**: <code>Facility[]</code> Information about all facilities  
 **Reject**: <code>Error</code>  
 
@@ -163,10 +151,6 @@ API Endpoint: '/facilities/:facilityId'
 Method: PUT
 
 **Kind**: instance method of [<code>Facilities</code>](#Facilities)  
-**Throws**:
-
-- <code>Error</code> 
-
 **Fulfill**: <code>undefined</code>  
 **Reject**: <code>Error</code>  
 
@@ -175,3 +159,11 @@ Method: PUT
 | facilityId | <code>number</code> | The id of the facility to update |
 | update | <code>Object</code> | An object containing the updated data for the facility |
 
+**Example**  
+```js
+contxtSdk.facilities.update(25, {
+  address: '221 B Baker St, London, England',
+  name: 'Sherlock Homes Museum',
+  organizationId: 25
+});
+```

--- a/docs/Typedefs.md
+++ b/docs/Typedefs.md
@@ -69,24 +69,24 @@ for authenticating and communicating with an individual API and the external mod
 | address1 | <code>string</code> |  |
 | address2 | <code>string</code> |  |
 | city | <code>string</code> |  |
-| created_at | <code>string</code> | ISO 8601 Extended Format date/time string |
+| createdAt | <code>string</code> | ISO 8601 Extended Format date/time string |
 | id | <code>number</code> |  |
 | Info | <code>Object</code> |  |
 | name | <code>string</code> |  |
 | Organization | <code>Object</code> |  |
 | Organization.id | <code>string</code> | UUID formatted id |
 | Organization.name | <code>string</code> |  |
-| Organization.created_at | <code>string</code> | ISO 8601 Extended Format date/time string |
-| Organization.updated_at | <code>string</code> | ISO 8601 Extended Format date/time string |
+| Organization.createdAt | <code>string</code> | ISO 8601 Extended Format date/time string |
+| Organization.updatedAt | <code>string</code> | ISO 8601 Extended Format date/time string |
 | state | <code>string</code> |  |
 | tags | <code>Array.&lt;Object&gt;</code> |  |
 | tags[].id | <code>number</code> |  |
-| tags[].facility_id | <code>number</code> |  |
+| tags[].facilityId | <code>number</code> |  |
 | tags[].name | <code>string</code> |  |
-| tags[].created_at | <code>string</code> | ISO 8601 Extended Format date/time string |
-| tags[].updated_at | <code>string</code> | ISO 8601 Extended Format date/time string |
+| tags[].createdAt | <code>string</code> | ISO 8601 Extended Format date/time string |
+| tags[].updatedAt | <code>string</code> | ISO 8601 Extended Format date/time string |
 | timezone | <code>string</code> | An IANA Time Zone Database string, i.e. America/Los_Angeles |
-| weather_location_id | <code>number</code> |  |
+| weatherLocationId | <code>number</code> |  |
 | zip | <code>string</code> | US Zip Code |
 
 <a name="MachineAuthSessionInfo"></a>
@@ -152,5 +152,5 @@ User provided configuration options
 | nickname | <code>string</code> |  |
 | picture | <code>string</code> | URL to an avatar |
 | sub | <code>string</code> | The Subject Claim of the user's JWT |
-| updated_at | <code>string</code> | ISO 8601 Extended Format date/time string |
+| updatedAt | <code>string</code> | ISO 8601 Extended Format date/time string |
 

--- a/docs/Typedefs.md
+++ b/docs/Typedefs.md
@@ -70,20 +70,21 @@ for authenticating and communicating with an individual API and the external mod
 | address2 | <code>string</code> |  |
 | city | <code>string</code> |  |
 | createdAt | <code>string</code> | ISO 8601 Extended Format date/time string |
+| geometryId | <code>string</code> | UUID corresponding with a geometry |
 | id | <code>number</code> |  |
-| Info | <code>Object</code> |  |
+| Info | <code>Object</code> | User declared information |
 | name | <code>string</code> |  |
 | Organization | <code>Object</code> |  |
+| Organization.createdAt | <code>string</code> | ISO 8601 Extended Format date/time string |
 | Organization.id | <code>string</code> | UUID formatted id |
 | Organization.name | <code>string</code> |  |
-| Organization.createdAt | <code>string</code> | ISO 8601 Extended Format date/time string |
 | Organization.updatedAt | <code>string</code> | ISO 8601 Extended Format date/time string |
 | state | <code>string</code> |  |
 | tags | <code>Array.&lt;Object&gt;</code> |  |
+| tags[].createdAt | <code>string</code> | ISO 8601 Extended Format date/time string |
 | tags[].id | <code>number</code> |  |
 | tags[].facilityId | <code>number</code> |  |
 | tags[].name | <code>string</code> |  |
-| tags[].createdAt | <code>string</code> | ISO 8601 Extended Format date/time string |
 | tags[].updatedAt | <code>string</code> | ISO 8601 Extended Format date/time string |
 | timezone | <code>string</code> | An IANA Time Zone Database string, i.e. America/Los_Angeles |
 | weatherLocationId | <code>number</code> |  |

--- a/package-lock.json
+++ b/package-lock.json
@@ -4569,6 +4569,11 @@
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
     "lodash.omit": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "faker": "^4.1.0",
     "fast-glob": "^2.1.0",
     "jsdoc-to-markdown": "^4.0.1",
+    "lodash.omit": "^4.5.0",
     "lodash.sortby": "^4.7.0",
     "lodash.times": "^4.3.2",
     "mocha": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "author": "ndustrial.io <dev@ndustrial.io> (ndustrial.io)",
   "license": "ISC",
   "dependencies": {
+    "lodash.isplainobject": "^4.0.6",
     "url-parse": "^1.2.0"
   },
   "devDependencies": {

--- a/src/facilities.js
+++ b/src/facilities.js
@@ -3,24 +3,24 @@
  * @property {string} address1
  * @property {string} address2
  * @property {string} city
- * @property {string} created_at ISO 8601 Extended Format date/time string
+ * @property {string} createdAt ISO 8601 Extended Format date/time string
  * @property {number} id
  * @property {Object} Info
  * @property {string} name
  * @property {Object} Organization
  * @property {string} Organization.id UUID formatted id
  * @property {string} Organization.name
- * @property {string} Organization.created_at ISO 8601 Extended Format date/time string
- * @property {string} Organization.updated_at ISO 8601 Extended Format date/time string
+ * @property {string} Organization.createdAt ISO 8601 Extended Format date/time string
+ * @property {string} Organization.updatedAt ISO 8601 Extended Format date/time string
  * @property {string} state
  * @property {Object[]} tags
  * @property {number} tags[].id
- * @property {number} tags[].facility_id
+ * @property {number} tags[].facilityId
  * @property {string} tags[].name
- * @property {string} tags[].created_at ISO 8601 Extended Format date/time string
- * @property {string} tags[].updated_at ISO 8601 Extended Format date/time string
+ * @property {string} tags[].createdAt ISO 8601 Extended Format date/time string
+ * @property {string} tags[].updatedAt ISO 8601 Extended Format date/time string
  * @property {string} timezone An IANA Time Zone Database string, i.e. America/Los_Angeles
- * @property {number} weather_location_id
+ * @property {number} weatherLocationId
  * @property {string} zip US Zip Code
  */
 
@@ -96,7 +96,8 @@ class Facilities {
       zip: facility.zip
     };
 
-    return this._request.post(`${this._baseUrl}/facilities`, data);
+    return this._request.post(`${this._baseUrl}/facilities`, data)
+      .then((facility) => this._formatFacility(facility));
   }
 
   /**
@@ -117,7 +118,8 @@ class Facilities {
    *   .catch((err) => console.log(err));
    */
   get(facilityId) {
-    return this._request.get(`${this._baseUrl}/facilities/${facilityId}`);
+    return this._request.get(`${this._baseUrl}/facilities/${facilityId}`)
+      .then((facility) => this._formatFacility(facility));
   }
 
   /**
@@ -136,7 +138,8 @@ class Facilities {
    *   .catch((err) => console.log(err));
    */
   getAll() {
-    return this._request.get(`${this._baseUrl}/facilities`);
+    return this._request.get(`${this._baseUrl}/facilities`)
+      .then((facilities) => facilities.map((facility) => this._formatFacility(facility)));
   }
 
   /**
@@ -157,7 +160,49 @@ class Facilities {
    *   .catch((err) => console.log(err));
    */
   getAllByOrganizationId(organizationId) {
-    return this._request.get(`${this._baseUrl}/organizations/${organizationId}/facilities`);
+    return this._request.get(`${this._baseUrl}/organizations/${organizationId}/facilities`)
+      .then((facilities) => facilities.map((facility) => this._formatFacility(facility)));
+  }
+
+  _formatFacility(input) {
+    return {
+      address1: input.address1,
+      address2: input.address2,
+      city: input.city,
+      createdAt: input.created_at,
+      geometryId: input.geometry_id,
+      id: input.id,
+      info: input.Info,
+      name: input.name,
+      organization: this._formatOrganization(input.Organization),
+      organizationId: input.organization_id,
+      state: input.state,
+      tags: this._formatTags(input.tags),
+      timezone: input.timezone,
+      weatherLocationId: input.weather_location_id,
+      zip: input.zip
+    };
+  }
+
+  _formatOrganization(organization) {
+    return {
+      createdAt: organization.created_at,
+      id: organization.id,
+      name: organization.name,
+      updatedAt: organization.updated_at
+    };
+  }
+
+  _formatTags(tags) {
+    return tags.map((tag) => {
+      return {
+        createdAt: tag.created_at,
+        facilityId: tag.facility_id,
+        id: tag.id,
+        name: tag.name,
+        updatedAt: tag.updated_at
+      };
+    });
   }
 }
 

--- a/src/facilities.js
+++ b/src/facilities.js
@@ -80,6 +80,27 @@ class Facilities {
   getAll() {
     return this._request.get(`${this._baseUrl}/facilities`);
   }
+
+  /**
+   * Gets a list of all facilities that belong to a particular organization
+   *
+   * API Endpoint: '/organizations/:organizationId/facilities'
+   * Method: GET
+   *
+   * @param {number|string} organizationId
+   *
+   * @returns {Promise}
+   * @fulfill {Facility[]} Information about all facilities
+   * @reject {Error}
+   *
+   * @example
+   * contxtSdk.facilities.getAllByOrganizationId(25)
+   *   .then((facilities) => console.log(facilities));
+   *   .catch((err) => console.log(err));
+   */
+  getAllByOrganizationId(organizationId) {
+    return this._request.get(`${this._baseUrl}/organizations/${organizationId}/facilities`);
+  }
 }
 
 export default Facilities;

--- a/src/facilities.js
+++ b/src/facilities.js
@@ -101,6 +101,25 @@ class Facilities {
   }
 
   /**
+   * Deletes a facility
+   *
+   * API Endpoint: '/facilities/:facilityId'
+   * Method: DELETE
+   *
+   * @param {number} facilityId The id of the facility
+   *
+   * @fulfill {undefined}
+   * @reject {Error}
+   */
+  delete(facilityId) {
+    if (!facilityId) {
+      throw new Error('A facility id is required for deleting a facility');
+    }
+
+    return this._request.delete(`${this._baseUrl}/facilities/${facilityId}`);
+  }
+
+  /**
    * Gets information about a facility
    *
    * API Endpoint: '/facilities/:facilityId'

--- a/src/facilities.js
+++ b/src/facilities.js
@@ -1,3 +1,5 @@
+import isPlainObject from 'lodash.isplainobject';
+
 /**
  * @typedef {Object} Facility
  * @property {string} address1
@@ -196,6 +198,38 @@ class Facilities {
   }
 
   /**
+   * Updates a facility's specifics
+   *
+   * API Endpoint: '/facilities/:facilityId'
+   * Method: PUT
+   *
+   * @param {number} facilityId The id of the facility to update
+   * @param {Object} update An object containing the updated data for the facility
+   *
+   * @returns {Promise}
+   * @fulfill {undefined}
+   * @reject {Error}
+   * @throws {Error}
+   */
+  update(facilityId, update) {
+    if (!facilityId) {
+      throw new Error('A facility id is required to update a facility.');
+    }
+
+    if (!update) {
+      throw new Error('An update is required to update a facility.');
+    }
+
+    if (!isPlainObject(update)) {
+      throw new Error('The facility update must be a well-formed object with the data you wish to update.');
+    }
+
+    const formattedUpdate = this._formatFacilityToServer(update);
+
+    return this._request.put(`${this._baseUrl}/facilities/${facilityId}`, formattedUpdate);
+  }
+
+  /**
    * Normalizes the facility object returned from the API server
    *
    * @param {Object} input
@@ -249,53 +283,89 @@ class Facilities {
   }
 
   /**
-   * Normalizes the organization object returned from the API server
+   * Normalizes the facility object returned from the API server
    *
-   * @param {Object} organization
-   * @param {string} organization.created_at ISO 8601 Extended Format date/time string
-   * @param {string} organization.id UUID
-   * @param {string} organization.name
-   * @param {string} organization.updated_at
-   * @param {string} organization_id UUID corresponding with an organization
+   * @param {Facility} input
    *
-   * @returns {Object} organization
-   * @returns {string} organization.createdAt ISO 8601 Extended Format date/time string
-   * @returns {string} organization.id UUID formatted id
-   * @returns {string} organization.name
-   * @returns {string} organization.updatedAt ISO 8601 Extended Format date/time string
+   * @returns {Object} output
+   * @returns {string} output.address1
+   * @returns {string} output.address2
+   * @returns {string} output.city
+   * @returns {string} output.geometry_id UUID corresponding with a geometry
+   * @returns {Object} output.Info User declared information
+   * @returns {string} output.name
+   * @returns {string} output.organization_id UUID corresponding with an organization
+   * @returns {string} output.state
+   * @returns {string} output.timezone An IANA Time Zone Database string, i.e. America/Los_Angeles
+   * @returns {string} output.weather_location_id
+   * @returns {string} output.zip
    *
    * @private
    */
-  _formatOrganizationFromServer(organization) {
+  _formatFacilityToServer(input) {
     return {
-      createdAt: organization.created_at,
-      id: organization.id,
-      name: organization.name,
-      updatedAt: organization.updated_at
+      address1: input.address1,
+      address2: input.address2,
+      city: input.city,
+      geometry_id: input.geometryId,
+      Info: input.info,
+      name: input.name,
+      organization_id: input.organizationId,
+      state: input.state,
+      timezone: input.timezone,
+      weather_location_id: input.weatherLocationId,
+      zip: input.zip
+    };
+  }
+
+  /**
+   * Normalizes the organization object returned from the API server
+   *
+   * @param {Object} input
+   * @param {string} input.created_at ISO 8601 Extended Format date/time string
+   * @param {string} input.id UUID
+   * @param {string} input.name
+   * @param {string} input.updated_at
+   * @param {string} input.organization_id UUID corresponding with an organization
+   *
+   * @returns {Object} output
+   * @returns {string} output.createdAt ISO 8601 Extended Format date/time string
+   * @returns {string} output.id UUID formatted id
+   * @returns {string} output.name
+   * @returns {string} output.updatedAt ISO 8601 Extended Format date/time string
+   *
+   * @private
+   */
+  _formatOrganizationFromServer(input) {
+    return {
+      createdAt: input.created_at,
+      id: input.id,
+      name: input.name,
+      updatedAt: input.updated_at
     };
   }
 
   /**
    * Normalizes the tags array returned from the API server
    *
-   * @param {Object[]} tags
-   * @param {string} tags[].created_at ISO 8601 Extended Format date/time string
-   * @param {number} tags[].facility_id Id corresponding with the parent facility
-   * @param {number} tags[].id
-   * @param {string} tags[].name
-   * @param {string} tags[].updated_at ISO 8601 Extended Format date/time string
+   * @param {Object[]} input
+   * @param {string} input[].created_at ISO 8601 Extended Format date/time string
+   * @param {number} input[].facility_id Id corresponding with the parent facility
+   * @param {number} input[].id
+   * @param {string} input[].name
+   * @param {string} input[].updated_at ISO 8601 Extended Format date/time string
    *
-   * @returns {Object[]} tags
-   * @returns {string} tags[].createdAt ISO 8601 Extended Format date/time string
-   * @returns {number} tags[].id
-   * @returns {number} tags[].facilityId
-   * @returns {string} tags[].name
-   * @returns {string} tags[].updatedAt ISO 8601 Extended Format date/time string
+   * @returns {Object[]} output
+   * @returns {string} output[].createdAt ISO 8601 Extended Format date/time string
+   * @returns {number} output[].id
+   * @returns {number} output[].facilityId
+   * @returns {string} output[].name
+   * @returns {string} output[].updatedAt ISO 8601 Extended Format date/time string
    *
    * @private
    */
-  _formatTagsFromServer(tags) {
-    return tags.map((tag) => {
+  _formatTagsFromServer(input) {
+    return input.map((tag) => {
       return {
         createdAt: tag.created_at,
         facilityId: tag.facility_id,

--- a/src/facilities.js
+++ b/src/facilities.js
@@ -199,6 +199,17 @@ class Facilities {
    *
    * @param {number} facilityId The id of the facility to update
    * @param {Object} update An object containing the updated data for the facility
+   * @param {string} [update.address1]
+   * @param {string} [update.address2]
+   * @param {string} [update.city]
+   * @param {string} [update.geometryId] UUID corresponding with a geometry
+   * @param {Object} [update.info] User declared information
+   * @param {string} [update.name]
+   * @param {string} [update.organizationId] UUID corresponding with an organization
+   * @param {string} [update.state]
+   * @param {string} [update.timezone]
+   * @param {number} [update.weatherLocationId]
+   * @param {string} [update.zip]
    *
    * @returns {Promise}
    * @fulfill {undefined}

--- a/src/facilities.js
+++ b/src/facilities.js
@@ -42,12 +42,70 @@ class Facilities {
   }
 
   /**
+   * Creates a new facility
+   *
+   * API Endpoint: '/facilities'
+   * Method: POST
+   *
+   * @param {Object} options
+   * @param {string} [options.address1]
+   * @param {string} [options.address2]
+   * @param {string} [options.city]
+   * @param {string} [options.geometryId] UUID corresponding with a geometry
+   * @param {string} options.name
+   * @param {string} options.organizationId UUID corresponding with an organzation
+   * @param {string} [options.state]
+   * @param {string} options.timezone
+   * @param {number} [options.weatherLocationId]
+   * @param {string} [options.zip]
+   *
+   * @returns {Promise}
+   * @fulfill {Facility} Information about the new facility
+   * @reject {Error}
+   * @throws {Error}
+   *
+   * @example
+   * contxtSdk.facilities
+   *   .create({
+   *     address: '221 B Baker St, London, England',
+   *     name: 'Sherlock Homes Museum',
+   *     organizationId: 25
+   *   })
+   *   .then((facilities) => console.log(facilities));
+   *   .catch((err) => console.log(err));
+   */
+  create(facility) {
+    const requiredFields = ['organizationId', 'name', 'timezone'];
+
+    requiredFields.forEach((field) => {
+      if (!facility[field]) {
+        throw new Error(`A ${field} is required to create a new facility.`);
+      }
+    });
+
+    const data = {
+      address1: facility.address1,
+      address2: facility.address2,
+      city: facility.city,
+      geometry_id: facility.geometryId,
+      name: facility.name,
+      organization_id: facility.organizationId,
+      state: facility.state,
+      timezone: facility.timezone,
+      weather_location_id: facility.weatherLocationId,
+      zip: facility.zip
+    };
+
+    return this._request.post(`${this._baseUrl}/facilities`, data);
+  }
+
+  /**
    * Gets information about a facility
    *
    * API Endpoint: '/facilities/:facilityId'
    * Method: GET
    *
-   * @param {number|string} facilityId The id of the facility
+   * @param {number} facilityId The id of the facility
    *
    * @returns {Promise}
    * @fulfill {Facility} Information about a facility
@@ -87,7 +145,7 @@ class Facilities {
    * API Endpoint: '/organizations/:organizationId/facilities'
    * Method: GET
    *
-   * @param {number|string} organizationId
+   * @param {string} organizationId UUID corresponding with an organzation
    *
    * @returns {Promise}
    * @fulfill {Facility[]} Information about all facilities

--- a/src/facilities.js
+++ b/src/facilities.js
@@ -65,7 +65,6 @@ class Facilities {
    * @returns {Promise}
    * @fulfill {Facility} Information about the new facility
    * @reject {Error}
-   * @throws {Error}
    *
    * @example
    * contxtSdk.facilities
@@ -77,14 +76,16 @@ class Facilities {
    *   .then((facilities) => console.log(facilities));
    *   .catch((err) => console.log(err));
    */
-  create(facility) {
+  create(facility = {}) {
     const requiredFields = ['organizationId', 'name', 'timezone'];
 
-    requiredFields.forEach((field) => {
+    for (let i = 0; requiredFields.length > i; i++) {
+      const field = requiredFields[i];
+
       if (!facility[field]) {
-        throw new Error(`A ${field} is required to create a new facility.`);
+        return Promise.reject(new Error(`A ${field} is required to create a new facility.`));
       }
-    });
+    }
 
     const data = {
       address1: facility.address1,
@@ -113,11 +114,13 @@ class Facilities {
    *
    * @fulfill {undefined}
    * @reject {Error}
-   * @throws {Error}
+   *
+   * @example
+   * contxtSdk.facilities.delete(25)
    */
   delete(facilityId) {
     if (!facilityId) {
-      throw new Error('A facility id is required for deleting a facility');
+      return Promise.reject(new Error('A facility id is required for deleting a facility'));
     }
 
     return this._request.delete(`${this._baseUrl}/facilities/${facilityId}`);
@@ -134,7 +137,6 @@ class Facilities {
    * @returns {Promise}
    * @fulfill {Facility} Information about a facility
    * @reject {Error}
-   * @throws {Error}
    *
    * @example
    * contxtSdk.facilities.get(25)
@@ -143,7 +145,9 @@ class Facilities {
    */
   get(facilityId) {
     if (!facilityId) {
-      throw new Error('A facility id is required for getting information about a facility');
+      return Promise.reject(
+        new Error('A facility id is required for getting information about a facility')
+      );
     }
 
     return this._request.get(`${this._baseUrl}/facilities/${facilityId}`)
@@ -181,7 +185,6 @@ class Facilities {
    * @returns {Promise}
    * @fulfill {Facility[]} Information about all facilities
    * @reject {Error}
-   * @throws {Error}
    *
    * @example
    * contxtSdk.facilities.getAllByOrganizationId(25)
@@ -190,7 +193,9 @@ class Facilities {
    */
   getAllByOrganizationId(organizationId) {
     if (!organizationId) {
-      throw new Error("An organization id is required for getting a list of an organization's facilities");
+      return Promise.reject(
+        new Error("An organization id is required for getting a list of an organization's facilities")
+      );
     }
 
     return this._request.get(`${this._baseUrl}/organizations/${organizationId}/facilities`)
@@ -209,19 +214,27 @@ class Facilities {
    * @returns {Promise}
    * @fulfill {undefined}
    * @reject {Error}
-   * @throws {Error}
+   *
+   * @example
+   * contxtSdk.facilities.update(25, {
+   *   address: '221 B Baker St, London, England',
+   *   name: 'Sherlock Homes Museum',
+   *   organizationId: 25
+   * });
    */
   update(facilityId, update) {
     if (!facilityId) {
-      throw new Error('A facility id is required to update a facility.');
+      return Promise.reject(new Error('A facility id is required to update a facility.'));
     }
 
     if (!update) {
-      throw new Error('An update is required to update a facility.');
+      return Promise.reject(new Error('An update is required to update a facility.'));
     }
 
     if (!isPlainObject(update)) {
-      throw new Error('The facility update must be a well-formed object with the data you wish to update.');
+      return Promise.reject(
+        new Error('The facility update must be a well-formed object with the data you wish to update.')
+      );
     }
 
     const formattedUpdate = this._formatFacilityToServer(update);
@@ -262,7 +275,7 @@ class Facilities {
    *
    * @private
    */
-  _formatFacilityFromServer(input) {
+  _formatFacilityFromServer(input = {}) {
     return {
       address1: input.address1,
       address2: input.address2,
@@ -302,7 +315,7 @@ class Facilities {
    *
    * @private
    */
-  _formatFacilityToServer(input) {
+  _formatFacilityToServer(input = {}) {
     return {
       address1: input.address1,
       address2: input.address2,
@@ -336,7 +349,7 @@ class Facilities {
    *
    * @private
    */
-  _formatOrganizationFromServer(input) {
+  _formatOrganizationFromServer(input = {}) {
     return {
       createdAt: input.created_at,
       id: input.id,
@@ -364,7 +377,7 @@ class Facilities {
    *
    * @private
    */
-  _formatTagsFromServer(input) {
+  _formatTagsFromServer(input = []) {
     return input.map((tag) => {
       return {
         createdAt: tag.created_at,

--- a/src/facilities.js
+++ b/src/facilities.js
@@ -87,18 +87,7 @@ class Facilities {
       }
     }
 
-    const data = {
-      address1: facility.address1,
-      address2: facility.address2,
-      city: facility.city,
-      geometry_id: facility.geometryId,
-      name: facility.name,
-      organization_id: facility.organizationId,
-      state: facility.state,
-      timezone: facility.timezone,
-      weather_location_id: facility.weatherLocationId,
-      zip: facility.zip
-    };
+    const data = this._formatFacilityToServer(facility);
 
     return this._request.post(`${this._baseUrl}/facilities`, data)
       .then((facility) => this._formatFacilityFromServer(facility));

--- a/src/facilities.js
+++ b/src/facilities.js
@@ -4,20 +4,21 @@
  * @property {string} address2
  * @property {string} city
  * @property {string} createdAt ISO 8601 Extended Format date/time string
+ * @property {string} geometryId UUID corresponding with a geometry
  * @property {number} id
- * @property {Object} Info
+ * @property {Object} Info User declared information
  * @property {string} name
  * @property {Object} Organization
+ * @property {string} Organization.createdAt ISO 8601 Extended Format date/time string
  * @property {string} Organization.id UUID formatted id
  * @property {string} Organization.name
- * @property {string} Organization.createdAt ISO 8601 Extended Format date/time string
  * @property {string} Organization.updatedAt ISO 8601 Extended Format date/time string
  * @property {string} state
  * @property {Object[]} tags
+ * @property {string} tags[].createdAt ISO 8601 Extended Format date/time string
  * @property {number} tags[].id
  * @property {number} tags[].facilityId
  * @property {string} tags[].name
- * @property {string} tags[].createdAt ISO 8601 Extended Format date/time string
  * @property {string} tags[].updatedAt ISO 8601 Extended Format date/time string
  * @property {string} timezone An IANA Time Zone Database string, i.e. America/Los_Angeles
  * @property {number} weatherLocationId
@@ -53,7 +54,7 @@ class Facilities {
    * @param {string} [options.city]
    * @param {string} [options.geometryId] UUID corresponding with a geometry
    * @param {string} options.name
-   * @param {string} options.organizationId UUID corresponding with an organzation
+   * @param {string} options.organizationId UUID corresponding with an organization
    * @param {string} [options.state]
    * @param {string} options.timezone
    * @param {number} [options.weatherLocationId]
@@ -173,7 +174,7 @@ class Facilities {
    * API Endpoint: '/organizations/:organizationId/facilities'
    * Method: GET
    *
-   * @param {string} organizationId UUID corresponding with an organzation
+   * @param {string} organizationId UUID corresponding with an organization
    *
    * @returns {Promise}
    * @fulfill {Facility[]} Information about all facilities
@@ -194,6 +195,39 @@ class Facilities {
       .then((facilities) => facilities.map((facility) => this._formatFacility(facility)));
   }
 
+  /**
+   * Normalizes the facility object returned from the API server
+   *
+   * @param {Object} input
+   * @param {string} input.address1
+   * @param {string} input.address2
+   * @param {string} input.city
+   * @param {string} input.created_at ISO 8601 Extended Format date/time string
+   * @param {string} input.geometry_id UUID corresponding with a geometry
+   * @param {number} input.id
+   * @param {Object} input.Info User declared information
+   * @param {string} input.name
+   * @param {Object} input.Organization
+   * @param {string} input.Organization.created_at ISO 8601 Extended Format date/time string
+   * @param {string} input.Organization.id UUID
+   * @param {string} input.Organization.name
+   * @param {string} input.Organization.updated_at
+   * @param {string} input.organization_id UUID corresponding with an organization
+   * @param {string} input.state
+   * @param {Object[]} input.tags
+   * @param {string} input.tags[].created_at ISO 8601 Extended Format date/time string
+   * @param {number} input.tags[].facility_id Id corresponding with the parent facility
+   * @param {number} input.tags[].id
+   * @param {string} input.tags[].name
+   * @param {string} input.tags[].updated_at ISO 8601 Extended Format date/time string
+   * @param {string} input.timezone An IANA Time Zone Database string, i.e. America/Los_Angeles
+   * @param {string} input.weather_location_id
+   * @param {string} input.zip
+   *
+   * @returns {Facility}
+   *
+   * @private
+   */
   _formatFacility(input) {
     return {
       address1: input.address1,
@@ -214,6 +248,24 @@ class Facilities {
     };
   }
 
+  /**
+   * Normalizes the organization object returned from the API server
+   *
+   * @param {Object} organization
+   * @param {string} organization.created_at ISO 8601 Extended Format date/time string
+   * @param {string} organization.id UUID
+   * @param {string} organization.name
+   * @param {string} organization.updated_at
+   * @param {string} organization_id UUID corresponding with an organization
+   *
+   * @returns {Object} organization
+   * @returns {string} organization.createdAt ISO 8601 Extended Format date/time string
+   * @returns {string} organization.id UUID formatted id
+   * @returns {string} organization.name
+   * @returns {string} organization.updatedAt ISO 8601 Extended Format date/time string
+   *
+   * @private
+   */
   _formatOrganization(organization) {
     return {
       createdAt: organization.created_at,
@@ -223,6 +275,25 @@ class Facilities {
     };
   }
 
+  /**
+   * Normalizes the tags array returned from the API server
+   *
+   * @param {Object[]} tags
+   * @param {string} tags[].created_at ISO 8601 Extended Format date/time string
+   * @param {number} tags[].facility_id Id corresponding with the parent facility
+   * @param {number} tags[].id
+   * @param {string} tags[].name
+   * @param {string} tags[].updated_at ISO 8601 Extended Format date/time string
+   *
+   * @returns {Object[]} tags
+   * @returns {string} tags[].createdAt ISO 8601 Extended Format date/time string
+   * @returns {number} tags[].id
+   * @returns {number} tags[].facilityId
+   * @returns {string} tags[].name
+   * @returns {string} tags[].updatedAt ISO 8601 Extended Format date/time string
+   *
+   * @private
+   */
   _formatTags(tags) {
     return tags.map((tag) => {
       return {

--- a/src/facilities.js
+++ b/src/facilities.js
@@ -110,6 +110,7 @@ class Facilities {
    *
    * @fulfill {undefined}
    * @reject {Error}
+   * @throws {Error}
    */
   delete(facilityId) {
     if (!facilityId) {
@@ -130,6 +131,7 @@ class Facilities {
    * @returns {Promise}
    * @fulfill {Facility} Information about a facility
    * @reject {Error}
+   * @throws {Error}
    *
    * @example
    * contxtSdk.facilities.get(25)
@@ -137,6 +139,10 @@ class Facilities {
    *   .catch((err) => console.log(err));
    */
   get(facilityId) {
+    if (!facilityId) {
+      throw new Error('A facility id is required for getting information about a facility');
+    }
+
     return this._request.get(`${this._baseUrl}/facilities/${facilityId}`)
       .then((facility) => this._formatFacility(facility));
   }
@@ -172,6 +178,7 @@ class Facilities {
    * @returns {Promise}
    * @fulfill {Facility[]} Information about all facilities
    * @reject {Error}
+   * @throws {Error}
    *
    * @example
    * contxtSdk.facilities.getAllByOrganizationId(25)
@@ -179,6 +186,10 @@ class Facilities {
    *   .catch((err) => console.log(err));
    */
   getAllByOrganizationId(organizationId) {
+    if (!organizationId) {
+      throw new Error("An organization id is required for getting a list of an organization's facilities");
+    }
+
     return this._request.get(`${this._baseUrl}/organizations/${organizationId}/facilities`)
       .then((facilities) => facilities.map((facility) => this._formatFacility(facility)));
   }

--- a/src/facilities.js
+++ b/src/facilities.js
@@ -98,7 +98,7 @@ class Facilities {
     };
 
     return this._request.post(`${this._baseUrl}/facilities`, data)
-      .then((facility) => this._formatFacility(facility));
+      .then((facility) => this._formatFacilityFromServer(facility));
   }
 
   /**
@@ -145,7 +145,7 @@ class Facilities {
     }
 
     return this._request.get(`${this._baseUrl}/facilities/${facilityId}`)
-      .then((facility) => this._formatFacility(facility));
+      .then((facility) => this._formatFacilityFromServer(facility));
   }
 
   /**
@@ -165,7 +165,7 @@ class Facilities {
    */
   getAll() {
     return this._request.get(`${this._baseUrl}/facilities`)
-      .then((facilities) => facilities.map((facility) => this._formatFacility(facility)));
+      .then((facilities) => facilities.map((facility) => this._formatFacilityFromServer(facility)));
   }
 
   /**
@@ -192,7 +192,7 @@ class Facilities {
     }
 
     return this._request.get(`${this._baseUrl}/organizations/${organizationId}/facilities`)
-      .then((facilities) => facilities.map((facility) => this._formatFacility(facility)));
+      .then((facilities) => facilities.map((facility) => this._formatFacilityFromServer(facility)));
   }
 
   /**
@@ -228,7 +228,7 @@ class Facilities {
    *
    * @private
    */
-  _formatFacility(input) {
+  _formatFacilityFromServer(input) {
     return {
       address1: input.address1,
       address2: input.address2,
@@ -238,10 +238,10 @@ class Facilities {
       id: input.id,
       info: input.Info,
       name: input.name,
-      organization: this._formatOrganization(input.Organization),
+      organization: this._formatOrganizationFromServer(input.Organization),
       organizationId: input.organization_id,
       state: input.state,
-      tags: this._formatTags(input.tags),
+      tags: this._formatTagsFromServer(input.tags),
       timezone: input.timezone,
       weatherLocationId: input.weather_location_id,
       zip: input.zip
@@ -266,7 +266,7 @@ class Facilities {
    *
    * @private
    */
-  _formatOrganization(organization) {
+  _formatOrganizationFromServer(organization) {
     return {
       createdAt: organization.created_at,
       id: organization.id,
@@ -294,7 +294,7 @@ class Facilities {
    *
    * @private
    */
-  _formatTags(tags) {
+  _formatTagsFromServer(tags) {
     return tags.map((tag) => {
       return {
         createdAt: tag.created_at,

--- a/src/facilities.spec.js
+++ b/src/facilities.spec.js
@@ -248,6 +248,8 @@ describe('Facilities', function() {
 
     it('formats the facility object', function() {
       return promise.then(() => {
+        expect(formatFacility).to.have.callCount(rawFacilities.length);
+
         rawFacilities.forEach((facility) => {
           expect(formatFacility).to.be.calledWith(facility);
         });
@@ -301,6 +303,8 @@ describe('Facilities', function() {
 
       it('formats the facility object', function() {
         return promise.then(() => {
+          expect(formatFacility).to.have.callCount(rawFacilities.length);
+
           rawFacilities.forEach((facility) => {
             expect(formatFacility).to.be.calledWith(facility);
           });

--- a/src/facilities.spec.js
+++ b/src/facilities.spec.js
@@ -9,8 +9,9 @@ describe('Facilities', function() {
     this.sandbox = sandbox.create();
 
     baseRequest = {
-      get: this.sandbox.stub(),
-      post: this.sandbox.stub()
+      delete: this.sandbox.stub().resolves(),
+      get: this.sandbox.stub().resolves(),
+      post: this.sandbox.stub().resolves()
     };
     baseSdk = {
       config: {
@@ -123,6 +124,42 @@ describe('Facilities', function() {
     });
   });
 
+  describe('delete', function() {
+    context('the facility id is provided', function() {
+      let expectedHost;
+      let facility;
+      let promise;
+
+      beforeEach(function() {
+        expectedHost = faker.internet.url();
+        facility = fixture.build('facility');
+
+        const facilities = new Facilities(baseSdk, baseRequest);
+        facilities._baseUrl = expectedHost;
+
+        promise = facilities.delete(facility.id);
+      });
+
+      it('requests to delete the facility', function() {
+        expect(baseRequest.delete).to.be
+          .calledWith(`${expectedHost}/facilities/${facility.id}`);
+      });
+
+      it('returns a resolved promise', function() {
+        return expect(promise).to.be.fulfilled;
+      });
+    });
+
+    context('the facility id is not provided', function() {
+      it('throws an error', function() {
+        const facilities = new Facilities(baseSdk, baseRequest);
+        const fn = () => facilities.delete();
+
+        expect(fn).to.throw('A facility id is required for deleting a facility');
+      });
+    });
+  });
+
   describe('get', function() {
     let expectedFacilityId;
     let expectedHost;
@@ -135,8 +172,8 @@ describe('Facilities', function() {
     beforeEach(function() {
       expectedFacilityId = faker.random.number();
       expectedHost = faker.internet.url();
-      rawFacility = fixture.build('facility', { id: expectedFacilityId }, { fromServer: true });
-      formattedFacility = fixture.build('facility', { id: expectedFacilityId });
+      rawFacility = fixture.build('facility', null, { fromServer: true });
+      formattedFacility = fixture.build('facility', { id: rawFacility.id });
 
       formatFacility = this.sandbox.stub(Facilities.prototype, '_formatFacility')
         .returns(formattedFacility);

--- a/src/facilities.spec.js
+++ b/src/facilities.spec.js
@@ -109,17 +109,16 @@ describe('Facilities', function() {
     context('when there is missing required information', function() {
       ['organizationId', 'name', 'timezone'].forEach(function(field) {
         it(`it throws an error when ${field} is missing`, function() {
-          const fn = () => {
-            const facility = fixture.build('facility');
-            const initialFacility = {
-              ...facility,
-              organizationId: facility.organizationId
-            };
-            const facilities = new Facilities(baseSdk, baseRequest);
-            facilities.create(omit(initialFacility, [field]));
+          const facility = fixture.build('facility');
+          const initialFacility = {
+            ...facility,
+            organizationId: facility.organizationId
           };
+          const facilities = new Facilities(baseSdk, baseRequest);
+          const promise = facilities.create(omit(initialFacility, [field]));
 
-          expect(fn).to.throw(`A ${field} is required to create a new facility.`);
+          return expect(promise).to.be
+            .rejectedWith(`A ${field} is required to create a new facility.`);
         });
       });
     });
@@ -154,9 +153,10 @@ describe('Facilities', function() {
     context('the facility id is not provided', function() {
       it('throws an error', function() {
         const facilities = new Facilities(baseSdk, baseRequest);
-        const fn = () => facilities.delete();
+        const promise = facilities.delete();
 
-        expect(fn).to.throw('A facility id is required for deleting a facility');
+        return expect(promise).to.be
+          .rejectedWith('A facility id is required for deleting a facility');
       });
     });
   });
@@ -209,9 +209,10 @@ describe('Facilities', function() {
     context('the facility id is not provided', function() {
       it('throws an error', function() {
         const facilities = new Facilities(baseSdk, baseRequest);
-        const fn = () => facilities.get();
+        const promise = facilities.get();
 
-        expect(fn).to.throw('A facility id is required for getting information about a facility');
+        return expect(promise).to.be
+          .rejectedWith('A facility id is required for getting information about a facility');
       });
     });
   });
@@ -320,10 +321,11 @@ describe('Facilities', function() {
     context('the organization id is not provided', function() {
       it('throws an error', function() {
         const facilities = new Facilities(baseSdk, baseRequest);
-        const fn = () => facilities.getAllByOrganizationId();
+        const promise = facilities.getAllByOrganizationId();
 
-        expect(fn).to
-          .throw("An organization id is required for getting a list of an organization's facilities");
+        return expect(promise).to.be.rejectedWith(
+          "An organization id is required for getting a list of an organization's facilities"
+        );
       });
     });
   });
@@ -375,23 +377,26 @@ describe('Facilities', function() {
 
       it('throws an error when there is no provided facility id', function() {
         const facilityUpdate = fixture.build('facility');
-        const fn = () => facilities.update(null, facilityUpdate);
+        const promise = facilities.update(null, facilityUpdate);
 
-        expect(fn).to.throw('A facility id is required to update a facility.');
+        return expect(promise).to.be
+          .rejectedWith('A facility id is required to update a facility.');
       });
 
       it('throws an error when there is no update provided', function() {
         const facilityUpdate = fixture.build('facility');
-        const fn = () => facilities.update(facilityUpdate.id);
+        const promise = facilities.update(facilityUpdate.id);
 
-        expect(fn).to.throw('An update is required to update a facility.');
+        return expect(promise).to.be.rejectedWith('An update is required to update a facility.');
       });
 
       it('throws an error when the update is not an object', function() {
         const facilityUpdate = fixture.build('facility');
-        const fn = () => facilities.update(facilityUpdate.id, [facilityUpdate]);
+        const promise = facilities.update(facilityUpdate.id, [facilityUpdate]);
 
-        expect(fn).to.throw('The facility update must be a well-formed object with the data you wish to update.');
+        return expect(promise).to.be.rejectedWith(
+          'The facility update must be a well-formed object with the data you wish to update.'
+        );
       });
     });
   });

--- a/src/facilities.spec.js
+++ b/src/facilities.spec.js
@@ -11,7 +11,8 @@ describe('Facilities', function() {
     baseRequest = {
       delete: this.sandbox.stub().resolves(),
       get: this.sandbox.stub().resolves(),
-      post: this.sandbox.stub().resolves()
+      post: this.sandbox.stub().resolves(),
+      put: this.sandbox.stub().resolves()
     };
     baseSdk = {
       config: {
@@ -332,14 +333,16 @@ describe('Facilities', function() {
       let expectedHost;
       let facilityUpdate;
       let formatFacilityToServer;
+      let formattedFacility;
       let promise;
 
       beforeEach(function() {
         expectedHost = faker.internet.url();
         facilityUpdate = fixture.build('facility');
+        formattedFacility = fixture.build('facility', null, { fromServer: true });
 
         formatFacilityToServer = this.sandbox.stub(Facilities.prototype, '_formatFacilityToServer')
-          .returns({});
+          .returns(formattedFacility);
 
         const facilities = new Facilities(baseSdk, baseRequest);
         facilities._baseUrl = expectedHost;
@@ -354,7 +357,7 @@ describe('Facilities', function() {
       it('updates the facility', function() {
         expect(baseRequest.put).to.be.calledWith(
           `${expectedHost}/facilities/${facilityUpdate.id}`,
-          {}
+          formattedFacility
         );
       });
 
@@ -436,6 +439,41 @@ describe('Facilities', function() {
     });
 
     it('converts the object keys to the camelCase', function() {
+      expect(formattedFacility).to.deep.equal(expectedFacility);
+    });
+  });
+
+  describe('_formatFacilityToServer', function() {
+    let expectedFacility;
+    let facility;
+    let formattedFacility;
+
+    beforeEach(function() {
+      facility = fixture.build('facility');
+      expectedFacility = omit(
+        {
+          ...facility,
+          geometry_id: facility.geometryId,
+          Info: facility.info,
+          organization_id: facility.organizationId,
+          weather_location_id: facility.weatherLocationId
+        },
+        [
+          'createdAt',
+          'geometryId',
+          'id',
+          'info',
+          'organization',
+          'organizationId',
+          'tags',
+          'weatherLocationId'
+        ]
+      );
+
+      formattedFacility = Facilities.prototype._formatFacilityToServer(facility);
+    });
+
+    it('converts the object keys to snake case and capitalizes certain keys', function() {
       expect(formattedFacility).to.deep.equal(expectedFacility);
     });
   });

--- a/src/facilities.spec.js
+++ b/src/facilities.spec.js
@@ -102,4 +102,38 @@ describe('Facilities', function() {
         .and.to.eventually.equal(expectedFacilities);
     });
   });
+
+  describe('getAllByOrganizationId', function() {
+    let expectedFacilities;
+    let expectedHost;
+    let expectedOrganizationId;
+    let promise;
+    let request;
+
+    beforeEach(function() {
+      expectedFacilities = fixture.buildList('facility', faker.random.number({ min: 1, max: 10 }));
+      expectedHost = faker.internet.url();
+      expectedOrganizationId = faker.random.number();
+      request = {
+        ...baseRequest,
+        get: this.sandbox.stub().resolves(expectedFacilities)
+      };
+
+      const facilities = new Facilities(baseSdk, request);
+      facilities._baseUrl = expectedHost;
+
+      promise = facilities.getAllByOrganizationId(expectedOrganizationId);
+    });
+
+    it('gets a list of facilities for an organization from the server', function() {
+      expect(request.get).to.be.calledWith(
+        `${expectedHost}/organizations/${expectedOrganizationId}/facilities`
+      );
+    });
+
+    it('returns a list of facilities', function() {
+      return expect(promise).to.be.fulfilled
+        .and.to.eventually.equal(expectedFacilities);
+    });
+  });
 });

--- a/src/facilities.spec.js
+++ b/src/facilities.spec.js
@@ -48,47 +48,58 @@ describe('Facilities', function() {
   describe('create', function() {
     context('when all required information is supplied', function() {
       context('when the facility is successfully created', function() {
-        let expectedFacility;
         let expectedHost;
+        let formatFacility;
+        let formattedFacility;
         let promise;
+        let rawFacility;
         let request;
 
         beforeEach(function() {
-          expectedFacility = fixture.build('facility');
           expectedHost = faker.internet.url();
+          rawFacility = fixture.build('facility', null, { fromServer: true });
+          formattedFacility = fixture.build('facility');
 
+          formatFacility = this.sandbox.stub(Facilities.prototype, '_formatFacility')
+            .returns(formattedFacility);
           request = {
             ...baseRequest,
-            post: this.sandbox.stub().resolves(expectedFacility)
+            post: this.sandbox.stub().resolves(rawFacility)
           };
 
           const facilities = new Facilities(baseSdk, request);
           facilities._baseUrl = expectedHost;
 
           promise = facilities.create({
-            address1: expectedFacility.address1,
-            address2: expectedFacility.address2,
-            city: expectedFacility.city,
-            geometryId: expectedFacility.geometry_id,
-            name: expectedFacility.name,
-            organizationId: expectedFacility.organization_id,
-            state: expectedFacility.state,
-            timezone: expectedFacility.timezone,
-            weatherLocationId: expectedFacility.weather_location_id,
-            zip: expectedFacility.zip
+            address1: rawFacility.address1,
+            address2: rawFacility.address2,
+            city: rawFacility.city,
+            geometryId: rawFacility.geometry_id,
+            name: rawFacility.name,
+            organizationId: rawFacility.organization_id,
+            state: rawFacility.state,
+            timezone: rawFacility.timezone,
+            weatherLocationId: rawFacility.weather_location_id,
+            zip: rawFacility.zip
           });
         });
 
         it('creates a new facility', function() {
           expect(request.post).to.be.deep.calledWith(
             `${expectedHost}/facilities`,
-            omit(expectedFacility, ['id', 'Info', 'Organization', 'tags'])
+            omit(rawFacility, ['created_at', 'id', 'Info', 'Organization', 'tags'])
           );
+        });
+
+        it('formats the facility object', function() {
+          return promise.then(() => {
+            expect(formatFacility).to.be.calledWith(rawFacility);
+          });
         });
 
         it('returns a fulfilled promise with the new facility information', function() {
           return expect(promise).to.be.fulfilled
-            .and.to.eventually.equal(expectedFacility);
+            .and.to.eventually.equal(formattedFacility);
         });
       });
     });
@@ -100,7 +111,7 @@ describe('Facilities', function() {
             const facility = fixture.build('facility');
             const initialFacility = {
               ...facility,
-              organizationId: facility.organization_id
+              organizationId: facility.organizationId
             };
             const facilities = new Facilities(baseSdk, baseRequest);
             facilities.create(omit(initialFacility, [field]));
@@ -113,19 +124,25 @@ describe('Facilities', function() {
   });
 
   describe('get', function() {
-    let expectedFacility;
     let expectedFacilityId;
     let expectedHost;
+    let formatFacility;
+    let formattedFacility;
     let promise;
+    let rawFacility;
     let request;
 
     beforeEach(function() {
       expectedFacilityId = faker.random.number();
-      expectedFacility = fixture.build('facility', { id: expectedFacilityId });
       expectedHost = faker.internet.url();
+      rawFacility = fixture.build('facility', { id: expectedFacilityId }, { fromServer: true });
+      formattedFacility = fixture.build('facility', { id: expectedFacilityId });
+
+      formatFacility = this.sandbox.stub(Facilities.prototype, '_formatFacility')
+        .returns(formattedFacility);
       request = {
         ...baseRequest,
-        get: this.sandbox.stub().resolves(expectedFacility)
+        get: this.sandbox.stub().resolves(rawFacility)
       };
 
       const facilities = new Facilities(baseSdk, request);
@@ -138,24 +155,40 @@ describe('Facilities', function() {
       expect(request.get).to.be.calledWith(`${expectedHost}/facilities/${expectedFacilityId}`);
     });
 
+    it('formats the facility object', function() {
+      return promise.then(() => {
+        expect(formatFacility).to.be.calledWith(rawFacility);
+      });
+    });
+
     it('returns the requested facility', function() {
       return expect(promise).to.be.fulfilled
-        .and.to.eventually.equal(expectedFacility);
+        .and.to.eventually.equal(formattedFacility);
     });
   });
 
   describe('getAll', function() {
-    let expectedFacilities;
     let expectedHost;
+    let formatFacility;
+    let formattedFacilities;
     let promise;
+    let rawFacilities;
     let request;
 
     beforeEach(function() {
-      expectedFacilities = fixture.buildList('facility', faker.random.number({ min: 1, max: 10 }));
       expectedHost = faker.internet.url();
+      const numberOfFacilities = faker.random.number({ min: 1, max: 10 });
+      formattedFacilities = fixture.buildList('facility', numberOfFacilities);
+      rawFacilities = fixture.buildList('facility', numberOfFacilities, null, { fromServer: true });
+
+      formatFacility = this.sandbox.stub(Facilities.prototype, '_formatFacility')
+        .callsFake((facility) => {
+          const index = rawFacilities.indexOf(facility);
+          return formattedFacilities[index];
+        });
       request = {
         ...baseRequest,
-        get: this.sandbox.stub().resolves(expectedFacilities)
+        get: this.sandbox.stub().resolves(rawFacilities)
       };
 
       const facilities = new Facilities(baseSdk, request);
@@ -168,26 +201,44 @@ describe('Facilities', function() {
       expect(request.get).to.be.calledWith(`${expectedHost}/facilities`);
     });
 
+    it('formats the facility object', function() {
+      return promise.then(() => {
+        rawFacilities.forEach((facility) => {
+          expect(formatFacility).to.be.calledWith(facility);
+        });
+      });
+    });
+
     it('returns a list of facilities', function() {
       return expect(promise).to.be.fulfilled
-        .and.to.eventually.equal(expectedFacilities);
+        .and.to.eventually.deep.equal(formattedFacilities);
     });
   });
 
   describe('getAllByOrganizationId', function() {
-    let expectedFacilities;
     let expectedHost;
     let expectedOrganizationId;
+    let formatFacility;
+    let formattedFacilities;
     let promise;
+    let rawFacilities;
     let request;
 
     beforeEach(function() {
-      expectedFacilities = fixture.buildList('facility', faker.random.number({ min: 1, max: 10 }));
       expectedHost = faker.internet.url();
       expectedOrganizationId = faker.random.number();
+      const numberOfFacilities = faker.random.number({ min: 1, max: 10 });
+      formattedFacilities = fixture.buildList('facility', numberOfFacilities);
+      rawFacilities = fixture.buildList('facility', numberOfFacilities, null, { fromServer: true });
+
+      formatFacility = this.sandbox.stub(Facilities.prototype, '_formatFacility')
+        .callsFake((facility) => {
+          const index = rawFacilities.indexOf(facility);
+          return formattedFacilities[index];
+        });
       request = {
         ...baseRequest,
-        get: this.sandbox.stub().resolves(expectedFacilities)
+        get: this.sandbox.stub().resolves(rawFacilities)
       };
 
       const facilities = new Facilities(baseSdk, request);
@@ -202,9 +253,123 @@ describe('Facilities', function() {
       );
     });
 
+    it('formats the facility object', function() {
+      return promise.then(() => {
+        rawFacilities.forEach((facility) => {
+          expect(formatFacility).to.be.calledWith(facility);
+        });
+      });
+    });
+
     it('returns a list of facilities', function() {
       return expect(promise).to.be.fulfilled
-        .and.to.eventually.equal(expectedFacilities);
+        .and.to.eventually.deep.equal(formattedFacilities);
+    });
+  });
+
+  describe('_formatFacility', function() {
+    let expectedFacility;
+    let facility;
+    let formatOrganization;
+    let formatTags;
+    let formattedFacility;
+
+    beforeEach(function() {
+      facility = fixture.build('facility', null, { fromServer: true });
+      expectedFacility = omit(
+        {
+          ...facility,
+          createdAt: facility.created_at,
+          geometryId: facility.geometry_id,
+          info: facility.Info,
+          organization: facility.Organization,
+          organizationId: facility.organization_id,
+          weatherLocationId: facility.weather_location_id
+        },
+        [
+          'created_at',
+          'geometry_id',
+          'Info',
+          'Organization',
+          'organization_id',
+          'weather_location_id'
+        ]
+      );
+
+      formatOrganization = this.sandbox.stub(Facilities.prototype, '_formatOrganization')
+        .callsFake((organization) => organization);
+      formatTags = this.sandbox.stub(Facilities.prototype, '_formatTags').callsFake((tags) => tags);
+
+      formattedFacility = Facilities.prototype._formatFacility(facility);
+    });
+
+    it('formats the necessary children objects', function() {
+      expect(formatOrganization).to.be.calledWith(facility.Organization);
+      expect(formatTags).to.be.calledWith(facility.tags);
+    });
+
+    it('converts the object keys to the camelCase', function() {
+      expect(formattedFacility).to.deep.equal(expectedFacility);
+    });
+  });
+
+  describe('_formatOrganization', function() {
+    let expectedOrganization;
+    let formattedOrganization;
+    let organization;
+
+    beforeEach(function() {
+      organization = fixture.build(
+        'organization',
+        null,
+        { fromServer: true }
+      );
+      expectedOrganization = omit(
+        {
+          ...organization,
+          createdAt: organization.created_at,
+          updatedAt: organization.updated_at
+        },
+        ['created_at', 'updated_at']
+      );
+
+      formattedOrganization = Facilities.prototype._formatOrganization(organization);
+    });
+
+    it('converts the object keys to camelCase', function() {
+      expect(formattedOrganization).to.deep.equal(expectedOrganization);
+    });
+  });
+
+  describe('_formatTags', function() {
+    let expectedTags;
+    let formattedTags;
+    let tags;
+
+    beforeEach(function() {
+      tags = fixture.buildList(
+        'facilityTag',
+        faker.random.number({ min: 1, max: 2 }),
+        null,
+        { fromServer: true }
+      );
+      expectedTags = tags.map((tag) => {
+        return omit(
+          {
+            ...tag,
+            createdAt: tag.created_at,
+            facilityId: tag.facility_id,
+            updatedAt: tag.updated_at
+          },
+          ['created_at', 'facility_id', 'updated_at']
+        );
+      });
+
+      formattedTags = Facilities.prototype._formatTags(tags);
+    });
+
+    it('converts the object keys to camelCase', function() {
+      expect(formattedTags).to.deep.equal(expectedTags);
     });
   });
 });

--- a/src/sessionTypes/auth0WebAuth.js
+++ b/src/sessionTypes/auth0WebAuth.js
@@ -8,7 +8,7 @@ import URL from 'url-parse';
  * @property {string} nickname
  * @property {string} picture URL to an avatar
  * @property {string} sub The Subject Claim of the user's JWT
- * @property {string} updated_at ISO 8601 Extended Format date/time string
+ * @property {string} updatedAt ISO 8601 Extended Format date/time string
  */
 
 /**
@@ -119,7 +119,13 @@ class Auth0WebAuth {
               reject(err);
             }
 
-            resolve(profile);
+            const formattedProfile = {
+              ...profile,
+              updatedAt: profile.updated_at
+            };
+            delete formattedProfile.updated_at;
+
+            resolve(formattedProfile);
           });
         });
       });

--- a/src/sessionTypes/auth0WebAuth.spec.js
+++ b/src/sessionTypes/auth0WebAuth.spec.js
@@ -1,5 +1,6 @@
 import auth0 from 'auth0-js';
 import axios from 'axios';
+import omit from 'lodash.omit';
 import sinon from 'sinon';
 import Auth0WebAuth from './auth0WebAuth';
 
@@ -165,18 +166,20 @@ describe('sessionTypes/Auth0WebAuth', function() {
       let expectedAccessToken;
       let expectedProfile;
       let getCurrentAccessToken;
+      let profile;
       let promise;
 
       beforeEach(function() {
         expectedAccessToken = faker.internet.password();
-        expectedProfile = faker.helpers.userCard();
+        profile = fixture.build('userProfile', null, { fromServer: true });
+        expectedProfile = omit({ ...profile, updatedAt: profile.updated_at }, ['updated_at']);
 
         getCurrentAccessToken = this.sandbox.stub(Auth0WebAuth.prototype, 'getCurrentAccessToken')
           .resolves(expectedAccessToken);
         this.sandbox.stub(Auth0WebAuth.prototype, '_loadSession');
         webAuthSession.client = {
           userInfo: this.sandbox.stub().callsFake((accessToken, cb) => {
-            cb(null, expectedProfile);
+            cb(null, profile);
           })
         };
 
@@ -196,7 +199,7 @@ describe('sessionTypes/Auth0WebAuth', function() {
 
       it("returns a fulfilled promise with the users's profile", function() {
         return expect(promise).to.be.fulfilled
-          .and.to.eventually.equal(expectedProfile);
+          .and.to.eventually.deep.equal(expectedProfile);
       });
     });
 

--- a/support/fixtures/factories/facility.js
+++ b/support/fixtures/factories/facility.js
@@ -10,6 +10,7 @@ factory.define('facility')
     address1: () => faker.address.streetAddress(),
     address2: () => faker.address.secondaryAddress(),
     city: () => faker.address.city(),
+    geometry_id: () => faker.random.uuid(),
     Info: () => {
       return {
         primary_contact_email: faker.internet.email(),

--- a/support/fixtures/factories/facility.js
+++ b/support/fixtures/factories/facility.js
@@ -22,7 +22,7 @@ factory.define('facility')
     Organization: () => factory.build('organization'),
     state: () => faker.address.state(),
     timezone: () => {
-      return faker.helpers.shuffle([
+      return faker.random.arrayElement([
         'America/New_York',
         'America/Chicago',
         'America/Denver',

--- a/support/fixtures/factories/facility.js
+++ b/support/fixtures/factories/facility.js
@@ -5,13 +5,15 @@ const faker = require('faker');
 const times = require('lodash.times');
 
 factory.define('facility')
+  .option('fromServer', false)
   .sequence('id')
   .attrs({
     address1: () => faker.address.streetAddress(),
     address2: () => faker.address.secondaryAddress(),
     city: () => faker.address.city(),
-    geometry_id: () => faker.random.uuid(),
-    Info: () => {
+    createdAt: () => faker.date.past().toISOString(),
+    geometryId: () => faker.random.uuid(),
+    info: () => {
       return {
         primary_contact_email: faker.internet.email(),
         primary_contact_first_name: faker.name.firstName(),
@@ -19,7 +21,6 @@ factory.define('facility')
         square_feet: faker.random.number()
       };
     },
-    Organization: () => factory.build('organization'),
     state: () => faker.address.state(),
     timezone: () => {
       return faker.random.arrayElement([
@@ -29,13 +30,39 @@ factory.define('facility')
         'America/Los_Angeles'
       ]);
     },
-    weather_location_id: () => null,
+    weatherLocationId: () => null,
     zip: () => faker.address.zipCode()
   })
   .attr('name', ['city'], (city) => `${faker.address.cityPrefix()} ${city}`)
-  .attr('organization_id', ['Organization'], (organization) => organization.id)
-  .attr('tags', ['id'], (id) => {
+  .attr('organization', ['fromServer'], (fromServer) => {
+    return factory.build('organization', null, { fromServer });
+  })
+  .attr('organizationId', ['organization'], (organization) => organization.id)
+  .attr('tags', ['id', 'fromServer'], (id, fromServer) => {
     return times(faker.random.number({ min: 0, max: 5 }), () => {
-      return factory.build('facilityTag', { facility_id: id });
+      return factory.build('facilityTag', { facilityId: id }, { fromServer });
     });
+  })
+  .after((facility, options) => {
+    // If building a facility object that comes from the server, transform it to have camel case and
+    // capital letters in the right spots
+    if (options.fromServer) {
+      facility.created_at = facility.createdAt;
+      delete facility.createdAt;
+
+      facility.geometry_id = facility.geometryId;
+      delete facility.geometryId;
+
+      facility.Info = facility.info;
+      delete facility.info;
+
+      facility.Organization = facility.organization;
+      delete facility.organization;
+
+      facility.organization_id = facility.organizationId;
+      delete facility.organizationId;
+
+      facility.weather_location_id = facility.weatherLocationId;
+      delete facility.weatherLocationId;
+    }
   });

--- a/support/fixtures/factories/facilityTag.js
+++ b/support/fixtures/factories/facilityTag.js
@@ -4,8 +4,25 @@ const factory = require('rosie').Factory;
 const faker = require('faker');
 
 factory.define('facilityTag')
+  .option('fromServer', false)
   .sequence('id')
   .attrs({
-    facility_id: () => faker.random.number(),
-    name: faker.commerce.productMaterial()
+    createdAt: () => faker.date.past().toISOString(),
+    facilityId: () => faker.random.number(),
+    name: () => faker.commerce.productMaterial(),
+    updatedAt: () => faker.date.recent().toISOString()
+  })
+  .after((facilityTag, options) => {
+    // If building a facility tag object that comes from the server, transform it to have camel case
+    // and capital letters in the right spots
+    if (options.fromServer) {
+      facilityTag.created_at = facilityTag.createdAt;
+      delete facilityTag.createdAt;
+
+      facilityTag.facility_id = facilityTag.facilityId;
+      delete facilityTag.facilityId;
+
+      facilityTag.updated_at = facilityTag.updatedAt;
+      delete facilityTag.updatedAt;
+    }
   });

--- a/support/fixtures/factories/index.js
+++ b/support/fixtures/factories/index.js
@@ -7,5 +7,6 @@ require('./defaultAudiences');
 require('./facility');
 require('./facilityTag');
 require('./organization');
+require('./userProfile');
 
 module.exports = factory;

--- a/support/fixtures/factories/organization.js
+++ b/support/fixtures/factories/organization.js
@@ -5,6 +5,19 @@ const faker = require('faker');
 
 factory.define('organization')
   .attrs({
+    createdAt: () => faker.date.past().toISOString(),
     id: () => faker.random.uuid(),
-    name: () => faker.company.companyName()
+    name: () => faker.company.companyName(),
+    updatedAt: () => faker.date.recent().toISOString()
+  })
+  .after((organization, options) => {
+    // If building an organization object that comes from the server, transform it to have camel
+    // case and capital letters in the right spots
+    if (options.fromServer) {
+      organization.created_at = organization.createdAt;
+      delete organization.createdAt;
+
+      organization.updated_at = organization.updatedAt;
+      delete organization.updatedAt;
+    }
   });

--- a/support/fixtures/factories/userProfile.js
+++ b/support/fixtures/factories/userProfile.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const factory = require('rosie').Factory;
+const faker = require('faker');
+
+factory.define('userProfile')
+  .attrs({
+    name: () => faker.name.findName(),
+    nickname: () => faker.name.firstName(),
+    picture: () => faker.image.avatar(),
+    sub: () => faker.hacker.adjective(),
+    updatedAt: () => faker.date.recent().toISOString()
+  })
+  .after((userProfile, options) => {
+    // If building a user profile object that comes from the server, transform it to have camel case
+    // and capital letters in the right spots
+    if (options.fromServer) {
+      userProfile.updated_at = userProfile.updatedAt;
+      delete userProfile.updatedAt;
+    }
+  });


### PR DESCRIPTION
## Why?
There is additional functionality in the facilities manager API that we need to be able to do through the SDK.

## What changed?
- Added Facilities#create that creates a new facility
- Added Facilities#delete that deletes an existing facility
- Added Facilities#getAllByOrganizationId that gets all facilities that belong to a particular organization
- Added Facilities#update that updates an existing facility
- Started normalizing data coming from the facilities manager API
  - There are some inconsistencies with how things are named in facilities responses
