### PR TITLE
Add FacilityGroupings#GetAllByOrganizationId

### DIFF
--- a/docs/FacilityGroupings.md
+++ b/docs/FacilityGroupings.md
@@ -11,6 +11,7 @@ the relationship between those groupings and facilities
     * [.addFacility(facilityGroupingId, facilityId)](#FacilityGroupings+addFacility) ⇒ <code>Promise</code>
     * [.create(facilityGrouping)](#FacilityGroupings+create) ⇒ <code>Promise</code>
     * [.getAll()](#FacilityGroupings+getAll) ⇒ <code>Promise</code>
+    * [.getAllByOrganizationId(organizationId)](#FacilityGroupings+getAllByOrganizationId) ⇒ <code>Promise</code>
     * [.removeFacility(facilityGroupingId, facilityId)](#FacilityGroupings+removeFacility) ⇒ <code>Promise</code>
 
 <a name="new_FacilityGroupings_new"></a>
@@ -83,7 +84,8 @@ contxtSdk.facilities.groupings
 <a name="FacilityGroupings+getAll"></a>
 
 ### contxtSdk.facilities.groupings.getAll() ⇒ <code>Promise</code>
-Get a listing of all facility groupings for the user's organization
+Get a listing of all facility groupings available to a user. Includes public groupings across
+any organization the user has access to and the user's private groupings.
 
 API Endpoint: '/groupings'
 Method: GET
@@ -91,6 +93,29 @@ Method: GET
 **Kind**: instance method of [<code>FacilityGroupings</code>](#FacilityGroupings)  
 **Fulfill**: <code>FacilityGrouping[]</code>  
 **Reject**: <code>Error</code>  
+**Example**  
+```js
+contxtSdk.facilites.groupings.getAll()
+  .then((groupings) => console.log(groupings))
+  .catch((err) => console.log(err));
+```
+<a name="FacilityGroupings+getAllByOrganizationId"></a>
+
+### contxtSdk.facilities.groupings.getAllByOrganizationId(organizationId) ⇒ <code>Promise</code>
+Get a listing of all facility groupings for an organization. Includes public groupings
+across that specific organization and the user's private groupings for that organization.
+
+API Endpoint: '/organizations/:organizationId/groupings'
+Method: GET
+
+**Kind**: instance method of [<code>FacilityGroupings</code>](#FacilityGroupings)  
+**Fulfill**: <code>FacilityGrouping[]</code>  
+**Reject**: <code>Error</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| organizationId | <code>string</code> | UUID corresponding with an organization |
+
 **Example**  
 ```js
 contxtSdk.facilites.groupings.getAll()

--- a/src/facilities/groupings.js
+++ b/src/facilities/groupings.js
@@ -129,7 +129,8 @@ class FacilityGroupings {
   }
 
   /**
-   * Get a listing of all facility groupings for the user's organization
+   * Get a listing of all facility groupings available to a user. Includes public groupings across
+   * any organization the user has access to and the user's private groupings.
    *
    * API Endpoint: '/groupings'
    * Method: GET
@@ -145,6 +146,35 @@ class FacilityGroupings {
    */
   getAll() {
     return this._request.get(`${this._baseUrl}/groupings`)
+      .then((groupings) => groupings.map(formatGroupingFromServer));
+  }
+
+  /**
+   * Get a listing of all facility groupings for an organization. Includes public groupings
+   * across that specific organization and the user's private groupings for that organization.
+   *
+   * API Endpoint: '/organizations/:organizationId/groupings'
+   * Method: GET
+   *
+   * @param {string} organizationId UUID corresponding with an organization
+   *
+   * @returns {Promise}
+   * @fulfill {FacilityGrouping[]}
+   * @reject {Error}
+   *
+   * @example
+   * contxtSdk.facilites.groupings.getAll()
+   *   .then((groupings) => console.log(groupings))
+   *   .catch((err) => console.log(err));
+   */
+  getAllByOrganizationId(organizationId) {
+    if (!organizationId) {
+      return Promise.reject(
+        new Error("An organization id is required for getting a list of an organization's facility groupings")
+      );
+    }
+
+    return this._request.get(`${this._baseUrl}/organizations/${organizationId}/groupings`)
       .then((groupings) => groupings.map(formatGroupingFromServer));
   }
 


### PR DESCRIPTION
## Why?
Getting all facility groupings a user has access to is nice, but being able to get all the facility groupings a user has that are only one organization is double nice.

## What changed?
- Added method to get facility groupings for a particular organization
