### PR TITLE
Add Facilities#updateInfo

### DIFF
--- a/src/facilities.js
+++ b/src/facilities.js
@@ -244,6 +244,42 @@ class Facilities {
   }
 
   /**
+   * Updates a facility's info (NOTE: This refers to the facility_info model)
+   *
+   * API Endpoint: '/facilities/:facilityId/info'
+   * Method: POST
+   *
+   * @param {number} facilityId The id of the facility to update
+   * @param {Object} update An object containing the updated facility info for the facility
+   *
+   * @returns {Promise}
+   * @fulfill {undefined}
+   * @reject {Error}
+   *
+   * @example
+   * contxtSdk.facilities.updateInfo(25, {
+   *   square_feet: '10000'
+   * });
+   */
+  updateInfo(facilityId, update) {
+    if (!facilityId) {
+      return Promise.reject(new Error("A facility id is required to update a facility's info."));
+    }
+
+    if (!update) {
+      return Promise.reject(new Error("An update is required to update a facility's info."));
+    }
+
+    if (!isPlainObject(update)) {
+      return Promise.reject(
+        new Error('The facility info update must be a well-formed object with the data you wish to update.')
+      );
+    }
+
+    return this._request.post(`${this._baseUrl}/facilities/${facilityId}/info`, update);
+  }
+
+  /**
    * Normalizes the facility object returned from the API server
    *
    * @param {Object} input

--- a/src/facilities.spec.js
+++ b/src/facilities.spec.js
@@ -400,6 +400,69 @@ describe('Facilities', function() {
     });
   });
 
+  describe('updateInfo', function() {
+    context('when all required information is available', function() {
+      let expectedHost;
+      let facilityId;
+      let facilityInfoUpdate;
+      let promise;
+
+      beforeEach(function() {
+        expectedHost = faker.internet.url();
+        facilityId = fixture.build('facility').id;
+        facilityInfoUpdate = fixture.build('facilityInfo');
+
+        const facilities = new Facilities(baseSdk, baseRequest);
+        facilities._baseUrl = expectedHost;
+
+        promise = facilities.updateInfo(facilityId, facilityInfoUpdate);
+      });
+
+      it('updates the facility', function() {
+        expect(baseRequest.post).to.be.calledWith(
+          `${expectedHost}/facilities/${facilityId}/info`,
+          facilityInfoUpdate
+        );
+      });
+
+      it('returns a fulfilled promise', function() {
+        return expect(promise).to.be.fulfilled;
+      });
+    });
+
+    context('when there is missing or malformed required information', function() {
+      let facilities;
+
+      beforeEach(function() {
+        facilities = new Facilities(baseSdk, baseRequest);
+      });
+
+      it('throws an error when there is no provided facility id', function() {
+        const facilityInfoUpdate = fixture.build('facilityInfo');
+        const promise = facilities.updateInfo(null, facilityInfoUpdate);
+
+        return expect(promise).to.be
+          .rejectedWith("A facility id is required to update a facility's info.");
+      });
+
+      it('throws an error when there is no update provided', function() {
+        const facility = fixture.build('facility');
+        const promise = facilities.updateInfo(facility.id);
+
+        return expect(promise).to.be.rejectedWith("An update is required to update a facility's info.");
+      });
+
+      it('throws an error when the update is not an object', function() {
+        const facility = fixture.build('facility');
+        const promise = facilities.updateInfo(facility.id, [facility.info]);
+
+        return expect(promise).to.be.rejectedWith(
+          'The facility info update must be a well-formed object with the data you wish to update.'
+        );
+      });
+    });
+  });
+
   describe('_formatFacilityFromServer', function() {
     let expectedFacility;
     let facility;

--- a/support/fixtures/factories/facility.js
+++ b/support/fixtures/factories/facility.js
@@ -13,14 +13,7 @@ factory.define('facility')
     city: () => faker.address.city(),
     createdAt: () => faker.date.past().toISOString(),
     geometryId: () => faker.random.uuid(),
-    info: () => {
-      return {
-        primary_contact_email: faker.internet.email(),
-        primary_contact_first_name: faker.name.firstName(),
-        primary_contact_last_name: faker.name.lastName(),
-        square_feet: faker.random.number()
-      };
-    },
+    info: () => factory.build('facilityInfo'),
     state: () => faker.address.state(),
     timezone: () => {
       return faker.random.arrayElement([

--- a/support/fixtures/factories/facilityInfo.js
+++ b/support/fixtures/factories/facilityInfo.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const factory = require('rosie').Factory;
+const faker = require('faker');
+
+factory.define('facilityInfo')
+  .attrs({
+    'General Manager': () => faker.name.findName(),
+    latitude: () => faker.address.latitude(),
+    longitude: () => faker.address.longitude(),
+    rail_access: () => faker.random.boolean(),
+    square_feet: () => faker.random.number()
+  });

--- a/support/fixtures/factories/index.js
+++ b/support/fixtures/factories/index.js
@@ -5,6 +5,7 @@ const factory = require('rosie').Factory;
 require('./audience');
 require('./defaultAudiences');
 require('./facility');
+require('./facilityInfo');
 require('./facilityTag');
 require('./organization');
 require('./userProfile');


### PR DESCRIPTION
## Why?
Some Facility attributes like `square_feet` are stored as facility info instead of directly on the facility model. We want to update those attributes.

## What changed?
- Added Facilities#updateInfo method that POSTs to `/facilities/:facilityId/info`