### PR TITLE
Facilities#createGrouping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [v0.0.8](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.8) (2018-??-??)
+**Added**
+- Facilities#createGrouping for creating new facility groupings
+
 ## [v0.0.7](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.7) (2018-03-29)
 **Renamed**
 - Facilities#updateInfo to Facilities#createOrUpdateInfo so that what the method does is more obvious

--- a/docs/Facilities.md
+++ b/docs/Facilities.md
@@ -8,7 +8,8 @@ of, information about different facilities
 
 * [Facilities](#Facilities)
     * [new Facilities(sdk, request)](#new_Facilities_new)
-    * [.create(options)](#Facilities+create) ⇒ <code>Promise</code>
+    * [.create(facility)](#Facilities+create) ⇒ <code>Promise</code>
+    * [.createGrouping(facilityGrouping)](#Facilities+createGrouping) ⇒ <code>Promise</code>
     * [.createOrUpdateInfo(facilityId, update)](#Facilities+createOrUpdateInfo) ⇒ <code>Promise</code>
     * [.delete(facilityId)](#Facilities+delete) ⇒ <code>Promise</code>
     * [.get(facilityId)](#Facilities+get) ⇒ <code>Promise</code>
@@ -27,7 +28,7 @@ of, information about different facilities
 
 <a name="Facilities+create"></a>
 
-### contxtSdk.facilities.create(options) ⇒ <code>Promise</code>
+### contxtSdk.facilities.create(facility) ⇒ <code>Promise</code>
 Creates a new facility
 
 API Endpoint: '/facilities'
@@ -39,17 +40,17 @@ Method: POST
 
 | Param | Type | Description |
 | --- | --- | --- |
-| options | <code>Object</code> |  |
-| [options.address1] | <code>string</code> |  |
-| [options.address2] | <code>string</code> |  |
-| [options.city] | <code>string</code> |  |
-| [options.geometryId] | <code>string</code> | UUID corresponding with a geometry |
-| options.name | <code>string</code> |  |
-| options.organizationId | <code>string</code> | UUID corresponding with an organization |
-| [options.state] | <code>string</code> |  |
-| options.timezone | <code>string</code> |  |
-| [options.weatherLocationId] | <code>number</code> |  |
-| [options.zip] | <code>string</code> |  |
+| facility | <code>Object</code> |  |
+| [facility.address1] | <code>string</code> |  |
+| [facility.address2] | <code>string</code> |  |
+| [facility.city] | <code>string</code> |  |
+| [facility.geometryId] | <code>string</code> | UUID corresponding with a geometry |
+| facility.name | <code>string</code> |  |
+| facility.organizationId | <code>string</code> | UUID corresponding with an organization |
+| [facility.state] | <code>string</code> |  |
+| facility.timezone | <code>string</code> |  |
+| [facility.weatherLocationId] | <code>number</code> |  |
+| [facility.zip] | <code>string</code> |  |
 
 **Example**  
 ```js
@@ -58,6 +59,40 @@ contxtSdk.facilities
     address: '221 B Baker St, London, England',
     name: 'Sherlock Holmes Museum',
     organizationId: 25
+  })
+  .then((facilities) => console.log(facilities));
+  .catch((err) => console.log(err));
+```
+<a name="Facilities+createGrouping"></a>
+
+### contxtSdk.facilities.createGrouping(facilityGrouping) ⇒ <code>Promise</code>
+Creates a new facility grouping
+
+API Endpoint: '/groupings'
+Method: POST
+
+**Kind**: instance method of [<code>Facilities</code>](#Facilities)  
+**Fulfill**: [<code>FacilityGrouping</code>](./Typedefs.md#FacilityGrouping) Information about the new facility grouping  
+**Reject**: <code>Error</code>  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| facilityGrouping | <code>Object</code> |  |  |
+| [facilityGrouping.description] | <code>string</code> |  |  |
+| [facilityGrouping.isPrivate] | <code>boolean</code> | <code>false</code> |  |
+| facilityGrouping.name | <code>string</code> |  |  |
+| facilityGrouping.organizationId | <code>string</code> |  | UUID |
+| [facilityGrouping.parentGroupingId] | <code>string</code> |  | UUID |
+
+**Example**  
+```js
+contxtSdk.facilities
+  .createGrouping({
+    description: 'US States of CT, MA, ME, NH, RI, VT',
+    isPrivate: false,
+    name: 'New England, USA',
+    organization_id: '61f5fe1d-d202-4ae7-af76-8f37f5bbeec5'
+    parent_grouping_id: 'e9f8f89c-609c-4c83-8ebc-cea928af661e'
   })
   .then((facilities) => console.log(facilities));
   .catch((err) => console.log(err));

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,6 +52,8 @@ for authenticating and communicating with an individual API and the external mod
 </dd>
 <dt><a href="./Typedefs.md#Facility">Facility</a> : <code>Object</code></dt>
 <dd></dd>
+<dt><a href="./Typedefs.md#FacilityGrouping">FacilityGrouping</a> : <code>Object</code></dt>
+<dd></dd>
 <dt><a href="./Typedefs.md#MachineAuthSessionInfo">MachineAuthSessionInfo</a> : <code>Object</code></dt>
 <dd></dd>
 <dt><a href="./Typedefs.md#SessionType">SessionType</a> : <code>Object</code></dt>

--- a/docs/Typedefs.md
+++ b/docs/Typedefs.md
@@ -90,6 +90,23 @@ for authenticating and communicating with an individual API and the external mod
 | weatherLocationId | <code>number</code> |  |
 | zip | <code>string</code> | US Zip Code |
 
+<a name="FacilityGrouping"></a>
+
+## FacilityGrouping : <code>Object</code>
+**Kind**: global typedef  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| createdAt | <code>string</code> | ISO 8601 Extended Format date/time string |
+| description | <code>string</code> |  |
+| id | <code>string</code> | UUID |
+| isPrivate | <code>boolean</code> |  |
+| name | <code>string</code> |  |
+| organizationId | <code>string</code> | UUID |
+| ownerId | <code>string</code> | Auth0 identifer of the user |
+| parentGroupingId | <code>string</code> | UUID |
+| updatedAt | <code>string</code> | ISO 8601 Extended Format date/time string |
+
 <a name="MachineAuthSessionInfo"></a>
 
 ## MachineAuthSessionInfo : <code>Object</code>

--- a/src/facilities.js
+++ b/src/facilities.js
@@ -1,4 +1,8 @@
 import isPlainObject from 'lodash.isplainobject';
+import {
+  formatFacilityFromServer,
+  formatFacilityToServer
+} from './utils/facilities';
 
 /**
  * @typedef {Object} Facility
@@ -87,10 +91,10 @@ class Facilities {
       }
     }
 
-    const data = this._formatFacilityToServer(facility);
+    const data = formatFacilityToServer(facility);
 
     return this._request.post(`${this._baseUrl}/facilities`, data)
-      .then((facility) => this._formatFacilityFromServer(facility));
+      .then((facility) => formatFacilityFromServer(facility));
   }
 
   /**
@@ -121,9 +125,7 @@ class Facilities {
     }
 
     if (!isPlainObject(update)) {
-      return Promise.reject(
-        new Error('The facility info update must be a well-formed object with the data you wish to update.')
-      );
+      return Promise.reject(new Error('The facility info update must be a well-formed object with the data you wish to update.'));
     }
 
     const options = {
@@ -177,13 +179,11 @@ class Facilities {
    */
   get(facilityId) {
     if (!facilityId) {
-      return Promise.reject(
-        new Error('A facility id is required for getting information about a facility')
-      );
+      return Promise.reject(new Error('A facility id is required for getting information about a facility'));
     }
 
     return this._request.get(`${this._baseUrl}/facilities/${facilityId}`)
-      .then((facility) => this._formatFacilityFromServer(facility));
+      .then((facility) => formatFacilityFromServer(facility));
   }
 
   /**
@@ -203,7 +203,7 @@ class Facilities {
    */
   getAll() {
     return this._request.get(`${this._baseUrl}/facilities`)
-      .then((facilities) => facilities.map((facility) => this._formatFacilityFromServer(facility)));
+      .then((facilities) => facilities.map((facility) => formatFacilityFromServer(facility)));
   }
 
   /**
@@ -225,13 +225,11 @@ class Facilities {
    */
   getAllByOrganizationId(organizationId) {
     if (!organizationId) {
-      return Promise.reject(
-        new Error("An organization id is required for getting a list of an organization's facilities")
-      );
+      return Promise.reject(new Error("An organization id is required for getting a list of an organization's facilities"));
     }
 
     return this._request.get(`${this._baseUrl}/organizations/${organizationId}/facilities`)
-      .then((facilities) => facilities.map((facility) => this._formatFacilityFromServer(facility)));
+      .then((facilities) => facilities.map((facility) => formatFacilityFromServer(facility)));
   }
 
   /**
@@ -275,161 +273,12 @@ class Facilities {
     }
 
     if (!isPlainObject(update)) {
-      return Promise.reject(
-        new Error('The facility update must be a well-formed object with the data you wish to update.')
-      );
+      return Promise.reject(new Error('The facility update must be a well-formed object with the data you wish to update.'));
     }
 
-    const formattedUpdate = this._formatFacilityToServer(update);
+    const formattedUpdate = formatFacilityToServer(update);
 
     return this._request.put(`${this._baseUrl}/facilities/${facilityId}`, formattedUpdate);
-  }
-
-  /**
-   * Normalizes the facility object returned from the API server
-   *
-   * @param {Object} input
-   * @param {string} input.address1
-   * @param {string} input.address2
-   * @param {string} input.city
-   * @param {string} input.created_at ISO 8601 Extended Format date/time string
-   * @param {string} input.geometry_id UUID corresponding with a geometry
-   * @param {number} input.id
-   * @param {Object} input.Info User declared information
-   * @param {string} input.name
-   * @param {Object} input.Organization
-   * @param {string} input.Organization.created_at ISO 8601 Extended Format date/time string
-   * @param {string} input.Organization.id UUID
-   * @param {string} input.Organization.name
-   * @param {string} input.Organization.updated_at
-   * @param {string} input.organization_id UUID corresponding with an organization
-   * @param {string} input.state
-   * @param {Object[]} input.tags
-   * @param {string} input.tags[].created_at ISO 8601 Extended Format date/time string
-   * @param {number} input.tags[].facility_id Id corresponding with the parent facility
-   * @param {number} input.tags[].id
-   * @param {string} input.tags[].name
-   * @param {string} input.tags[].updated_at ISO 8601 Extended Format date/time string
-   * @param {string} input.timezone An IANA Time Zone Database string, i.e. America/Los_Angeles
-   * @param {string} input.weather_location_id
-   * @param {string} input.zip
-   *
-   * @returns {Facility}
-   *
-   * @private
-   */
-  _formatFacilityFromServer(input = {}) {
-    return {
-      address1: input.address1,
-      address2: input.address2,
-      city: input.city,
-      createdAt: input.created_at,
-      geometryId: input.geometry_id,
-      id: input.id,
-      info: input.Info,
-      name: input.name,
-      organization: this._formatOrganizationFromServer(input.Organization),
-      organizationId: input.organization_id,
-      state: input.state,
-      tags: this._formatTagsFromServer(input.tags),
-      timezone: input.timezone,
-      weatherLocationId: input.weather_location_id,
-      zip: input.zip
-    };
-  }
-
-  /**
-   * Normalizes the facility object returned from the API server
-   *
-   * @param {Facility} input
-   *
-   * @returns {Object} output
-   * @returns {string} output.address1
-   * @returns {string} output.address2
-   * @returns {string} output.city
-   * @returns {string} output.geometry_id UUID corresponding with a geometry
-   * @returns {Object} output.Info User declared information
-   * @returns {string} output.name
-   * @returns {string} output.organization_id UUID corresponding with an organization
-   * @returns {string} output.state
-   * @returns {string} output.timezone An IANA Time Zone Database string, i.e. America/Los_Angeles
-   * @returns {string} output.weather_location_id
-   * @returns {string} output.zip
-   *
-   * @private
-   */
-  _formatFacilityToServer(input = {}) {
-    return {
-      address1: input.address1,
-      address2: input.address2,
-      city: input.city,
-      geometry_id: input.geometryId,
-      Info: input.info,
-      name: input.name,
-      organization_id: input.organizationId,
-      state: input.state,
-      timezone: input.timezone,
-      weather_location_id: input.weatherLocationId,
-      zip: input.zip
-    };
-  }
-
-  /**
-   * Normalizes the organization object returned from the API server
-   *
-   * @param {Object} input
-   * @param {string} input.created_at ISO 8601 Extended Format date/time string
-   * @param {string} input.id UUID
-   * @param {string} input.name
-   * @param {string} input.updated_at
-   * @param {string} input.organization_id UUID corresponding with an organization
-   *
-   * @returns {Object} output
-   * @returns {string} output.createdAt ISO 8601 Extended Format date/time string
-   * @returns {string} output.id UUID formatted id
-   * @returns {string} output.name
-   * @returns {string} output.updatedAt ISO 8601 Extended Format date/time string
-   *
-   * @private
-   */
-  _formatOrganizationFromServer(input = {}) {
-    return {
-      createdAt: input.created_at,
-      id: input.id,
-      name: input.name,
-      updatedAt: input.updated_at
-    };
-  }
-
-  /**
-   * Normalizes the tags array returned from the API server
-   *
-   * @param {Object[]} input
-   * @param {string} input[].created_at ISO 8601 Extended Format date/time string
-   * @param {number} input[].facility_id Id corresponding with the parent facility
-   * @param {number} input[].id
-   * @param {string} input[].name
-   * @param {string} input[].updated_at ISO 8601 Extended Format date/time string
-   *
-   * @returns {Object[]} output
-   * @returns {string} output[].createdAt ISO 8601 Extended Format date/time string
-   * @returns {number} output[].id
-   * @returns {number} output[].facilityId
-   * @returns {string} output[].name
-   * @returns {string} output[].updatedAt ISO 8601 Extended Format date/time string
-   *
-   * @private
-   */
-  _formatTagsFromServer(input = []) {
-    return input.map((tag) => {
-      return {
-        createdAt: tag.created_at,
-        facilityId: tag.facility_id,
-        id: tag.id,
-        name: tag.name,
-        updatedAt: tag.updated_at
-      };
-    });
   }
 }
 

--- a/src/facilities.js
+++ b/src/facilities.js
@@ -138,7 +138,7 @@ class Facilities {
    *     organization_id: '61f5fe1d-d202-4ae7-af76-8f37f5bbeec5'
    *     parent_grouping_id: 'e9f8f89c-609c-4c83-8ebc-cea928af661e'
    *   })
-   *   .then((facilities) => console.log(facilities));
+   *   .then((grouping) => console.log(grouping));
    *   .catch((err) => console.log(err));
    */
   createGrouping(grouping = {}) {

--- a/src/facilities.spec.js
+++ b/src/facilities.spec.js
@@ -1,5 +1,6 @@
 import omit from 'lodash.omit';
 import Facilities from './facilities';
+import * as facilitiesUtils from './utils/facilities';
 
 describe('Facilities', function() {
   let baseRequest;
@@ -66,9 +67,9 @@ describe('Facilities', function() {
         initialFacility = fixture.build('facility');
         rawFacility = fixture.build('facility', null, { fromServer: true });
 
-        formatFacilityFromServer = this.sandbox.stub(Facilities.prototype, '_formatFacilityFromServer')
+        formatFacilityFromServer = this.sandbox.stub(facilitiesUtils, 'formatFacilityFromServer')
           .returns(expectedFacility);
-        formatFacilityToServer = this.sandbox.stub(Facilities.prototype, '_formatFacilityToServer')
+        formatFacilityToServer = this.sandbox.stub(facilitiesUtils, 'formatFacilityToServer')
           .returns(formattedFacility);
         request = {
           ...baseRequest,
@@ -224,7 +225,7 @@ describe('Facilities', function() {
     context('the facility id is provided', function() {
       let expectedFacilityId;
       let expectedHost;
-      let formatFacility;
+      let formatFacilityFromServer;
       let formattedFacility;
       let promise;
       let rawFacility;
@@ -236,7 +237,7 @@ describe('Facilities', function() {
         rawFacility = fixture.build('facility', null, { fromServer: true });
         formattedFacility = fixture.build('facility', { id: rawFacility.id });
 
-        formatFacility = this.sandbox.stub(Facilities.prototype, '_formatFacilityFromServer')
+        formatFacilityFromServer = this.sandbox.stub(facilitiesUtils, 'formatFacilityFromServer')
           .returns(formattedFacility);
         request = {
           ...baseRequest,
@@ -255,7 +256,7 @@ describe('Facilities', function() {
 
       it('formats the facility object', function() {
         return promise.then(() => {
-          expect(formatFacility).to.be.calledWith(rawFacility);
+          expect(formatFacilityFromServer).to.be.calledWith(rawFacility);
         });
       });
 
@@ -278,7 +279,7 @@ describe('Facilities', function() {
 
   describe('getAll', function() {
     let expectedHost;
-    let formatFacility;
+    let formatFacilityFromServer;
     let formattedFacilities;
     let promise;
     let rawFacilities;
@@ -290,7 +291,7 @@ describe('Facilities', function() {
       formattedFacilities = fixture.buildList('facility', numberOfFacilities);
       rawFacilities = fixture.buildList('facility', numberOfFacilities, null, { fromServer: true });
 
-      formatFacility = this.sandbox.stub(Facilities.prototype, '_formatFacilityFromServer')
+      formatFacilityFromServer = this.sandbox.stub(facilitiesUtils, 'formatFacilityFromServer')
         .callsFake((facility) => {
           const index = rawFacilities.indexOf(facility);
           return formattedFacilities[index];
@@ -312,10 +313,10 @@ describe('Facilities', function() {
 
     it('formats the facility object', function() {
       return promise.then(() => {
-        expect(formatFacility).to.have.callCount(rawFacilities.length);
+        expect(formatFacilityFromServer).to.have.callCount(rawFacilities.length);
 
         rawFacilities.forEach((facility) => {
-          expect(formatFacility).to.be.calledWith(facility);
+          expect(formatFacilityFromServer).to.be.calledWith(facility);
         });
       });
     });
@@ -330,7 +331,7 @@ describe('Facilities', function() {
     context('the organization id is not provided', function() {
       let expectedHost;
       let expectedOrganizationId;
-      let formatFacility;
+      let formatFacilityFromServer;
       let formattedFacilities;
       let promise;
       let rawFacilities;
@@ -343,7 +344,7 @@ describe('Facilities', function() {
         formattedFacilities = fixture.buildList('facility', numberOfFacilities);
         rawFacilities = fixture.buildList('facility', numberOfFacilities, null, { fromServer: true });
 
-        formatFacility = this.sandbox.stub(Facilities.prototype, '_formatFacilityFromServer')
+        formatFacilityFromServer = this.sandbox.stub(facilitiesUtils, 'formatFacilityFromServer')
           .callsFake((facility) => {
             const index = rawFacilities.indexOf(facility);
             return formattedFacilities[index];
@@ -367,10 +368,10 @@ describe('Facilities', function() {
 
       it('formats the facility object', function() {
         return promise.then(() => {
-          expect(formatFacility).to.have.callCount(rawFacilities.length);
+          expect(formatFacilityFromServer).to.have.callCount(rawFacilities.length);
 
           rawFacilities.forEach((facility) => {
-            expect(formatFacility).to.be.calledWith(facility);
+            expect(formatFacilityFromServer).to.be.calledWith(facility);
           });
         });
       });
@@ -406,7 +407,7 @@ describe('Facilities', function() {
         facilityUpdate = fixture.build('facility');
         formattedFacility = fixture.build('facility', null, { fromServer: true });
 
-        formatFacilityToServer = this.sandbox.stub(Facilities.prototype, '_formatFacilityToServer')
+        formatFacilityToServer = this.sandbox.stub(facilitiesUtils, 'formatFacilityToServer')
           .returns(formattedFacility);
 
         const facilities = new Facilities(baseSdk, baseRequest);
@@ -461,148 +462,6 @@ describe('Facilities', function() {
           'The facility update must be a well-formed object with the data you wish to update.'
         );
       });
-    });
-  });
-
-  describe('_formatFacilityFromServer', function() {
-    let expectedFacility;
-    let facility;
-    let formatOrganizationFromServer;
-    let formatTagsFromServer;
-    let formattedFacility;
-
-    beforeEach(function() {
-      facility = fixture.build('facility', null, { fromServer: true });
-      expectedFacility = omit(
-        {
-          ...facility,
-          createdAt: facility.created_at,
-          geometryId: facility.geometry_id,
-          info: facility.Info,
-          organization: facility.Organization,
-          organizationId: facility.organization_id,
-          weatherLocationId: facility.weather_location_id
-        },
-        [
-          'created_at',
-          'geometry_id',
-          'Info',
-          'Organization',
-          'organization_id',
-          'weather_location_id'
-        ]
-      );
-
-      formatOrganizationFromServer = this.sandbox.stub(Facilities.prototype, '_formatOrganizationFromServer')
-        .callsFake((organization) => organization);
-      formatTagsFromServer = this.sandbox.stub(Facilities.prototype, '_formatTagsFromServer')
-        .callsFake((tags) => tags);
-
-      formattedFacility = Facilities.prototype._formatFacilityFromServer(facility);
-    });
-
-    it('formats the necessary children objects', function() {
-      expect(formatOrganizationFromServer).to.be.calledWith(facility.Organization);
-      expect(formatTagsFromServer).to.be.calledWith(facility.tags);
-    });
-
-    it('converts the object keys to the camelCase', function() {
-      expect(formattedFacility).to.deep.equal(expectedFacility);
-    });
-  });
-
-  describe('_formatFacilityToServer', function() {
-    let expectedFacility;
-    let facility;
-    let formattedFacility;
-
-    beforeEach(function() {
-      facility = fixture.build('facility');
-      expectedFacility = omit(
-        {
-          ...facility,
-          geometry_id: facility.geometryId,
-          Info: facility.info,
-          organization_id: facility.organizationId,
-          weather_location_id: facility.weatherLocationId
-        },
-        [
-          'createdAt',
-          'geometryId',
-          'id',
-          'info',
-          'organization',
-          'organizationId',
-          'tags',
-          'weatherLocationId'
-        ]
-      );
-
-      formattedFacility = Facilities.prototype._formatFacilityToServer(facility);
-    });
-
-    it('converts the object keys to snake case and capitalizes certain keys', function() {
-      expect(formattedFacility).to.deep.equal(expectedFacility);
-    });
-  });
-
-  describe('_formatOrganizationFromServer', function() {
-    let expectedOrganization;
-    let formattedOrganization;
-    let organization;
-
-    beforeEach(function() {
-      organization = fixture.build(
-        'organization',
-        null,
-        { fromServer: true }
-      );
-      expectedOrganization = omit(
-        {
-          ...organization,
-          createdAt: organization.created_at,
-          updatedAt: organization.updated_at
-        },
-        ['created_at', 'updated_at']
-      );
-
-      formattedOrganization = Facilities.prototype._formatOrganizationFromServer(organization);
-    });
-
-    it('converts the object keys to camelCase', function() {
-      expect(formattedOrganization).to.deep.equal(expectedOrganization);
-    });
-  });
-
-  describe('_formatTagsFromServer', function() {
-    let expectedTags;
-    let formattedTags;
-    let tags;
-
-    beforeEach(function() {
-      tags = fixture.buildList(
-        'facilityTag',
-        faker.random.number({ min: 1, max: 2 }),
-        null,
-        { fromServer: true }
-      );
-      expectedTags = tags.map((tag) => {
-        return omit(
-          {
-            ...tag,
-            createdAt: tag.created_at,
-            facilityId: tag.facility_id,
-            updatedAt: tag.updated_at
-          },
-          ['created_at', 'facility_id', 'updated_at']
-        );
-      });
-
-      formattedTags = Facilities.prototype._formatTagsFromServer(tags);
-    });
-
-    it('converts the object keys to camelCase', function() {
-      expect(formattedTags).to.deep.equal(expectedTags);
     });
   });
 });

--- a/src/utils/facilities/formatFacilityFromServer.js
+++ b/src/utils/facilities/formatFacilityFromServer.js
@@ -1,0 +1,59 @@
+import {
+  formatOrganizationFromServer,
+  formatTagsFromServer
+} from './index';
+
+/**
+ * Normalizes the facility object returned from the API server
+ *
+ * @param {Object} input
+ * @param {string} input.address1
+ * @param {string} input.address2
+ * @param {string} input.city
+ * @param {string} input.created_at ISO 8601 Extended Format date/time string
+ * @param {string} input.geometry_id UUID corresponding with a geometry
+ * @param {number} input.id
+ * @param {Object} input.Info User declared information
+ * @param {string} input.name
+ * @param {Object} input.Organization
+ * @param {string} input.Organization.created_at ISO 8601 Extended Format date/time string
+ * @param {string} input.Organization.id UUID
+ * @param {string} input.Organization.name
+ * @param {string} input.Organization.updated_at
+ * @param {string} input.organization_id UUID corresponding with an organization
+ * @param {string} input.state
+ * @param {Object[]} input.tags
+ * @param {string} input.tags[].created_at ISO 8601 Extended Format date/time string
+ * @param {number} input.tags[].facility_id Id corresponding with the parent facility
+ * @param {number} input.tags[].id
+ * @param {string} input.tags[].name
+ * @param {string} input.tags[].updated_at ISO 8601 Extended Format date/time string
+ * @param {string} input.timezone An IANA Time Zone Database string, i.e. America/Los_Angeles
+ * @param {string} input.weather_location_id
+ * @param {string} input.zip
+ *
+ * @returns {Facility}
+ *
+ * @private
+ */
+function formatFacilityFromServer(input = {}) {
+  return {
+    address1: input.address1,
+    address2: input.address2,
+    city: input.city,
+    createdAt: input.created_at,
+    geometryId: input.geometry_id,
+    id: input.id,
+    info: input.Info,
+    name: input.name,
+    organization: formatOrganizationFromServer(input.Organization),
+    organizationId: input.organization_id,
+    state: input.state,
+    tags: formatTagsFromServer(input.tags),
+    timezone: input.timezone,
+    weatherLocationId: input.weather_location_id,
+    zip: input.zip
+  };
+}
+
+export default formatFacilityFromServer;

--- a/src/utils/facilities/formatFacilityFromServer.spec.js
+++ b/src/utils/facilities/formatFacilityFromServer.spec.js
@@ -1,0 +1,56 @@
+import omit from 'lodash.omit';
+import formatFacilityFromServer from './formatFacilityFromServer';
+import * as facilitiesUtils from './index';
+
+describe('utils/facilities/formatFacilityFromServer', function() {
+  let expectedFacility;
+  let facility;
+  let formatOrganizationFromServer;
+  let formatTagsFromServer;
+  let formattedFacility;
+
+  beforeEach(function() {
+    this.sandbox = sandbox.create();
+
+    facility = fixture.build('facility', null, { fromServer: true });
+    expectedFacility = omit(
+      {
+        ...facility,
+        createdAt: facility.created_at,
+        geometryId: facility.geometry_id,
+        info: facility.Info,
+        organization: facility.Organization,
+        organizationId: facility.organization_id,
+        weatherLocationId: facility.weather_location_id
+      },
+      [
+        'created_at',
+        'geometry_id',
+        'Info',
+        'Organization',
+        'organization_id',
+        'weather_location_id'
+      ]
+    );
+
+    formatOrganizationFromServer = this.sandbox.stub(facilitiesUtils, 'formatOrganizationFromServer')
+      .callsFake((organization) => organization);
+    formatTagsFromServer = this.sandbox.stub(facilitiesUtils, 'formatTagsFromServer')
+      .callsFake((tags) => tags);
+
+    formattedFacility = formatFacilityFromServer(facility);
+  });
+
+  afterEach(function() {
+    this.sandbox.restore();
+  });
+
+  it('formats the necessary children objects', function() {
+    expect(formatOrganizationFromServer).to.be.calledWith(facility.Organization);
+    expect(formatTagsFromServer).to.be.calledWith(facility.tags);
+  });
+
+  it('converts the object keys to the camelCase', function() {
+    expect(formattedFacility).to.deep.equal(expectedFacility);
+  });
+});

--- a/src/utils/facilities/formatFacilityToServer.js
+++ b/src/utils/facilities/formatFacilityToServer.js
@@ -1,5 +1,5 @@
 /**
- * Normalizes the facility object returned from the API server
+ * Normalizes the facility object being sent to the API server
  *
  * @param {Facility} input
  *

--- a/src/utils/facilities/formatFacilityToServer.js
+++ b/src/utils/facilities/formatFacilityToServer.js
@@ -1,0 +1,37 @@
+/**
+ * Normalizes the facility object returned from the API server
+ *
+ * @param {Facility} input
+ *
+ * @returns {Object} output
+ * @returns {string} output.address1
+ * @returns {string} output.address2
+ * @returns {string} output.city
+ * @returns {string} output.geometry_id UUID corresponding with a geometry
+ * @returns {Object} output.Info User declared information
+ * @returns {string} output.name
+ * @returns {string} output.organization_id UUID corresponding with an organization
+ * @returns {string} output.state
+ * @returns {string} output.timezone An IANA Time Zone Database string, i.e. America/Los_Angeles
+ * @returns {string} output.weather_location_id
+ * @returns {string} output.zip
+ *
+ * @private
+ */
+function formatFacilityToServer(input = {}) {
+  return {
+    address1: input.address1,
+    address2: input.address2,
+    city: input.city,
+    geometry_id: input.geometryId,
+    Info: input.info,
+    name: input.name,
+    organization_id: input.organizationId,
+    state: input.state,
+    timezone: input.timezone,
+    weather_location_id: input.weatherLocationId,
+    zip: input.zip
+  };
+}
+
+export default formatFacilityToServer;

--- a/src/utils/facilities/formatFacilityToServer.spec.js
+++ b/src/utils/facilities/formatFacilityToServer.spec.js
@@ -1,0 +1,37 @@
+import omit from 'lodash.omit';
+import formatFacilityToServer from './formatFacilityToServer';
+
+describe('utils/facilities/formatFacilityToServer', function() {
+  let expectedFacility;
+  let facility;
+  let formattedFacility;
+
+  beforeEach(function() {
+    facility = fixture.build('facility');
+    expectedFacility = omit(
+      {
+        ...facility,
+        geometry_id: facility.geometryId,
+        Info: facility.info,
+        organization_id: facility.organizationId,
+        weather_location_id: facility.weatherLocationId
+      },
+      [
+        'createdAt',
+        'geometryId',
+        'id',
+        'info',
+        'organization',
+        'organizationId',
+        'tags',
+        'weatherLocationId'
+      ]
+    );
+
+    formattedFacility = formatFacilityToServer(facility);
+  });
+
+  it('converts the object keys to snake case and capitalizes certain keys', function() {
+    expect(formattedFacility).to.deep.equal(expectedFacility);
+  });
+});

--- a/src/utils/facilities/formatGroupingFromServer.js
+++ b/src/utils/facilities/formatGroupingFromServer.js
@@ -1,0 +1,34 @@
+/**
+ * Normalizes the facility grouping object returned from the API server
+ *
+ * @param {Object} input
+ * @param {string} input.created_at ISO 8601 Extended Format date/time string
+ * @param {string} input.description
+ * @param {string} input.id UUID
+ * @param {boolean} input.is_private
+ * @param {string} input.name
+ * @param {string} input.organization_id UUID
+ * @param {string} input.owner_id Auth0 identifer of the owner
+ * @param {string} input.parent_grouping_id UUID
+ * @param {string} input.updated_at ISO 8601 Extended Format date/time string
+ *
+ * @returns {FacilityGrouping}}
+ *
+ * @private
+ */
+
+function formatGroupingFromServer(input = {}) {
+  return {
+    createdAt: input.created_at,
+    description: input.description,
+    id: input.id,
+    isPrivate: input.is_private,
+    name: input.name,
+    organizationId: input.organization_id,
+    ownerId: input.owner_id,
+    parentGroupingId: input.parent_grouping_id,
+    updatedAt: input.updated_at
+  };
+}
+
+export default formatGroupingFromServer;

--- a/src/utils/facilities/formatGroupingFromServer.spec.js
+++ b/src/utils/facilities/formatGroupingFromServer.spec.js
@@ -1,0 +1,30 @@
+import omit from 'lodash.omit';
+import formatGroupingFromServer from './formatGroupingFromServer';
+
+describe('utils/facilities/formatGroupingFromServer', function() {
+  let expectedGrouping;
+  let formattedGrouping;
+  let grouping;
+
+  beforeEach(function() {
+    grouping = fixture.build('facilityGrouping', null, { fromServer: true });
+    expectedGrouping = omit(
+      {
+        ...grouping,
+        createdAt: grouping.created_at,
+        isPrivate: grouping.is_private,
+        organizationId: grouping.organization_id,
+        ownerId: grouping.owner_id,
+        parentGroupingId: grouping.parent_grouping_id,
+        updatedAt: grouping.updated_at
+      },
+      ['created_at', 'is_private', 'organization_id', 'owner_id', 'parent_grouping_id', 'updated_at']
+    );
+
+    formattedGrouping = formatGroupingFromServer(grouping);
+  });
+
+  it('converts the object keys to camelCase', function() {
+    expect(formattedGrouping).to.deep.equal(expectedGrouping);
+  });
+});

--- a/src/utils/facilities/formatGroupingToServer.js
+++ b/src/utils/facilities/formatGroupingToServer.js
@@ -1,0 +1,27 @@
+/**
+ * Normalizes the facility object being sent to the API server
+ *
+ * @param {FacilityGrouping} input
+ *
+ * @param {Object} output
+ * @param {string} output.description
+ * @param {boolean} output.is_private
+ * @param {string} output.name
+ * @param {string} output.organization_id UUID
+ * @param {string} output.owner_id Auth0 identifer of the owner
+ * @param {string} output.parent_grouping_id UUID
+ *
+ * @private
+ */
+function formatGroupingToServer(input = {}) {
+  return {
+    description: input.description,
+    is_private: input.isPrivate,
+    name: input.name,
+    organization_id: input.organizationId,
+    owner_id: input.ownerId,
+    parent_grouping_id: input.parentGroupingId
+  };
+}
+
+export default formatGroupingToServer;

--- a/src/utils/facilities/formatGroupingToServer.spec.js
+++ b/src/utils/facilities/formatGroupingToServer.spec.js
@@ -1,0 +1,28 @@
+import omit from 'lodash.omit';
+import formatGroupingToServer from './formatGroupingToServer';
+
+describe('utils/facilities/formatGroupingToServer', function() {
+  let expectedGrouping;
+  let formattedGrouping;
+  let grouping;
+
+  beforeEach(function() {
+    grouping = fixture.build('facilityGrouping');
+    expectedGrouping = omit(
+      {
+        ...grouping,
+        is_private: grouping.isPrivate,
+        organization_id: grouping.organizationId,
+        owner_id: grouping.ownerId,
+        parent_grouping_id: grouping.parentGroupingId
+      },
+      ['createdAt', 'id', 'isPrivate', 'organizationId', 'ownerId', 'parentGroupingId', 'updatedAt']
+    );
+
+    formattedGrouping = formatGroupingToServer(grouping);
+  });
+
+  it('converts the object keys to snake case and capitalizes certain keys', function() {
+    expect(formattedGrouping).to.deep.equal(expectedGrouping);
+  });
+});

--- a/src/utils/facilities/formatOrganizationFromServer.js
+++ b/src/utils/facilities/formatOrganizationFromServer.js
@@ -1,0 +1,28 @@
+/**
+ * Normalizes the organization object returned from the API server
+ *
+ * @param {Object} input
+ * @param {string} input.created_at ISO 8601 Extended Format date/time string
+ * @param {string} input.id UUID
+ * @param {string} input.name
+ * @param {string} input.updated_at
+ * @param {string} input.organization_id UUID corresponding with an organization
+ *
+ * @returns {Object} output
+ * @returns {string} output.createdAt ISO 8601 Extended Format date/time string
+ * @returns {string} output.id UUID formatted id
+ * @returns {string} output.name
+ * @returns {string} output.updatedAt ISO 8601 Extended Format date/time string
+ *
+ * @private
+ */
+function formatOrganizationFromServer(input = {}) {
+  return {
+    createdAt: input.created_at,
+    id: input.id,
+    name: input.name,
+    updatedAt: input.updated_at
+  };
+}
+
+export default formatOrganizationFromServer;

--- a/src/utils/facilities/formatOrganizationFromServer.spec.js
+++ b/src/utils/facilities/formatOrganizationFromServer.spec.js
@@ -1,0 +1,30 @@
+import omit from 'lodash.omit';
+import formatOrganizationFromServer from './formatOrganizationFromServer';
+
+describe('utils/facilities/formatOrganizationFromServer', function() {
+  let expectedOrganization;
+  let formattedOrganization;
+  let organization;
+
+  beforeEach(function() {
+    organization = fixture.build(
+      'organization',
+      null,
+      { fromServer: true }
+    );
+    expectedOrganization = omit(
+      {
+        ...organization,
+        createdAt: organization.created_at,
+        updatedAt: organization.updated_at
+      },
+      ['created_at', 'updated_at']
+    );
+
+    formattedOrganization = formatOrganizationFromServer(organization);
+  });
+
+  it('converts the object keys to camelCase', function() {
+    expect(formattedOrganization).to.deep.equal(expectedOrganization);
+  });
+});

--- a/src/utils/facilities/formatTagsFromServer.js
+++ b/src/utils/facilities/formatTagsFromServer.js
@@ -1,0 +1,32 @@
+/**
+ * Normalizes the tags array returned from the API server
+ *
+ * @param {Object[]} input
+ * @param {string} input[].created_at ISO 8601 Extended Format date/time string
+ * @param {number} input[].facility_id Id corresponding with the parent facility
+ * @param {number} input[].id
+ * @param {string} input[].name
+ * @param {string} input[].updated_at ISO 8601 Extended Format date/time string
+ *
+ * @returns {Object[]} output
+ * @returns {string} output[].createdAt ISO 8601 Extended Format date/time string
+ * @returns {number} output[].id
+ * @returns {number} output[].facilityId
+ * @returns {string} output[].name
+ * @returns {string} output[].updatedAt ISO 8601 Extended Format date/time string
+ *
+ * @private
+ */
+function formatTagsFromServer(input = []) {
+  return input.map((tag) => {
+    return {
+      createdAt: tag.created_at,
+      facilityId: tag.facility_id,
+      id: tag.id,
+      name: tag.name,
+      updatedAt: tag.updated_at
+    };
+  });
+}
+
+export default formatTagsFromServer;

--- a/src/utils/facilities/formatTagsFromServer.spec.js
+++ b/src/utils/facilities/formatTagsFromServer.spec.js
@@ -1,0 +1,34 @@
+import omit from 'lodash.omit';
+import formatTagsFromServer from './formatTagsFromServer';
+
+describe('utils/facilities/formatTagsFromServer', function() {
+  let expectedTags;
+  let formattedTags;
+  let tags;
+
+  beforeEach(function() {
+    tags = fixture.buildList(
+      'facilityTag',
+      faker.random.number({ min: 1, max: 2 }),
+      null,
+      { fromServer: true }
+    );
+    expectedTags = tags.map((tag) => {
+      return omit(
+        {
+          ...tag,
+          createdAt: tag.created_at,
+          facilityId: tag.facility_id,
+          updatedAt: tag.updated_at
+        },
+        ['created_at', 'facility_id', 'updated_at']
+      );
+    });
+
+    formattedTags = formatTagsFromServer(tags);
+  });
+
+  it('converts the object keys to camelCase', function() {
+    expect(formattedTags).to.deep.equal(expectedTags);
+  });
+});

--- a/src/utils/facilities/index.js
+++ b/src/utils/facilities/index.js
@@ -1,0 +1,11 @@
+import formatFacilityFromServer from './formatFacilityFromServer';
+import formatFacilityToServer from './formatFacilityToServer';
+import formatOrganizationFromServer from './formatOrganizationFromServer';
+import formatTagsFromServer from './formatTagsFromServer';
+
+export {
+  formatFacilityFromServer,
+  formatFacilityToServer,
+  formatOrganizationFromServer,
+  formatTagsFromServer
+};

--- a/src/utils/facilities/index.js
+++ b/src/utils/facilities/index.js
@@ -1,11 +1,15 @@
 import formatFacilityFromServer from './formatFacilityFromServer';
 import formatFacilityToServer from './formatFacilityToServer';
+import formatGroupingFromServer from './formatGroupingFromServer';
+import formatGroupingToServer from './formatGroupingToServer';
 import formatOrganizationFromServer from './formatOrganizationFromServer';
 import formatTagsFromServer from './formatTagsFromServer';
 
 export {
   formatFacilityFromServer,
   formatFacilityToServer,
+  formatGroupingFromServer,
+  formatGroupingToServer,
   formatOrganizationFromServer,
   formatTagsFromServer
 };

--- a/support/fixtures/factories/facilityGrouping.js
+++ b/support/fixtures/factories/facilityGrouping.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const factory = require('rosie').Factory;
+const faker = require('faker');
+
+factory.define('facilityGrouping')
+  .option('fromServer', false)
+  .attrs({
+    createdAt: () => faker.date.past().toISOString(),
+    description: () => faker.hacker.phrase(),
+    id: () => faker.random.uuid(),
+    isPrivate: () => faker.random.boolean(),
+    name: () => faker.commerce.productName(),
+    organizationId: () => factory.build('organization').id,
+    ownerId: () => faker.internet.userName(),
+    parentGroupingId: () => faker.random.uuid(),
+    updatedAt: () => faker.date.recent().toISOString()
+  })
+  .after((facilityGrouping, options) => {
+    // If building a facility grouping object that comes from the server, transform it to have camel
+    // case and capital letters in the right spots
+    if (options.formServer) {
+      facilityGrouping.created_at = facilityGrouping.createdAt;
+      delete facilityGrouping.createdAt;
+
+      facilityGrouping.is_private = facilityGrouping.isPrivate;
+      delete facilityGrouping.isPrivate;
+
+      facilityGrouping.organization_id = facilityGrouping.organizationId;
+      delete facilityGrouping.organizationId;
+
+      facilityGrouping.owner_id = facilityGrouping.ownerId;
+      delete facilityGrouping.ownerId;
+
+      facilityGrouping.parent_grouping_id = facilityGrouping.parentGroupingId;
+      delete facilityGrouping.parentGroupingId;
+
+      facilityGrouping.updated_at = facilityGrouping.updatedAt;
+      delete facilityGrouping.updatedAt;
+    }
+  });

--- a/support/fixtures/factories/facilityGrouping.js
+++ b/support/fixtures/factories/facilityGrouping.js
@@ -19,7 +19,7 @@ factory.define('facilityGrouping')
   .after((facilityGrouping, options) => {
     // If building a facility grouping object that comes from the server, transform it to have camel
     // case and capital letters in the right spots
-    if (options.formServer) {
+    if (options.fromServer) {
       facilityGrouping.created_at = facilityGrouping.createdAt;
       delete facilityGrouping.createdAt;
 

--- a/support/fixtures/factories/index.js
+++ b/support/fixtures/factories/index.js
@@ -5,6 +5,7 @@ const factory = require('rosie').Factory;
 require('./audience');
 require('./defaultAudiences');
 require('./facility');
+require('./facilityGrouping');
 require('./facilityInfo');
 require('./facilityTag');
 require('./organization');


### PR DESCRIPTION
## Why?
We need the ability to create new facility groupings.

## What changed?
- Added `Facilities@createGrouping`
- Moved the facility transform utils/helpers to a utils directory
  - Cleans up the Facilities class quite a bit
  - Future improvement would be figuring out how to DRY these up a bit. Potentially could pull in a package that does camelCase -> snake_case and vice versa. May need to build an adapter for it or do a custom implementation since some keys we will not want to transform, or will require custom transforms