### PR TITLE
Rename Facilities#updateInfo to Facilities#createOrUpdateInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [v0.0.7](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.7) (2018-03-29)
+**Renamed**
+- Facilities#updateInfo to Facilities#createOrUpdateInfo so that what the method does is more obvious
+
 ## [v0.0.6](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.6) (2018-03-28)
 **Added**
 - Facilities#updateInfo for updating a facility's facilily info

--- a/docs/Facilities.md
+++ b/docs/Facilities.md
@@ -9,12 +9,12 @@ of, information about different facilities
 * [Facilities](#Facilities)
     * [new Facilities(sdk, request)](#new_Facilities_new)
     * [.create(options)](#Facilities+create) ⇒ <code>Promise</code>
+    * [.createOrUpdateInfo(facilityId, update)](#Facilities+createOrUpdateInfo) ⇒ <code>Promise</code>
     * [.delete(facilityId)](#Facilities+delete) ⇒ <code>Promise</code>
     * [.get(facilityId)](#Facilities+get) ⇒ <code>Promise</code>
     * [.getAll()](#Facilities+getAll) ⇒ <code>Promise</code>
     * [.getAllByOrganizationId(organizationId)](#Facilities+getAllByOrganizationId) ⇒ <code>Promise</code>
     * [.update(facilityId, update)](#Facilities+update) ⇒ <code>Promise</code>
-    * [.updateInfo(facilityId, update)](#Facilities+updateInfo) ⇒ <code>Promise</code>
 
 <a name="new_Facilities_new"></a>
 
@@ -61,6 +61,29 @@ contxtSdk.facilities
   })
   .then((facilities) => console.log(facilities));
   .catch((err) => console.log(err));
+```
+<a name="Facilities+createOrUpdateInfo"></a>
+
+### contxtSdk.facilities.createOrUpdateInfo(facilityId, update) ⇒ <code>Promise</code>
+Creates or updates a facility's info (NOTE: This refers to the facility_info model)
+
+API Endpoint: '/facilities/:facilityId/info?should_update=true'
+Method: POST
+
+**Kind**: instance method of [<code>Facilities</code>](#Facilities)  
+**Fulfill**: <code>undefined</code>  
+**Reject**: <code>Error</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| facilityId | <code>number</code> | The id of the facility to update |
+| update | <code>Object</code> | An object containing the facility info for the facility |
+
+**Example**  
+```js
+contxtSdk.facilities.createOrUpdateInfo(25, {
+  square_feet: '10000'
+});
 ```
 <a name="Facilities+delete"></a>
 
@@ -177,28 +200,5 @@ contxtSdk.facilities.update(25, {
   address: '221 B Baker St, London, England',
   name: 'Sherlock Homes Museum',
   organizationId: 25
-});
-```
-<a name="Facilities+updateInfo"></a>
-
-### contxtSdk.facilities.updateInfo(facilityId, update) ⇒ <code>Promise</code>
-Updates a facility's info (NOTE: This refers to the facility_info model)
-
-API Endpoint: '/facilities/:facilityId/info'
-Method: POST
-
-**Kind**: instance method of [<code>Facilities</code>](#Facilities)  
-**Fulfill**: <code>undefined</code>  
-**Reject**: <code>Error</code>  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| facilityId | <code>number</code> | The id of the facility to update |
-| update | <code>Object</code> | An object containing the updated facility info for the facility |
-
-**Example**  
-```js
-contxtSdk.facilities.updateInfo(25, {
-  square_feet: '10000'
 });
 ```

--- a/src/facilities.js
+++ b/src/facilities.js
@@ -94,6 +94,48 @@ class Facilities {
   }
 
   /**
+   * Creates or updates a facility's info (NOTE: This refers to the facility_info model)
+   *
+   * API Endpoint: '/facilities/:facilityId/info?should_update=true'
+   * Method: POST
+   *
+   * @param {number} facilityId The id of the facility to update
+   * @param {Object} update An object containing the facility info for the facility
+   *
+   * @returns {Promise}
+   * @fulfill {undefined}
+   * @reject {Error}
+   *
+   * @example
+   * contxtSdk.facilities.createOrUpdateInfo(25, {
+   *   square_feet: '10000'
+   * });
+   */
+  createOrUpdateInfo(facilityId, update) {
+    if (!facilityId) {
+      return Promise.reject(new Error("A facility id is required to update a facility's info."));
+    }
+
+    if (!update) {
+      return Promise.reject(new Error("An update is required to update a facility's info."));
+    }
+
+    if (!isPlainObject(update)) {
+      return Promise.reject(
+        new Error('The facility info update must be a well-formed object with the data you wish to update.')
+      );
+    }
+
+    const options = {
+      params: {
+        should_update: true
+      }
+    };
+
+    return this._request.post(`${this._baseUrl}/facilities/${facilityId}/info`, update, options);
+  }
+
+  /**
    * Deletes a facility
    *
    * API Endpoint: '/facilities/:facilityId'
@@ -241,42 +283,6 @@ class Facilities {
     const formattedUpdate = this._formatFacilityToServer(update);
 
     return this._request.put(`${this._baseUrl}/facilities/${facilityId}`, formattedUpdate);
-  }
-
-  /**
-   * Updates a facility's info (NOTE: This refers to the facility_info model)
-   *
-   * API Endpoint: '/facilities/:facilityId/info'
-   * Method: POST
-   *
-   * @param {number} facilityId The id of the facility to update
-   * @param {Object} update An object containing the updated facility info for the facility
-   *
-   * @returns {Promise}
-   * @fulfill {undefined}
-   * @reject {Error}
-   *
-   * @example
-   * contxtSdk.facilities.updateInfo(25, {
-   *   square_feet: '10000'
-   * });
-   */
-  updateInfo(facilityId, update) {
-    if (!facilityId) {
-      return Promise.reject(new Error("A facility id is required to update a facility's info."));
-    }
-
-    if (!update) {
-      return Promise.reject(new Error("An update is required to update a facility's info."));
-    }
-
-    if (!isPlainObject(update)) {
-      return Promise.reject(
-        new Error('The facility info update must be a well-formed object with the data you wish to update.')
-      );
-    }
-
-    return this._request.post(`${this._baseUrl}/facilities/${facilityId}/info`, update);
   }
 
   /**

--- a/src/facilities.spec.js
+++ b/src/facilities.spec.js
@@ -119,6 +119,70 @@ describe('Facilities', function() {
     });
   });
 
+  describe('createOrUpdateInfo', function() {
+    context('when all required information is available', function() {
+      let expectedHost;
+      let facilityId;
+      let facilityInfoUpdate;
+      let promise;
+
+      beforeEach(function() {
+        expectedHost = faker.internet.url();
+        facilityId = fixture.build('facility').id;
+        facilityInfoUpdate = fixture.build('facilityInfo');
+
+        const facilities = new Facilities(baseSdk, baseRequest);
+        facilities._baseUrl = expectedHost;
+
+        promise = facilities.createOrUpdateInfo(facilityId, facilityInfoUpdate);
+      });
+
+      it('updates the facility', function() {
+        expect(baseRequest.post).to.be.calledWith(
+          `${expectedHost}/facilities/${facilityId}/info`,
+          facilityInfoUpdate,
+          { params: { should_update: true } }
+        );
+      });
+
+      it('returns a fulfilled promise', function() {
+        return expect(promise).to.be.fulfilled;
+      });
+    });
+
+    context('when there is missing or malformed required information', function() {
+      let facilities;
+
+      beforeEach(function() {
+        facilities = new Facilities(baseSdk, baseRequest);
+      });
+
+      it('throws an error when there is no provided facility id', function() {
+        const facilityInfoUpdate = fixture.build('facilityInfo');
+        const promise = facilities.createOrUpdateInfo(null, facilityInfoUpdate);
+
+        return expect(promise).to.be
+          .rejectedWith("A facility id is required to update a facility's info.");
+      });
+
+      it('throws an error when there is no update provided', function() {
+        const facility = fixture.build('facility');
+        const promise = facilities.createOrUpdateInfo(facility.id);
+
+        return expect(promise).to.be.rejectedWith("An update is required to update a facility's info.");
+      });
+
+      it('throws an error when the update is not an object', function() {
+        const facility = fixture.build('facility');
+        const promise = facilities.createOrUpdateInfo(facility.id, [facility.info]);
+
+        return expect(promise).to.be.rejectedWith(
+          'The facility info update must be a well-formed object with the data you wish to update.'
+        );
+      });
+    });
+  });
+
   describe('delete', function() {
     context('the facility id is provided', function() {
       let expectedHost;
@@ -395,69 +459,6 @@ describe('Facilities', function() {
 
         return expect(promise).to.be.rejectedWith(
           'The facility update must be a well-formed object with the data you wish to update.'
-        );
-      });
-    });
-  });
-
-  describe('updateInfo', function() {
-    context('when all required information is available', function() {
-      let expectedHost;
-      let facilityId;
-      let facilityInfoUpdate;
-      let promise;
-
-      beforeEach(function() {
-        expectedHost = faker.internet.url();
-        facilityId = fixture.build('facility').id;
-        facilityInfoUpdate = fixture.build('facilityInfo');
-
-        const facilities = new Facilities(baseSdk, baseRequest);
-        facilities._baseUrl = expectedHost;
-
-        promise = facilities.updateInfo(facilityId, facilityInfoUpdate);
-      });
-
-      it('updates the facility', function() {
-        expect(baseRequest.post).to.be.calledWith(
-          `${expectedHost}/facilities/${facilityId}/info`,
-          facilityInfoUpdate
-        );
-      });
-
-      it('returns a fulfilled promise', function() {
-        return expect(promise).to.be.fulfilled;
-      });
-    });
-
-    context('when there is missing or malformed required information', function() {
-      let facilities;
-
-      beforeEach(function() {
-        facilities = new Facilities(baseSdk, baseRequest);
-      });
-
-      it('throws an error when there is no provided facility id', function() {
-        const facilityInfoUpdate = fixture.build('facilityInfo');
-        const promise = facilities.updateInfo(null, facilityInfoUpdate);
-
-        return expect(promise).to.be
-          .rejectedWith("A facility id is required to update a facility's info.");
-      });
-
-      it('throws an error when there is no update provided', function() {
-        const facility = fixture.build('facility');
-        const promise = facilities.updateInfo(facility.id);
-
-        return expect(promise).to.be.rejectedWith("An update is required to update a facility's info.");
-      });
-
-      it('throws an error when the update is not an object', function() {
-        const facility = fixture.build('facility');
-        const promise = facilities.updateInfo(facility.id, [facility.info]);
-
-        return expect(promise).to.be.rejectedWith(
-          'The facility info update must be a well-formed object with the data you wish to update.'
         );
       });
     });


### PR DESCRIPTION
## Why?
1. The method name implied it would be doing a PATCH instead of a POST, and clarity is good.
2. An additional query param is required to be sent to the API for this to behave correctly.

## What changed?
- Renamed the method
- Added the `should_update` query param to the request
