### PR TITLE
adding getAllByOrganizationIdWithGroupings facility method :construction:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [v0.0.11](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.11) (2018-05-16)
+
+**Changed**
+
+* Facilities#getAllByOrganizationId to accept parameters to include facility grouping information
+
 ## [v0.0.10](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.10) (2018-05-01)
 
 **Added**

--- a/docs/Facilities.md
+++ b/docs/Facilities.md
@@ -186,7 +186,7 @@ Method: GET
 
 **Example**  
 ```js
-contxtSdk.facilities.getAllByOrganizationId(25)
+contxtSdk.facilities.getAllByOrganizationIdWithGroupings(25)
   .then((facilities) => console.log(facilities));
   .catch((err) => console.log(err));
 ```

--- a/docs/Facilities.md
+++ b/docs/Facilities.md
@@ -14,6 +14,7 @@ of, information about different facilities
     * [.get(facilityId)](#Facilities+get) ⇒ <code>Promise</code>
     * [.getAll()](#Facilities+getAll) ⇒ <code>Promise</code>
     * [.getAllByOrganizationId(organizationId)](#Facilities+getAllByOrganizationId) ⇒ <code>Promise</code>
+    * [.getAllByOrganizationIdWithGroupings(organizationId)](#Facilities+getAllByOrganizationIdWithGroupings) ⇒ <code>Promise</code>
     * [.update(facilityId, update)](#Facilities+update) ⇒ <code>Promise</code>
 
 <a name="new_Facilities_new"></a>
@@ -150,6 +151,29 @@ contxtSdk.facilities.getAll()
 Gets a list of all facilities that belong to a particular organization
 
 API Endpoint: '/organizations/:organizationId/facilities'
+Method: GET
+
+**Kind**: instance method of [<code>Facilities</code>](#Facilities)  
+**Fulfill**: <code>Facility[]</code> Information about all facilities  
+**Reject**: <code>Error</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| organizationId | <code>string</code> | UUID corresponding with an organization |
+
+**Example**  
+```js
+contxtSdk.facilities.getAllByOrganizationId(25)
+  .then((facilities) => console.log(facilities));
+  .catch((err) => console.log(err));
+```
+<a name="Facilities+getAllByOrganizationIdWithGroupings"></a>
+
+### contxtSdk.facilities.getAllByOrganizationIdWithGroupings(organizationId) ⇒ <code>Promise</code>
+Gets a list of all facilities that belong to a particular organization.
+Also, includes the groupings that each facility belongs to.
+
+API Endpoint: '/organizations/:organizationId/facilities?includeGroupings=true'
 Method: GET
 
 **Kind**: instance method of [<code>Facilities</code>](#Facilities)  

--- a/docs/Facilities.md
+++ b/docs/Facilities.md
@@ -160,11 +160,11 @@ Method: GET
 | --- | --- | --- |
 | organizationId | <code>string</code> | UUID corresponding with an organization |
 | [options] | <code>object</code> | Object containing parameters to be called with the request |
-| [options.include_groupings] | <code>boolean</code> | Boolean flag for including groupings data with each facility |
+| [options.includeGroupings] | <code>boolean</code> | Boolean flag for including groupings data with each facility |
 
 **Example**  
 ```js
-contxtSdk.facilities.getAllByOrganizationId(25, {include_groupings: true})
+contxtSdk.facilities.getAllByOrganizationId(25, {includeGroupings: true})
   .then((facilities) => console.log(facilities));
   .catch((err) => console.log(err));
 ```

--- a/docs/Facilities.md
+++ b/docs/Facilities.md
@@ -13,7 +13,7 @@ of, information about different facilities
     * [.delete(facilityId)](#Facilities+delete) ⇒ <code>Promise</code>
     * [.get(facilityId)](#Facilities+get) ⇒ <code>Promise</code>
     * [.getAll()](#Facilities+getAll) ⇒ <code>Promise</code>
-    * [.getAllByOrganizationId(organizationId, options)](#Facilities+getAllByOrganizationId) ⇒ <code>Promise</code>
+    * [.getAllByOrganizationId(organizationId, [options])](#Facilities+getAllByOrganizationId) ⇒ <code>Promise</code>
     * [.update(facilityId, update)](#Facilities+update) ⇒ <code>Promise</code>
 
 <a name="new_Facilities_new"></a>
@@ -146,7 +146,7 @@ contxtSdk.facilities.getAll()
 ```
 <a name="Facilities+getAllByOrganizationId"></a>
 
-### contxtSdk.facilities.getAllByOrganizationId(organizationId, options) ⇒ <code>Promise</code>
+### contxtSdk.facilities.getAllByOrganizationId(organizationId, [options]) ⇒ <code>Promise</code>
 Gets a list of all facilities that belong to a particular organization
 
 API Endpoint: '/organizations/:organizationId/facilities'
@@ -156,10 +156,11 @@ Method: GET
 **Fulfill**: <code>Facility[]</code> Information about all facilities  
 **Reject**: <code>Error</code>  
 
-| Param | Type | Default | Description |
-| --- | --- | --- | --- |
-| organizationId | <code>string</code> |  | UUID corresponding with an organization |
-| options | <code>object</code> | <code></code> | Object containing parameters to be called with the request |
+| Param | Type | Description |
+| --- | --- | --- |
+| organizationId | <code>string</code> | UUID corresponding with an organization |
+| [options] | <code>object</code> | Object containing parameters to be called with the request |
+| [options.include_groupings] | <code>boolean</code> | Boolean flag for including groupings data with each facility |
 
 **Example**  
 ```js

--- a/docs/Facilities.md
+++ b/docs/Facilities.md
@@ -13,8 +13,7 @@ of, information about different facilities
     * [.delete(facilityId)](#Facilities+delete) ⇒ <code>Promise</code>
     * [.get(facilityId)](#Facilities+get) ⇒ <code>Promise</code>
     * [.getAll()](#Facilities+getAll) ⇒ <code>Promise</code>
-    * [.getAllByOrganizationId(organizationId)](#Facilities+getAllByOrganizationId) ⇒ <code>Promise</code>
-    * [.getAllByOrganizationIdWithGroupings(organizationId)](#Facilities+getAllByOrganizationIdWithGroupings) ⇒ <code>Promise</code>
+    * [.getAllByOrganizationId(organizationId, options)](#Facilities+getAllByOrganizationId) ⇒ <code>Promise</code>
     * [.update(facilityId, update)](#Facilities+update) ⇒ <code>Promise</code>
 
 <a name="new_Facilities_new"></a>
@@ -77,7 +76,7 @@ Method: POST
 
 | Param | Type | Description |
 | --- | --- | --- |
-| facilityId | <code>number</code> | The id of the facility to update |
+| facilityId | <code>number</code> | The ID of the facility to update |
 | update | <code>Object</code> | An object containing the facility info for the facility |
 
 **Example**  
@@ -100,7 +99,7 @@ Method: DELETE
 
 | Param | Type | Description |
 | --- | --- | --- |
-| facilityId | <code>number</code> | The id of the facility |
+| facilityId | <code>number</code> | The ID of the facility |
 
 **Example**  
 ```js
@@ -120,7 +119,7 @@ Method: GET
 
 | Param | Type | Description |
 | --- | --- | --- |
-| facilityId | <code>number</code> | The id of the facility |
+| facilityId | <code>number</code> | The ID of the facility |
 
 **Example**  
 ```js
@@ -147,7 +146,7 @@ contxtSdk.facilities.getAll()
 ```
 <a name="Facilities+getAllByOrganizationId"></a>
 
-### contxtSdk.facilities.getAllByOrganizationId(organizationId) ⇒ <code>Promise</code>
+### contxtSdk.facilities.getAllByOrganizationId(organizationId, options) ⇒ <code>Promise</code>
 Gets a list of all facilities that belong to a particular organization
 
 API Endpoint: '/organizations/:organizationId/facilities'
@@ -157,36 +156,14 @@ Method: GET
 **Fulfill**: <code>Facility[]</code> Information about all facilities  
 **Reject**: <code>Error</code>  
 
-| Param | Type | Description |
-| --- | --- | --- |
-| organizationId | <code>string</code> | UUID corresponding with an organization |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| organizationId | <code>string</code> |  | UUID corresponding with an organization |
+| options | <code>object</code> | <code></code> | Object containing parameters to be called with the request |
 
 **Example**  
 ```js
-contxtSdk.facilities.getAllByOrganizationId(25)
-  .then((facilities) => console.log(facilities));
-  .catch((err) => console.log(err));
-```
-<a name="Facilities+getAllByOrganizationIdWithGroupings"></a>
-
-### contxtSdk.facilities.getAllByOrganizationIdWithGroupings(organizationId) ⇒ <code>Promise</code>
-Gets a list of all facilities that belong to a particular organization.
-Also, includes the groupings that each facility belongs to.
-
-API Endpoint: '/organizations/:organizationId/facilities?includeGroupings=true'
-Method: GET
-
-**Kind**: instance method of [<code>Facilities</code>](#Facilities)  
-**Fulfill**: <code>Facility[]</code> Information about all facilities  
-**Reject**: <code>Error</code>  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| organizationId | <code>string</code> | UUID corresponding with an organization |
-
-**Example**  
-```js
-contxtSdk.facilities.getAllByOrganizationIdWithGroupings(25)
+contxtSdk.facilities.getAllByOrganizationId(25, {include_groupings: true})
   .then((facilities) => console.log(facilities));
   .catch((err) => console.log(err));
 ```
@@ -204,7 +181,7 @@ Method: PUT
 
 | Param | Type | Description |
 | --- | --- | --- |
-| facilityId | <code>number</code> | The id of the facility to update |
+| facilityId | <code>number</code> | The ID of the facility to update |
 | update | <code>Object</code> | An object containing the updated data for the facility |
 | [update.address1] | <code>string</code> |  |
 | [update.address2] | <code>string</code> |  |

--- a/docs/Typedefs.md
+++ b/docs/Typedefs.md
@@ -76,7 +76,7 @@ for authenticating and communicating with an individual API and the external mod
 | name | <code>string</code> |  |
 | [Organization] | <code>Object</code> |  |
 | [Organization.createdAt] | <code>string</code> | ISO 8601 Extended Format date/time string |
-| [Organization.id] | <code>string</code> | UUID formatted id |
+| [Organization.id] | <code>string</code> | UUID formatted ID |
 | [Organization.name] | <code>string</code> |  |
 | [Organization.updatedAt] | <code>string</code> | ISO 8601 Extended Format date/time string |
 | state | <code>string</code> |  |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ndustrial/contxt-sdk",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ndustrial/contxt-sdk",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/facilities/index.js
+++ b/src/facilities/index.js
@@ -92,14 +92,17 @@ class Facilities {
       const field = requiredFields[i];
 
       if (!facility[field]) {
-        return Promise.reject(new Error(`A ${field} is required to create a new facility.`));
+        return Promise.reject(
+          new Error(`A ${field} is required to create a new facility.`)
+        );
       }
     }
 
     const data = formatFacilityToServer(facility);
 
-    return this._request.post(`${this._baseUrl}/facilities`, data)
-      .then((facility) => formatFacilityFromServer(facility));
+    return this._request
+      .post(`${this._baseUrl}/facilities`, data)
+      .then(facility => formatFacilityFromServer(facility));
   }
 
   /**
@@ -122,16 +125,22 @@ class Facilities {
    */
   createOrUpdateInfo(facilityId, update) {
     if (!facilityId) {
-      return Promise.reject(new Error("A facility id is required to update a facility's info."));
+      return Promise.reject(
+        new Error("A facility id is required to update a facility's info.")
+      );
     }
 
     if (!update) {
-      return Promise.reject(new Error("An update is required to update a facility's info."));
+      return Promise.reject(
+        new Error("An update is required to update a facility's info.")
+      );
     }
 
     if (!isPlainObject(update)) {
       return Promise.reject(
-        new Error('The facility info update must be a well-formed object with the data you wish to update.')
+        new Error(
+          'The facility info update must be a well-formed object with the data you wish to update.'
+        )
       );
     }
 
@@ -141,7 +150,11 @@ class Facilities {
       }
     };
 
-    return this._request.post(`${this._baseUrl}/facilities/${facilityId}/info`, update, options);
+    return this._request.post(
+      `${this._baseUrl}/facilities/${facilityId}/info`,
+      update,
+      options
+    );
   }
 
   /**
@@ -161,7 +174,9 @@ class Facilities {
    */
   delete(facilityId) {
     if (!facilityId) {
-      return Promise.reject(new Error('A facility id is required for deleting a facility'));
+      return Promise.reject(
+        new Error('A facility id is required for deleting a facility')
+      );
     }
 
     return this._request.delete(`${this._baseUrl}/facilities/${facilityId}`);
@@ -187,12 +202,15 @@ class Facilities {
   get(facilityId) {
     if (!facilityId) {
       return Promise.reject(
-        new Error('A facility id is required for getting information about a facility')
+        new Error(
+          'A facility id is required for getting information about a facility'
+        )
       );
     }
 
-    return this._request.get(`${this._baseUrl}/facilities/${facilityId}`)
-      .then((facility) => formatFacilityFromServer(facility));
+    return this._request
+      .get(`${this._baseUrl}/facilities/${facilityId}`)
+      .then(facility => formatFacilityFromServer(facility));
   }
 
   /**
@@ -211,8 +229,11 @@ class Facilities {
    *   .catch((err) => console.log(err));
    */
   getAll() {
-    return this._request.get(`${this._baseUrl}/facilities`)
-      .then((facilities) => facilities.map((facility) => formatFacilityFromServer(facility)));
+    return this._request
+      .get(`${this._baseUrl}/facilities`)
+      .then(facilities =>
+        facilities.map(facility => formatFacilityFromServer(facility))
+      );
   }
 
   /**
@@ -235,12 +256,55 @@ class Facilities {
   getAllByOrganizationId(organizationId) {
     if (!organizationId) {
       return Promise.reject(
-        new Error("An organization id is required for getting a list of an organization's facilities")
+        new Error(
+          "An organization id is required for getting a list of an organization's facilities"
+        )
       );
     }
 
-    return this._request.get(`${this._baseUrl}/organizations/${organizationId}/facilities`)
-      .then((facilities) => facilities.map((facility) => formatFacilityFromServer(facility)));
+    return this._request
+      .get(`${this._baseUrl}/organizations/${organizationId}/facilities`)
+      .then(facilities =>
+        facilities.map(facility => formatFacilityFromServer(facility))
+      );
+  }
+
+  /**
+   * Gets a list of all facilities that belong to a particular organization.
+   * Also, includes the groupings that each facility belongs to.
+   *
+   * API Endpoint: '/organizations/:organizationId/facilities?includeGroupings=true'
+   * Method: GET
+   *
+   * @param {string} organizationId UUID corresponding with an organization
+   *
+   * @returns {Promise}
+   * @fulfill {Facility[]} Information about all facilities
+   * @reject {Error}
+   *
+   * @example
+   * contxtSdk.facilities.getAllByOrganizationId(25)
+   *   .then((facilities) => console.log(facilities));
+   *   .catch((err) => console.log(err));
+   */
+  getAllByOrganizationIdWithGroupings(organizationId) {
+    if (!organizationId) {
+      return Promise.reject(
+        new Error(
+          "An organization id is required for getting a list of an organization's facilities"
+        )
+      );
+    }
+
+    return this._request
+      .get(
+        `${
+          this._baseUrl
+        }/organizations/${organizationId}/facilities?includeGroupings=true`
+      )
+      .then(facilities =>
+        facilities.map(facility => formatFacilityFromServer(facility))
+      );
   }
 
   /**
@@ -276,22 +340,31 @@ class Facilities {
    */
   update(facilityId, update) {
     if (!facilityId) {
-      return Promise.reject(new Error('A facility id is required to update a facility.'));
+      return Promise.reject(
+        new Error('A facility id is required to update a facility.')
+      );
     }
 
     if (!update) {
-      return Promise.reject(new Error('An update is required to update a facility.'));
+      return Promise.reject(
+        new Error('An update is required to update a facility.')
+      );
     }
 
     if (!isPlainObject(update)) {
       return Promise.reject(
-        new Error('The facility update must be a well-formed object with the data you wish to update.')
+        new Error(
+          'The facility update must be a well-formed object with the data you wish to update.'
+        )
       );
     }
 
     const formattedUpdate = formatFacilityToServer(update);
 
-    return this._request.put(`${this._baseUrl}/facilities/${facilityId}`, formattedUpdate);
+    return this._request.put(
+      `${this._baseUrl}/facilities/${facilityId}`,
+      formattedUpdate
+    );
   }
 }
 

--- a/src/facilities/index.js
+++ b/src/facilities/index.js
@@ -2,7 +2,8 @@ import isPlainObject from 'lodash.isplainobject';
 import FacilityGroupings from './groupings';
 import {
   formatFacilityFromServer,
-  formatFacilityToServer
+  formatFacilityToServer,
+  formatFacilityOptionsToServer
 } from '../utils/facilities';
 
 /**
@@ -264,11 +265,7 @@ class Facilities {
       );
     }
 
-    const params = {
-      ...options,
-      include_groupings: options ? options.includeGroupings : false
-    };
-    delete params.includeGroupings;
+    const params = formatFacilityOptionsToServer(options);
 
     return this._request
       .get(`${this._baseUrl}/organizations/${organizationId}/facilities`, {

--- a/src/facilities/index.js
+++ b/src/facilities/index.js
@@ -244,14 +244,14 @@ class Facilities {
    *
    * @param {string} organizationId UUID corresponding with an organization
    * @param {object} [options] Object containing parameters to be called with the request
-   * @param {boolean} [options.include_groupings] Boolean flag for including groupings data with each facility
+   * @param {boolean} [options.includeGroupings] Boolean flag for including groupings data with each facility
    *
    * @returns {Promise}
    * @fulfill {Facility[]} Information about all facilities
    * @reject {Error}
    *
    * @example
-   * contxtSdk.facilities.getAllByOrganizationId(25, {include_groupings: true})
+   * contxtSdk.facilities.getAllByOrganizationId(25, {includeGroupings: true})
    *   .then((facilities) => console.log(facilities));
    *   .catch((err) => console.log(err));
    */
@@ -264,9 +264,15 @@ class Facilities {
       );
     }
 
+    const params = {
+      ...options,
+      include_groupings: options ? options.includeGroupings : false
+    };
+    delete params.includeGroupings;
+
     return this._request
       .get(`${this._baseUrl}/organizations/${organizationId}/facilities`, {
-        params: options
+        params
       })
       .then(facilities =>
         facilities.map(facility => formatFacilityFromServer(facility))

--- a/src/facilities/index.js
+++ b/src/facilities/index.js
@@ -243,7 +243,8 @@ class Facilities {
    * Method: GET
    *
    * @param {string} organizationId UUID corresponding with an organization
-   * @param {object} options Object containing parameters to be called with the request
+   * @param {object} [options] Object containing parameters to be called with the request
+   * @param {boolean} [options.include_groupings] Boolean flag for including groupings data with each facility
    *
    * @returns {Promise}
    * @fulfill {Facility[]} Information about all facilities
@@ -254,7 +255,7 @@ class Facilities {
    *   .then((facilities) => console.log(facilities));
    *   .catch((err) => console.log(err));
    */
-  getAllByOrganizationId(organizationId, options = null) {
+  getAllByOrganizationId(organizationId, options) {
     if (!organizationId) {
       return Promise.reject(
         new Error(

--- a/src/facilities/index.js
+++ b/src/facilities/index.js
@@ -283,7 +283,7 @@ class Facilities {
    * @reject {Error}
    *
    * @example
-   * contxtSdk.facilities.getAllByOrganizationId(25)
+   * contxtSdk.facilities.getAllByOrganizationIdWithGroupings(25)
    *   .then((facilities) => console.log(facilities));
    *   .catch((err) => console.log(err));
    */

--- a/src/facilities/index.js
+++ b/src/facilities/index.js
@@ -243,17 +243,18 @@ class Facilities {
    * Method: GET
    *
    * @param {string} organizationId UUID corresponding with an organization
+   * @param {object} options Object containing parameters to be called with the request
    *
    * @returns {Promise}
    * @fulfill {Facility[]} Information about all facilities
    * @reject {Error}
    *
    * @example
-   * contxtSdk.facilities.getAllByOrganizationId(25)
+   * contxtSdk.facilities.getAllByOrganizationId(25, {include_groupings: true})
    *   .then((facilities) => console.log(facilities));
    *   .catch((err) => console.log(err));
    */
-  getAllByOrganizationId(organizationId) {
+  getAllByOrganizationId(organizationId, options = null) {
     if (!organizationId) {
       return Promise.reject(
         new Error(
@@ -263,45 +264,9 @@ class Facilities {
     }
 
     return this._request
-      .get(`${this._baseUrl}/organizations/${organizationId}/facilities`)
-      .then(facilities =>
-        facilities.map(facility => formatFacilityFromServer(facility))
-      );
-  }
-
-  /**
-   * Gets a list of all facilities that belong to a particular organization.
-   * Also, includes the groupings that each facility belongs to.
-   *
-   * API Endpoint: '/organizations/:organizationId/facilities?includeGroupings=true'
-   * Method: GET
-   *
-   * @param {string} organizationId UUID corresponding with an organization
-   *
-   * @returns {Promise}
-   * @fulfill {Facility[]} Information about all facilities
-   * @reject {Error}
-   *
-   * @example
-   * contxtSdk.facilities.getAllByOrganizationIdWithGroupings(25)
-   *   .then((facilities) => console.log(facilities));
-   *   .catch((err) => console.log(err));
-   */
-  getAllByOrganizationIdWithGroupings(organizationId) {
-    if (!organizationId) {
-      return Promise.reject(
-        new Error(
-          "An organization ID is required for getting a list of an organization's facilities"
-        )
-      );
-    }
-
-    return this._request
-      .get(
-        `${
-          this._baseUrl
-        }/organizations/${organizationId}/facilities?includeGroupings=true`
-      )
+      .get(`${this._baseUrl}/organizations/${organizationId}/facilities`, {
+        params: options
+      })
       .then(facilities =>
         facilities.map(facility => formatFacilityFromServer(facility))
       );

--- a/src/facilities/index.js
+++ b/src/facilities/index.js
@@ -17,7 +17,7 @@ import {
  * @property {string} name
  * @property {Object} [Organization]
  * @property {string} [Organization.createdAt] ISO 8601 Extended Format date/time string
- * @property {string} [Organization.id] UUID formatted id
+ * @property {string} [Organization.id] UUID formatted ID
  * @property {string} [Organization.name]
  * @property {string} [Organization.updatedAt] ISO 8601 Extended Format date/time string
  * @property {string} state
@@ -111,7 +111,7 @@ class Facilities {
    * API Endpoint: '/facilities/:facilityId/info?should_update=true'
    * Method: POST
    *
-   * @param {number} facilityId The id of the facility to update
+   * @param {number} facilityId The ID of the facility to update
    * @param {Object} update An object containing the facility info for the facility
    *
    * @returns {Promise}
@@ -126,7 +126,7 @@ class Facilities {
   createOrUpdateInfo(facilityId, update) {
     if (!facilityId) {
       return Promise.reject(
-        new Error("A facility id is required to update a facility's info.")
+        new Error("A facility ID is required to update a facility's info.")
       );
     }
 
@@ -163,7 +163,7 @@ class Facilities {
    * API Endpoint: '/facilities/:facilityId'
    * Method: DELETE
    *
-   * @param {number} facilityId The id of the facility
+   * @param {number} facilityId The ID of the facility
    *
    * @returns {Promise}
    * @fulfill {undefined}
@@ -175,7 +175,7 @@ class Facilities {
   delete(facilityId) {
     if (!facilityId) {
       return Promise.reject(
-        new Error('A facility id is required for deleting a facility')
+        new Error('A facility ID is required for deleting a facility')
       );
     }
 
@@ -188,7 +188,7 @@ class Facilities {
    * API Endpoint: '/facilities/:facilityId'
    * Method: GET
    *
-   * @param {number} facilityId The id of the facility
+   * @param {number} facilityId The ID of the facility
    *
    * @returns {Promise}
    * @fulfill {Facility} Information about a facility
@@ -203,7 +203,7 @@ class Facilities {
     if (!facilityId) {
       return Promise.reject(
         new Error(
-          'A facility id is required for getting information about a facility'
+          'A facility ID is required for getting information about a facility'
         )
       );
     }
@@ -257,7 +257,7 @@ class Facilities {
     if (!organizationId) {
       return Promise.reject(
         new Error(
-          "An organization id is required for getting a list of an organization's facilities"
+          "An organization ID is required for getting a list of an organization's facilities"
         )
       );
     }
@@ -291,7 +291,7 @@ class Facilities {
     if (!organizationId) {
       return Promise.reject(
         new Error(
-          "An organization id is required for getting a list of an organization's facilities"
+          "An organization ID is required for getting a list of an organization's facilities"
         )
       );
     }
@@ -313,7 +313,7 @@ class Facilities {
    * API Endpoint: '/facilities/:facilityId'
    * Method: PUT
    *
-   * @param {number} facilityId The id of the facility to update
+   * @param {number} facilityId The ID of the facility to update
    * @param {Object} update An object containing the updated data for the facility
    * @param {string} [update.address1]
    * @param {string} [update.address2]
@@ -341,7 +341,7 @@ class Facilities {
   update(facilityId, update) {
     if (!facilityId) {
       return Promise.reject(
-        new Error('A facility id is required to update a facility.')
+        new Error('A facility ID is required to update a facility.')
       );
     }
 

--- a/src/facilities/index.spec.js
+++ b/src/facilities/index.spec.js
@@ -402,8 +402,9 @@ describe('Facilities', function () {
           };
           const facilities = new Facilities(baseSdk, request);
           facilities.getAllByOrganizationId(expectedOrganizationId, {
-            include_groupings: true
+            includeGroupings: true
           });
+          debugger;
           expect(request.get.firstCall.args).to.deep.include({
             params: {
               include_groupings: true

--- a/src/facilities/index.spec.js
+++ b/src/facilities/index.spec.js
@@ -393,82 +393,30 @@ describe('Facilities', function () {
         return expect(promise).to.be.fulfilled
           .and.to.eventually.deep.equal(formattedFacilities);
       });
+
+      context('include_groupings options are passed', function () {
+        it('includes the query parameter in the request', function () {
+          request = {
+            ...baseRequest,
+            get: this.sandbox.stub().resolves(rawFacilities)
+          };
+          const facilities = new Facilities(baseSdk, request);
+          facilities.getAllByOrganizationId(expectedOrganizationId, {
+            include_groupings: true
+          });
+          expect(request.get.firstCall.args).to.deep.include({
+            params: {
+              include_groupings: true
+            }
+          });
+        });
+      });
     });
 
     context('the organization id is not provided', function () {
       it('throws an error', function () {
         const facilities = new Facilities(baseSdk, baseRequest);
         const promise = facilities.getAllByOrganizationId();
-
-        return expect(promise).to.be.rejectedWith(
-          "An organization ID is required for getting a list of an organization's facilities"
-        );
-      });
-    });
-  });
-
-  describe('getAllByOrganizationIdWithGroupings', function () {
-    context('the organization ID is provided', function () {
-      let expectedOrganizationId;
-      let formatFacilityFromServer;
-      let formattedFacilities;
-      let promise;
-      let rawFacilities;
-      let request;
-
-      beforeEach(function () {
-        expectedOrganizationId = faker.random.number();
-        const numberOfFacilities = faker.random.number({
-          min: 1,
-          max: 10
-        });
-        formattedFacilities = fixture.buildList('facility', numberOfFacilities);
-        rawFacilities = fixture.buildList('facility', numberOfFacilities, null, {
-          fromServer: true
-        });
-
-        formatFacilityFromServer = this.sandbox.stub(facilitiesUtils, 'formatFacilityFromServer')
-          .callsFake((facility) => {
-            const index = rawFacilities.indexOf(facility);
-            return formattedFacilities[index];
-          });
-        request = {
-          ...baseRequest,
-          get: this.sandbox.stub().resolves(rawFacilities)
-        };
-
-        const facilities = new Facilities(baseSdk, request);
-        facilities._baseUrl = expectedHost;
-
-        promise = facilities.getAllByOrganizationIdWithGroupings(expectedOrganizationId);
-      });
-
-      it('gets a list of facilities for an organization from the server', function () {
-        expect(request.get).to.be.calledWith(
-          `${expectedHost}/organizations/${expectedOrganizationId}/facilities?includeGroupings=true`
-        );
-      });
-
-      it('formats the facility object', function () {
-        return promise.then(() => {
-          expect(formatFacilityFromServer).to.have.callCount(rawFacilities.length);
-
-          rawFacilities.forEach((facility) => {
-            expect(formatFacilityFromServer).to.be.calledWith(facility);
-          });
-        });
-      });
-
-      it('returns a list of facilities', function () {
-        return expect(promise).to.be.fulfilled
-          .and.to.eventually.deep.equal(formattedFacilities);
-      });
-    });
-
-    context('the organization ID is not provided', function () {
-      it('throws an error', function () {
-        const facilities = new Facilities(baseSdk, baseRequest);
-        const promise = facilities.getAllByOrganizationIdWithGroupings();
 
         return expect(promise).to.be.rejectedWith(
           "An organization ID is required for getting a list of an organization's facilities"

--- a/src/facilities/index.spec.js
+++ b/src/facilities/index.spec.js
@@ -2,12 +2,12 @@ import omit from 'lodash.omit';
 import Facilities from './index';
 import * as facilitiesUtils from '../utils/facilities';
 
-describe('Facilities', function() {
+describe('Facilities', function () {
   let baseRequest;
   let baseSdk;
   let expectedHost;
 
-  beforeEach(function() {
+  beforeEach(function () {
     this.sandbox = sandbox.create();
 
     baseRequest = {
@@ -26,32 +26,32 @@ describe('Facilities', function() {
     expectedHost = faker.internet.url();
   });
 
-  afterEach(function() {
+  afterEach(function () {
     this.sandbox.restore();
   });
 
-  describe('constructor', function() {
+  describe('constructor', function () {
     let facilities;
 
-    beforeEach(function() {
+    beforeEach(function () {
       facilities = new Facilities(baseSdk, baseRequest);
     });
 
-    it('sets a base url for the class instance', function() {
+    it('sets a base url for the class instance', function () {
       expect(facilities._baseUrl).to.equal(`${baseSdk.config.audiences.facilities.host}/v1`);
     });
 
-    it('appends the supplied request module to the class instance', function() {
+    it('appends the supplied request module to the class instance', function () {
       expect(facilities._request).to.equal(baseRequest);
     });
 
-    it('appends the supplied sdk to the class instance', function() {
+    it('appends the supplied sdk to the class instance', function () {
       expect(facilities._sdk).to.equal(baseSdk);
     });
   });
 
-  describe('create', function() {
-    context('when all required information is supplied', function() {
+  describe('create', function () {
+    context('when all required information is supplied', function () {
       let expectedFacility;
       let formatFacilityFromServer;
       let formatFacilityToServer;
@@ -61,11 +61,17 @@ describe('Facilities', function() {
       let rawFacility;
       let request;
 
-      beforeEach(function() {
-        expectedFacility = fixture.build('facility', null, { fromServer: true });
-        formattedFacility = fixture.build('facility', null, { fromServer: true });
+      beforeEach(function () {
+        expectedFacility = fixture.build('facility', null, {
+          fromServer: true
+        });
+        formattedFacility = fixture.build('facility', null, {
+          fromServer: true
+        });
         initialFacility = fixture.build('facility');
-        rawFacility = fixture.build('facility', null, { fromServer: true });
+        rawFacility = fixture.build('facility', null, {
+          fromServer: true
+        });
 
         formatFacilityFromServer = this.sandbox.stub(facilitiesUtils, 'formatFacilityFromServer')
           .returns(expectedFacility);
@@ -82,29 +88,29 @@ describe('Facilities', function() {
         promise = facilities.create(initialFacility);
       });
 
-      it('formats the submitted facility object to send to the server', function() {
+      it('formats the submitted facility object to send to the server', function () {
         expect(formatFacilityToServer).to.be.calledWith(initialFacility);
       });
 
-      it('creates a new facility', function() {
+      it('creates a new facility', function () {
         expect(request.post).to.be.deep.calledWith(`${expectedHost}/facilities`, formattedFacility);
       });
 
-      it('formats the returned facility object', function() {
+      it('formats the returned facility object', function () {
         return promise.then(() => {
           expect(formatFacilityFromServer).to.be.calledWith(rawFacility);
         });
       });
 
-      it('returns a fulfilled promise with the new facility information', function() {
+      it('returns a fulfilled promise with the new facility information', function () {
         return expect(promise).to.be.fulfilled
           .and.to.eventually.equal(expectedFacility);
       });
     });
 
-    context('when there is missing required information', function() {
-      ['organizationId', 'name', 'timezone'].forEach(function(field) {
-        it(`it throws an error when ${field} is missing`, function() {
+    context('when there is missing required information', function () {
+      ['organizationId', 'name', 'timezone'].forEach(function (field) {
+        it(`it throws an error when ${field} is missing`, function () {
           const facility = fixture.build('facility');
           const initialFacility = {
             ...facility,
@@ -120,13 +126,13 @@ describe('Facilities', function() {
     });
   });
 
-  describe('createOrUpdateInfo', function() {
-    context('when all required information is available', function() {
+  describe('createOrUpdateInfo', function () {
+    context('when all required information is available', function () {
       let facilityId;
       let facilityInfoUpdate;
       let promise;
 
-      beforeEach(function() {
+      beforeEach(function () {
         facilityId = fixture.build('facility').id;
         facilityInfoUpdate = fixture.build('facilityInfo');
 
@@ -136,27 +142,30 @@ describe('Facilities', function() {
         promise = facilities.createOrUpdateInfo(facilityId, facilityInfoUpdate);
       });
 
-      it('updates the facility', function() {
+      it('updates the facility', function () {
         expect(baseRequest.post).to.be.calledWith(
           `${expectedHost}/facilities/${facilityId}/info`,
-          facilityInfoUpdate,
-          { params: { should_update: true } }
+          facilityInfoUpdate, {
+            params: {
+              should_update: true
+            }
+          }
         );
       });
 
-      it('returns a fulfilled promise', function() {
+      it('returns a fulfilled promise', function () {
         return expect(promise).to.be.fulfilled;
       });
     });
 
-    context('when there is missing or malformed required information', function() {
+    context('when there is missing or malformed required information', function () {
       let facilities;
 
-      beforeEach(function() {
+      beforeEach(function () {
         facilities = new Facilities(baseSdk, baseRequest);
       });
 
-      it('throws an error when there is no provided facility id', function() {
+      it('throws an error when there is no provided facility id', function () {
         const facilityInfoUpdate = fixture.build('facilityInfo');
         const promise = facilities.createOrUpdateInfo(null, facilityInfoUpdate);
 
@@ -164,14 +173,14 @@ describe('Facilities', function() {
           .rejectedWith("A facility id is required to update a facility's info.");
       });
 
-      it('throws an error when there is no update provided', function() {
+      it('throws an error when there is no update provided', function () {
         const facility = fixture.build('facility');
         const promise = facilities.createOrUpdateInfo(facility.id);
 
         return expect(promise).to.be.rejectedWith("An update is required to update a facility's info.");
       });
 
-      it('throws an error when the update is not an object', function() {
+      it('throws an error when the update is not an object', function () {
         const facility = fixture.build('facility');
         const promise = facilities.createOrUpdateInfo(facility.id, [facility.info]);
 
@@ -182,12 +191,12 @@ describe('Facilities', function() {
     });
   });
 
-  describe('delete', function() {
-    context('the facility id is provided', function() {
+  describe('delete', function () {
+    context('the facility id is provided', function () {
       let facility;
       let promise;
 
-      beforeEach(function() {
+      beforeEach(function () {
         facility = fixture.build('facility');
 
         const facilities = new Facilities(baseSdk, baseRequest);
@@ -196,18 +205,18 @@ describe('Facilities', function() {
         promise = facilities.delete(facility.id);
       });
 
-      it('requests to delete the facility', function() {
+      it('requests to delete the facility', function () {
         expect(baseRequest.delete).to.be
           .calledWith(`${expectedHost}/facilities/${facility.id}`);
       });
 
-      it('returns a resolved promise', function() {
+      it('returns a resolved promise', function () {
         return expect(promise).to.be.fulfilled;
       });
     });
 
-    context('the facility id is not provided', function() {
-      it('throws an error', function() {
+    context('the facility id is not provided', function () {
+      it('throws an error', function () {
         const facilities = new Facilities(baseSdk, baseRequest);
         const promise = facilities.delete();
 
@@ -217,8 +226,8 @@ describe('Facilities', function() {
     });
   });
 
-  describe('get', function() {
-    context('the facility id is provided', function() {
+  describe('get', function () {
+    context('the facility id is provided', function () {
       let expectedFacilityId;
       let formatFacilityFromServer;
       let formattedFacility;
@@ -226,10 +235,14 @@ describe('Facilities', function() {
       let rawFacility;
       let request;
 
-      beforeEach(function() {
+      beforeEach(function () {
         expectedFacilityId = faker.random.number();
-        rawFacility = fixture.build('facility', null, { fromServer: true });
-        formattedFacility = fixture.build('facility', { id: rawFacility.id });
+        rawFacility = fixture.build('facility', null, {
+          fromServer: true
+        });
+        formattedFacility = fixture.build('facility', {
+          id: rawFacility.id
+        });
 
         formatFacilityFromServer = this.sandbox.stub(facilitiesUtils, 'formatFacilityFromServer')
           .returns(formattedFacility);
@@ -244,24 +257,24 @@ describe('Facilities', function() {
         promise = facilities.get(expectedFacilityId);
       });
 
-      it('gets a list of facilities from the server', function() {
+      it('gets a list of facilities from the server', function () {
         expect(request.get).to.be.calledWith(`${expectedHost}/facilities/${expectedFacilityId}`);
       });
 
-      it('formats the facility object', function() {
+      it('formats the facility object', function () {
         return promise.then(() => {
           expect(formatFacilityFromServer).to.be.calledWith(rawFacility);
         });
       });
 
-      it('returns the requested facility', function() {
+      it('returns the requested facility', function () {
         return expect(promise).to.be.fulfilled
           .and.to.eventually.equal(formattedFacility);
       });
     });
 
-    context('the facility id is not provided', function() {
-      it('throws an error', function() {
+    context('the facility id is not provided', function () {
+      it('throws an error', function () {
         const facilities = new Facilities(baseSdk, baseRequest);
         const promise = facilities.get();
 
@@ -271,17 +284,22 @@ describe('Facilities', function() {
     });
   });
 
-  describe('getAll', function() {
+  describe('getAll', function () {
     let formatFacilityFromServer;
     let formattedFacilities;
     let promise;
     let rawFacilities;
     let request;
 
-    beforeEach(function() {
-      const numberOfFacilities = faker.random.number({ min: 1, max: 10 });
+    beforeEach(function () {
+      const numberOfFacilities = faker.random.number({
+        min: 1,
+        max: 10
+      });
       formattedFacilities = fixture.buildList('facility', numberOfFacilities);
-      rawFacilities = fixture.buildList('facility', numberOfFacilities, null, { fromServer: true });
+      rawFacilities = fixture.buildList('facility', numberOfFacilities, null, {
+        fromServer: true
+      });
 
       formatFacilityFromServer = this.sandbox.stub(facilitiesUtils, 'formatFacilityFromServer')
         .callsFake((facility) => {
@@ -299,11 +317,11 @@ describe('Facilities', function() {
       promise = facilities.getAll();
     });
 
-    it('gets a list of facilities from the server', function() {
+    it('gets a list of facilities from the server', function () {
       expect(request.get).to.be.calledWith(`${expectedHost}/facilities`);
     });
 
-    it('formats the facility object', function() {
+    it('formats the facility object', function () {
       return promise.then(() => {
         expect(formatFacilityFromServer).to.have.callCount(rawFacilities.length);
 
@@ -313,14 +331,14 @@ describe('Facilities', function() {
       });
     });
 
-    it('returns a list of facilities', function() {
+    it('returns a list of facilities', function () {
       return expect(promise).to.be.fulfilled
         .and.to.eventually.deep.equal(formattedFacilities);
     });
   });
 
-  describe('getAllByOrganizationId', function() {
-    context('the organization id is not provided', function() {
+  describe('getAllByOrganizationId', function () {
+    context('the organization id is provided', function () {
       let expectedOrganizationId;
       let formatFacilityFromServer;
       let formattedFacilities;
@@ -328,11 +346,16 @@ describe('Facilities', function() {
       let rawFacilities;
       let request;
 
-      beforeEach(function() {
+      beforeEach(function () {
         expectedOrganizationId = faker.random.number();
-        const numberOfFacilities = faker.random.number({ min: 1, max: 10 });
+        const numberOfFacilities = faker.random.number({
+          min: 1,
+          max: 10
+        });
         formattedFacilities = fixture.buildList('facility', numberOfFacilities);
-        rawFacilities = fixture.buildList('facility', numberOfFacilities, null, { fromServer: true });
+        rawFacilities = fixture.buildList('facility', numberOfFacilities, null, {
+          fromServer: true
+        });
 
         formatFacilityFromServer = this.sandbox.stub(facilitiesUtils, 'formatFacilityFromServer')
           .callsFake((facility) => {
@@ -350,13 +373,13 @@ describe('Facilities', function() {
         promise = facilities.getAllByOrganizationId(expectedOrganizationId);
       });
 
-      it('gets a list of facilities for an organization from the server', function() {
+      it('gets a list of facilities for an organization from the server', function () {
         expect(request.get).to.be.calledWith(
           `${expectedHost}/organizations/${expectedOrganizationId}/facilities`
         );
       });
 
-      it('formats the facility object', function() {
+      it('formats the facility object', function () {
         return promise.then(() => {
           expect(formatFacilityFromServer).to.have.callCount(rawFacilities.length);
 
@@ -366,14 +389,14 @@ describe('Facilities', function() {
         });
       });
 
-      it('returns a list of facilities', function() {
+      it('returns a list of facilities', function () {
         return expect(promise).to.be.fulfilled
           .and.to.eventually.deep.equal(formattedFacilities);
       });
     });
 
-    context('the organization id is not provided', function() {
-      it('throws an error', function() {
+    context('the organization id is not provided', function () {
+      it('throws an error', function () {
         const facilities = new Facilities(baseSdk, baseRequest);
         const promise = facilities.getAllByOrganizationId();
 
@@ -384,16 +407,88 @@ describe('Facilities', function() {
     });
   });
 
-  describe('update', function() {
-    context('when all required information is available', function() {
+  describe('getAllByOrganizationIdWithGroupings', function () {
+    context('the organization id is provided', function () {
+      let expectedOrganizationId;
+      let formatFacilityFromServer;
+      let formattedFacilities;
+      let promise;
+      let rawFacilities;
+      let request;
+
+      beforeEach(function () {
+        expectedOrganizationId = faker.random.number();
+        const numberOfFacilities = faker.random.number({
+          min: 1,
+          max: 10
+        });
+        formattedFacilities = fixture.buildList('facility', numberOfFacilities);
+        rawFacilities = fixture.buildList('facility', numberOfFacilities, null, {
+          fromServer: true
+        });
+
+        formatFacilityFromServer = this.sandbox.stub(facilitiesUtils, 'formatFacilityFromServer')
+          .callsFake((facility) => {
+            const index = rawFacilities.indexOf(facility);
+            return formattedFacilities[index];
+          });
+        request = {
+          ...baseRequest,
+          get: this.sandbox.stub().resolves(rawFacilities)
+        };
+
+        const facilities = new Facilities(baseSdk, request);
+        facilities._baseUrl = expectedHost;
+
+        promise = facilities.getAllByOrganizationIdWithGroupings(expectedOrganizationId);
+      });
+
+      it('gets a list of facilities for an organization from the server', function () {
+        expect(request.get).to.be.calledWith(
+          `${expectedHost}/organizations/${expectedOrganizationId}/facilities?includeGroupings=true`
+        );
+      });
+
+      it('formats the facility object', function () {
+        return promise.then(() => {
+          expect(formatFacilityFromServer).to.have.callCount(rawFacilities.length);
+
+          rawFacilities.forEach((facility) => {
+            expect(formatFacilityFromServer).to.be.calledWith(facility);
+          });
+        });
+      });
+
+      it('returns a list of facilities', function () {
+        return expect(promise).to.be.fulfilled
+          .and.to.eventually.deep.equal(formattedFacilities);
+      });
+    });
+
+    context('the organization id is not provided', function () {
+      it('throws an error', function () {
+        const facilities = new Facilities(baseSdk, baseRequest);
+        const promise = facilities.getAllByOrganizationIdWithGroupings();
+
+        return expect(promise).to.be.rejectedWith(
+          "An organization id is required for getting a list of an organization's facilities"
+        );
+      });
+    });
+  });
+
+  describe('update', function () {
+    context('when all required information is available', function () {
       let facilityUpdate;
       let formatFacilityToServer;
       let formattedFacility;
       let promise;
 
-      beforeEach(function() {
+      beforeEach(function () {
         facilityUpdate = fixture.build('facility');
-        formattedFacility = fixture.build('facility', null, { fromServer: true });
+        formattedFacility = fixture.build('facility', null, {
+          fromServer: true
+        });
 
         formatFacilityToServer = this.sandbox.stub(facilitiesUtils, 'formatFacilityToServer')
           .returns(formattedFacility);
@@ -404,30 +499,30 @@ describe('Facilities', function() {
         promise = facilities.update(facilityUpdate.id, facilityUpdate);
       });
 
-      it('formats the data into the right format', function() {
+      it('formats the data into the right format', function () {
         expect(formatFacilityToServer).to.be.calledWith(facilityUpdate);
       });
 
-      it('updates the facility', function() {
+      it('updates the facility', function () {
         expect(baseRequest.put).to.be.calledWith(
           `${expectedHost}/facilities/${facilityUpdate.id}`,
           formattedFacility
         );
       });
 
-      it('returns a fulfilled promise', function() {
+      it('returns a fulfilled promise', function () {
         return expect(promise).to.be.fulfilled;
       });
     });
 
-    context('when there is missing or malformed required information', function() {
+    context('when there is missing or malformed required information', function () {
       let facilities;
 
-      beforeEach(function() {
+      beforeEach(function () {
         facilities = new Facilities(baseSdk, baseRequest);
       });
 
-      it('throws an error when there is no provided facility id', function() {
+      it('throws an error when there is no provided facility id', function () {
         const facilityUpdate = fixture.build('facility');
         const promise = facilities.update(null, facilityUpdate);
 
@@ -435,14 +530,14 @@ describe('Facilities', function() {
           .rejectedWith('A facility id is required to update a facility.');
       });
 
-      it('throws an error when there is no update provided', function() {
+      it('throws an error when there is no update provided', function () {
         const facilityUpdate = fixture.build('facility');
         const promise = facilities.update(facilityUpdate.id);
 
         return expect(promise).to.be.rejectedWith('An update is required to update a facility.');
       });
 
-      it('throws an error when the update is not an object', function() {
+      it('throws an error when the update is not an object', function () {
         const facilityUpdate = fixture.build('facility');
         const promise = facilities.update(facilityUpdate.id, [facilityUpdate]);
 

--- a/src/facilities/index.spec.js
+++ b/src/facilities/index.spec.js
@@ -404,7 +404,6 @@ describe('Facilities', function () {
           facilities.getAllByOrganizationId(expectedOrganizationId, {
             includeGroupings: true
           });
-          debugger;
           expect(request.get.firstCall.args).to.deep.include({
             params: {
               include_groupings: true

--- a/src/facilities/index.spec.js
+++ b/src/facilities/index.spec.js
@@ -165,12 +165,12 @@ describe('Facilities', function () {
         facilities = new Facilities(baseSdk, baseRequest);
       });
 
-      it('throws an error when there is no provided facility id', function () {
+      it('throws an error when there is no provided facility ID', function () {
         const facilityInfoUpdate = fixture.build('facilityInfo');
         const promise = facilities.createOrUpdateInfo(null, facilityInfoUpdate);
 
         return expect(promise).to.be
-          .rejectedWith("A facility id is required to update a facility's info.");
+          .rejectedWith("A facility ID is required to update a facility's info.");
       });
 
       it('throws an error when there is no update provided', function () {
@@ -192,7 +192,7 @@ describe('Facilities', function () {
   });
 
   describe('delete', function () {
-    context('the facility id is provided', function () {
+    context('the facility ID is provided', function () {
       let facility;
       let promise;
 
@@ -215,19 +215,19 @@ describe('Facilities', function () {
       });
     });
 
-    context('the facility id is not provided', function () {
+    context('the facility ID is not provided', function () {
       it('throws an error', function () {
         const facilities = new Facilities(baseSdk, baseRequest);
         const promise = facilities.delete();
 
         return expect(promise).to.be
-          .rejectedWith('A facility id is required for deleting a facility');
+          .rejectedWith('A facility ID is required for deleting a facility');
       });
     });
   });
 
   describe('get', function () {
-    context('the facility id is provided', function () {
+    context('the facility ID is provided', function () {
       let expectedFacilityId;
       let formatFacilityFromServer;
       let formattedFacility;
@@ -273,13 +273,13 @@ describe('Facilities', function () {
       });
     });
 
-    context('the facility id is not provided', function () {
+    context('the facility ID is not provided', function () {
       it('throws an error', function () {
         const facilities = new Facilities(baseSdk, baseRequest);
         const promise = facilities.get();
 
         return expect(promise).to.be
-          .rejectedWith('A facility id is required for getting information about a facility');
+          .rejectedWith('A facility ID is required for getting information about a facility');
       });
     });
   });
@@ -338,7 +338,7 @@ describe('Facilities', function () {
   });
 
   describe('getAllByOrganizationId', function () {
-    context('the organization id is provided', function () {
+    context('the organization ID is provided', function () {
       let expectedOrganizationId;
       let formatFacilityFromServer;
       let formattedFacilities;
@@ -401,14 +401,14 @@ describe('Facilities', function () {
         const promise = facilities.getAllByOrganizationId();
 
         return expect(promise).to.be.rejectedWith(
-          "An organization id is required for getting a list of an organization's facilities"
+          "An organization ID is required for getting a list of an organization's facilities"
         );
       });
     });
   });
 
   describe('getAllByOrganizationIdWithGroupings', function () {
-    context('the organization id is provided', function () {
+    context('the organization ID is provided', function () {
       let expectedOrganizationId;
       let formatFacilityFromServer;
       let formattedFacilities;
@@ -465,13 +465,13 @@ describe('Facilities', function () {
       });
     });
 
-    context('the organization id is not provided', function () {
+    context('the organization ID is not provided', function () {
       it('throws an error', function () {
         const facilities = new Facilities(baseSdk, baseRequest);
         const promise = facilities.getAllByOrganizationIdWithGroupings();
 
         return expect(promise).to.be.rejectedWith(
-          "An organization id is required for getting a list of an organization's facilities"
+          "An organization ID is required for getting a list of an organization's facilities"
         );
       });
     });
@@ -527,7 +527,7 @@ describe('Facilities', function () {
         const promise = facilities.update(null, facilityUpdate);
 
         return expect(promise).to.be
-          .rejectedWith('A facility id is required to update a facility.');
+          .rejectedWith('A facility ID is required to update a facility.');
       });
 
       it('throws an error when there is no update provided', function () {

--- a/src/utils/facilities/formatFacilityFromServer.js
+++ b/src/utils/facilities/formatFacilityFromServer.js
@@ -12,12 +12,12 @@ import {
  * @param {string} input.address2
  * @param {string} input.city
  * @param {string} input.created_at ISO 8601 Extended Format date/time string
- * @param {Object[]} [input.facilitiesGroupings]
- * @param {string} input.facilitiesGroupings[].created_at ISO 8601 Extended Format date/time string
- * @param {number} input.facilitiesGroupings[].facility_id ID corresponding with the parent facility
- * @param {number} input.facilitiesGroupings[].id
- * @param {string} input.facilitiesGroupings[].name
- * @param {string} input.facilitiesGroupings[].updated_at ISO 8601 Extended Format date/time string
+ * @param {Object[]}[input.facility_groupings]
+ * @param {string} [input.facility_groupings[].created_at] ISO 8601 Extended Format date/time string
+ * @param {number} [input.facility_groupings[].facility_id] ID corresponding with the parent facility
+ * @param {number} [input.facility_groupings[].id]
+ * @param {string} [input.facility_groupings[].name]
+ * @param {string} [input.facility_groupings[].updated_at] ISO 8601 Extended Format date/time string
  * @param {string} input.geometry_id UUID corresponding with a geometry
  * @param {number} input.id
  * @param {Object} [input.Info] User declared information
@@ -71,8 +71,8 @@ function formatFacilityFromServer(input = {}) {
     facility.tags = formatTagsFromServer(input.tags);
   }
 
-  if (input.facilitiesGroupings) {
-    facility.facilitiesGroupings = input.facilitiesGroupings.map(formatGroupingFromServer);
+  if (input.facility_groupings) {
+    facility.facilitiesGroupings = input.facility_groupings.map(formatGroupingFromServer);
   }
 
   return facility;

--- a/src/utils/facilities/formatFacilityFromServer.js
+++ b/src/utils/facilities/formatFacilityFromServer.js
@@ -1,6 +1,7 @@
 import {
   formatOrganizationFromServer,
-  formatTagsFromServer
+  formatTagsFromServer,
+  formatGroupingFromServer
 } from './index';
 
 /**
@@ -11,6 +12,12 @@ import {
  * @param {string} input.address2
  * @param {string} input.city
  * @param {string} input.created_at ISO 8601 Extended Format date/time string
+ * @param {Object[]} [input.facilitiesGroupings]
+ * @param {string} input.facilitiesGroupings[].created_at ISO 8601 Extended Format date/time string
+ * @param {number} input.facilitiesGroupings[].facility_id Id corresponding with the parent facility
+ * @param {number} input.facilitiesGroupings[].id
+ * @param {string} input.facilitiesGroupings[].name
+ * @param {string} input.facilitiesGroupings[].updated_at ISO 8601 Extended Format date/time string
  * @param {string} input.geometry_id UUID corresponding with a geometry
  * @param {number} input.id
  * @param {Object} [input.Info] User declared information
@@ -62,6 +69,12 @@ function formatFacilityFromServer(input = {}) {
 
   if (input.tags) {
     facility.tags = formatTagsFromServer(input.tags);
+  }
+
+  if (input.facilitiesGroupings) {
+    facility.facilitiesGroupings = input.facilitiesGroupings.map(grouping => {
+      return formatGroupingFromServer(grouping);
+    });
   }
 
   return facility;

--- a/src/utils/facilities/formatFacilityFromServer.js
+++ b/src/utils/facilities/formatFacilityFromServer.js
@@ -14,7 +14,7 @@ import {
  * @param {string} input.created_at ISO 8601 Extended Format date/time string
  * @param {Object[]} [input.facilitiesGroupings]
  * @param {string} input.facilitiesGroupings[].created_at ISO 8601 Extended Format date/time string
- * @param {number} input.facilitiesGroupings[].facility_id Id corresponding with the parent facility
+ * @param {number} input.facilitiesGroupings[].facility_id ID corresponding with the parent facility
  * @param {number} input.facilitiesGroupings[].id
  * @param {string} input.facilitiesGroupings[].name
  * @param {string} input.facilitiesGroupings[].updated_at ISO 8601 Extended Format date/time string
@@ -31,7 +31,7 @@ import {
  * @param {string} input.state
  * @param {Object[]} [input.tags]
  * @param {string} [input.tags[].created_at] ISO 8601 Extended Format date/time string
- * @param {number} [input.tags[].facility_id] Id corresponding with the parent facility
+ * @param {number} [input.tags[].facility_id] ID corresponding with the parent facility
  * @param {number} [input.tags[].id]
  * @param {string} [input.tags[].name]
  * @param {string} [input.tags[].updated_at] ISO 8601 Extended Format date/time string
@@ -72,9 +72,7 @@ function formatFacilityFromServer(input = {}) {
   }
 
   if (input.facilitiesGroupings) {
-    facility.facilitiesGroupings = input.facilitiesGroupings.map(grouping => {
-      return formatGroupingFromServer(grouping);
-    });
+    facility.facilitiesGroupings = input.facilitiesGroupings.map(formatGroupingFromServer);
   }
 
   return facility;

--- a/src/utils/facilities/formatFacilityFromServer.js
+++ b/src/utils/facilities/formatFacilityFromServer.js
@@ -72,7 +72,7 @@ function formatFacilityFromServer(input = {}) {
   }
 
   if (input.facility_groupings) {
-    facility.facilitiesGroupings = input.facility_groupings.map(formatGroupingFromServer);
+    facility.facility_groupings = input.facility_groupings.map(formatGroupingFromServer);
   }
 
   return facility;

--- a/src/utils/facilities/formatFacilityFromServer.spec.js
+++ b/src/utils/facilities/formatFacilityFromServer.spec.js
@@ -101,7 +101,7 @@ describe('utils/facilities/formatFacilityFromServer', function () {
       const facility = fixture.build('facility', null, {
         fromServer: true
       });
-      delete facility.facilitiesGroupings;
+      delete facility.facility_groupings;
       const formattedFacility = formatFacilityFromServer(facility);
 
       expect(formatGroupingFromServer).to.be.not.called;

--- a/src/utils/facilities/formatFacilityFromServer.spec.js
+++ b/src/utils/facilities/formatFacilityFromServer.spec.js
@@ -54,7 +54,9 @@ describe('utils/facilities/formatFacilityFromServer', function () {
     it('formats the necessary children objects', function () {
       expect(formatOrganizationFromServer).to.be.calledWith(facility.Organization);
       expect(formatTagsFromServer).to.be.calledWith(facility.tags);
-      expect(formatGroupingFromServer).to.be.calledWith(facility.facilitiesGroupings[0]);
+      facility.facility_groupings.forEach((grouping) =>
+        expect(formatGroupingFromServer).to.be.calledWith(grouping)
+      );
     });
 
     it('converts the object keys to the camelCase', function () {
@@ -103,7 +105,7 @@ describe('utils/facilities/formatFacilityFromServer', function () {
       const formattedFacility = formatFacilityFromServer(facility);
 
       expect(formatGroupingFromServer).to.be.not.called;
-      expect(formattedFacility).to.not.include.keys(['facilitiesGroupings']);
+      expect(formattedFacility).to.not.include.keys(['facility_groupings']);
     });
   });
 });

--- a/src/utils/facilities/formatFacilityFromServer.spec.js
+++ b/src/utils/facilities/formatFacilityFromServer.spec.js
@@ -2,74 +2,81 @@ import omit from 'lodash.omit';
 import formatFacilityFromServer from './formatFacilityFromServer';
 import * as facilitiesUtils from './index';
 
-describe('utils/facilities/formatFacilityFromServer', function() {
+describe('utils/facilities/formatFacilityFromServer', function () {
   let formatOrganizationFromServer;
   let formatTagsFromServer;
+  let formatGroupingFromServer;
 
-  beforeEach(function() {
+  beforeEach(function () {
     this.sandbox = sandbox.create();
 
     formatOrganizationFromServer = this.sandbox.stub(facilitiesUtils, 'formatOrganizationFromServer')
       .callsFake((organization) => organization);
     formatTagsFromServer = this.sandbox.stub(facilitiesUtils, 'formatTagsFromServer')
       .callsFake((tags) => tags);
+    formatGroupingFromServer = this.sandbox.stub(facilitiesUtils, 'formatGroupingFromServer')
+      .callsFake((grouping) => grouping);
   });
 
-  afterEach(function() {
+  afterEach(function () {
     this.sandbox.restore();
   });
 
-  context('when all possible fields are in the facility object', function() {
+  context('when all possible fields are in the facility object', function () {
     let expectedFacility;
     let facility;
     let formattedFacility;
 
-    beforeEach(function() {
-      facility = fixture.build('facility', null, { fromServer: true });
-      expectedFacility = omit(
-        {
-          ...facility,
-          createdAt: facility.created_at,
-          geometryId: facility.geometry_id,
-          info: facility.Info,
-          organization: facility.Organization,
-          organizationId: facility.organization_id,
-          weatherLocationId: facility.weather_location_id
-        },
-        [
-          'created_at',
-          'geometry_id',
-          'Info',
-          'Organization',
-          'organization_id',
-          'weather_location_id'
-        ]
-      );
+    beforeEach(function () {
+      facility = fixture.build('facility', null, {
+        fromServer: true
+      });
+      expectedFacility = omit({
+        ...facility,
+        createdAt: facility.created_at,
+        geometryId: facility.geometry_id,
+        info: facility.Info,
+        organization: facility.Organization,
+        organizationId: facility.organization_id,
+        weatherLocationId: facility.weather_location_id
+      }, [
+        'created_at',
+        'geometry_id',
+        'Info',
+        'Organization',
+        'organization_id',
+        'weather_location_id'
+      ]);
 
       formattedFacility = formatFacilityFromServer(facility);
     });
 
-    it('formats the necessary children objects', function() {
+    it('formats the necessary children objects', function () {
       expect(formatOrganizationFromServer).to.be.calledWith(facility.Organization);
       expect(formatTagsFromServer).to.be.calledWith(facility.tags);
+      expect(formatGroupingFromServer).to.be.calledWith(facility.facilitiesGroupings[0]);
     });
 
-    it('converts the object keys to the camelCase', function() {
+    it('converts the object keys to the camelCase', function () {
       expect(formattedFacility).to.deep.equal(expectedFacility);
     });
   });
 
-  context('when the facilities object does not have all possible keys', function() {
-    it('does not include the facility info if facility info is in the initial data', function() {
-      const facility = fixture.build('facility', null, { fromServer: true });
+  context('when the facilities object does not have all possible keys', function () {
+    it('does not include the facility info if facility info is in the initial data', function () {
+      const facility = fixture.build('facility', null, {
+        fromServer: true
+      });
       delete facility.Info;
       const formattedFacility = formatFacilityFromServer(facility);
 
       expect(formattedFacility).to.not.include.keys(['info']);
     });
 
-    it('does not include the organization if organization info is not in the initial data', function() {
-      const facility = fixture.build('facility', null, { fromServer: true });
+    it('does not include the organization if organization info is not in the initial data', function () {
+      const facility = fixture.build('facility', null, {
+        fromServer: true
+      });
       delete facility.Organization;
       const formattedFacility = formatFacilityFromServer(facility);
 
@@ -77,13 +84,26 @@ describe('utils/facilities/formatFacilityFromServer', function() {
       expect(formattedFacility).to.not.include.keys(['organization']);
     });
 
-    it('does not include the tags if tags are not in the initial data', function() {
-      const facility = fixture.build('facility', null, { fromServer: true });
+    it('does not include the tags if tags are not in the initial data', function () {
+      const facility = fixture.build('facility', null, {
+        fromServer: true
+      });
       delete facility.tags;
       const formattedFacility = formatFacilityFromServer(facility);
 
       expect(formatTagsFromServer).to.be.not.called;
       expect(formattedFacility).to.not.include.keys(['tags']);
+    });
+
+    it('does not include the facilities groupings if groupings are not in the initial data', function () {
+      const facility = fixture.build('facility', null, {
+        fromServer: true
+      });
+      delete facility.facilitiesGroupings;
+      const formattedFacility = formatFacilityFromServer(facility);
+
+      expect(formatGroupingFromServer).to.be.not.called;
+      expect(formattedFacility).to.not.include.keys(['facilitiesGroupings']);
     });
   });
 });

--- a/src/utils/facilities/formatFacilityOptionsToServer.js
+++ b/src/utils/facilities/formatFacilityOptionsToServer.js
@@ -1,0 +1,24 @@
+/**
+ * Normalizes the options provided when retrieving facilities
+ *
+ * @param {Object} options
+ * @param {Boolean} [options.includeGroupings] Boolean flag for including groupings data with each facility
+ *
+ * @returns {Object} output
+ * @returns {Boolean} output.include_groupings
+ *
+ * @private
+ */
+
+function formatFacilityOptionsToServer(options) {
+  const output = {
+    ...options,
+    include_groupings: options && options.includeGroupings ? options.includeGroupings : false
+  };
+
+  delete output.includeGroupings;
+
+  return output;
+}
+
+export default formatFacilityOptionsToServer;

--- a/src/utils/facilities/formatFacilityOptionsToServer.spec.js
+++ b/src/utils/facilities/formatFacilityOptionsToServer.spec.js
@@ -1,4 +1,3 @@
-import omit from 'lodash.omit';
 import times from 'lodash.times';
 import formatFacilityOptionsToServer from './formatFacilityOptionsToServer';
 

--- a/src/utils/facilities/formatFacilityOptionsToServer.spec.js
+++ b/src/utils/facilities/formatFacilityOptionsToServer.spec.js
@@ -1,0 +1,51 @@
+import omit from 'lodash.omit';
+import times from 'lodash.times';
+import formatFacilityOptionsToServer from './formatFacilityOptionsToServer';
+
+describe('utils/facilities/formatFacilityOptionsToServer', function () {
+  it('provides a default object if no options passed', function () {
+    const options = formatFacilityOptionsToServer();
+    expect(options).to.deep.equal({
+      include_groupings: false
+    });
+  });
+
+  it('provides an object that includes any custom options', function () {
+    const customOptions = times(faker.random.number({
+      min: 1,
+      max: 10
+    })).reduce(memo => {
+      memo[faker.hacker.adjective()] = faker.helpers.createTransaction();
+      return memo;
+    }, {});
+
+    const expectedOptions = Object.assign({}, customOptions, {
+      include_groupings: false
+    });
+
+    const options = formatFacilityOptionsToServer(customOptions);
+
+    expect(options).to.deep.equal(expectedOptions);
+  });
+
+  it('provides an object that includes the `include_groupings` that the API service can understand', function () {
+    const expectedIncludeGroupings = faker.random.boolean();
+    const customOptions = times(faker.random.number({
+      min: 1,
+      max: 10
+    })).reduce(memo => {
+      memo[faker.hacker.adjective()] = faker.helpers.createTransaction();
+      return memo;
+    }, {});
+
+    const expectedOptions = Object.assign({}, customOptions, {
+      include_groupings: expectedIncludeGroupings
+    });
+
+    const options = formatFacilityOptionsToServer({ ...customOptions,
+      includeGroupings: expectedIncludeGroupings
+    });
+
+    expect(options).to.deep.equal(expectedOptions);
+  });
+});

--- a/src/utils/facilities/formatFacilityToServer.spec.js
+++ b/src/utils/facilities/formatFacilityToServer.spec.js
@@ -16,14 +16,14 @@ describe('utils/facilities/formatFacilityToServer', function () {
       weather_location_id: facility.weatherLocationId
     }, [
       'createdAt',
+      'facility_groupings',
       'geometryId',
       'id',
       'info',
       'organization',
       'organizationId',
       'tags',
-      'weatherLocationId',
-      'facilitiesGroupings'
+      'weatherLocationId'
     ]);
 
     formattedFacility = formatFacilityToServer(facility);

--- a/src/utils/facilities/formatFacilityToServer.spec.js
+++ b/src/utils/facilities/formatFacilityToServer.spec.js
@@ -1,37 +1,35 @@
 import omit from 'lodash.omit';
 import formatFacilityToServer from './formatFacilityToServer';
 
-describe('utils/facilities/formatFacilityToServer', function() {
+describe('utils/facilities/formatFacilityToServer', function () {
   let expectedFacility;
   let facility;
   let formattedFacility;
 
-  beforeEach(function() {
+  beforeEach(function () {
     facility = fixture.build('facility');
-    expectedFacility = omit(
-      {
-        ...facility,
-        geometry_id: facility.geometryId,
-        Info: facility.info,
-        organization_id: facility.organizationId,
-        weather_location_id: facility.weatherLocationId
-      },
-      [
-        'createdAt',
-        'geometryId',
-        'id',
-        'info',
-        'organization',
-        'organizationId',
-        'tags',
-        'weatherLocationId'
-      ]
-    );
+    expectedFacility = omit({
+      ...facility,
+      geometry_id: facility.geometryId,
+      Info: facility.info,
+      organization_id: facility.organizationId,
+      weather_location_id: facility.weatherLocationId
+    }, [
+      'createdAt',
+      'geometryId',
+      'id',
+      'info',
+      'organization',
+      'organizationId',
+      'tags',
+      'weatherLocationId',
+      'facilitiesGroupings'
+    ]);
 
     formattedFacility = formatFacilityToServer(facility);
   });
 
-  it('converts the object keys to snake case and capitalizes certain keys', function() {
+  it('converts the object keys to snake case and capitalizes certain keys', function () {
     expect(formattedFacility).to.deep.equal(expectedFacility);
   });
 });

--- a/src/utils/facilities/formatGroupingToServer.js
+++ b/src/utils/facilities/formatGroupingToServer.js
@@ -3,13 +3,13 @@
  *
  * @param {FacilityGrouping} input
  *
- * @param {Object} output
- * @param {string} output.description
- * @param {boolean} output.is_private
- * @param {string} output.name
- * @param {string} output.organization_id UUID
- * @param {string} output.owner_id Auth0 identifer of the owner
- * @param {string} output.parent_grouping_id UUID
+ * @returns {Object} output
+ * @returns {string} output.description
+ * @returns {boolean} output.is_private
+ * @returns {string} output.name
+ * @returns {string} output.organization_id UUID
+ * @returns {string} output.owner_id Auth0 identifer of the owner
+ * @returns {string} output.parent_grouping_id UUID
  *
  * @private
  */

--- a/src/utils/facilities/index.js
+++ b/src/utils/facilities/index.js
@@ -1,5 +1,6 @@
 import formatFacilityFromServer from './formatFacilityFromServer';
 import formatFacilityToServer from './formatFacilityToServer';
+import formatFacilityOptionsToServer from './formatFacilityOptionsToServer';
 import formatGroupingFacilityFromServer from './formatGroupingFacilityFromServer';
 import formatGroupingFromServer from './formatGroupingFromServer';
 import formatGroupingToServer from './formatGroupingToServer';
@@ -9,6 +10,7 @@ import formatTagsFromServer from './formatTagsFromServer';
 export {
   formatFacilityFromServer,
   formatFacilityToServer,
+  formatFacilityOptionsToServer,
   formatGroupingFacilityFromServer,
   formatGroupingFromServer,
   formatGroupingToServer,

--- a/support/fixtures/factories/facility.js
+++ b/support/fixtures/factories/facility.js
@@ -28,12 +28,33 @@ factory.define('facility')
   })
   .attr('name', ['city'], (city) => `${faker.address.cityPrefix()} ${city}`)
   .attr('organization', ['fromServer'], (fromServer) => {
-    return factory.build('organization', null, { fromServer });
+    return factory.build('organization', null, {
+      fromServer
+    });
   })
   .attr('organizationId', ['organization'], (organization) => organization.id)
   .attr('tags', ['id', 'fromServer'], (id, fromServer) => {
-    return times(faker.random.number({ min: 0, max: 5 }), () => {
-      return factory.build('facilityTag', { facilityId: id }, { fromServer });
+    return times(faker.random.number({
+      min: 0,
+      max: 5
+    }), () => {
+      return factory.build('facilityTag', {
+        facilityId: id
+      }, {
+        fromServer
+      });
+    });
+  })
+  .attr('facilitiesGroupings', ['id', 'fromServer'], (id, fromServer) => {
+    return times(faker.random.number({
+      min: 0,
+      max: 5
+    }), () => {
+      return factory.build('facilityGrouping', {
+        facilityId: id
+      }, {
+        fromServer
+      });
     });
   })
   .after((facility, options) => {

--- a/support/fixtures/factories/facility.js
+++ b/support/fixtures/factories/facility.js
@@ -26,6 +26,18 @@ factory.define('facility')
     weatherLocationId: () => null,
     zip: () => faker.address.zipCode()
   })
+  .attr('facility_groupings', ['id', 'fromServer'], (id, fromServer) => {
+    return times(faker.random.number({
+      min: 0,
+      max: 5
+    }), () => {
+      return factory.build('facilityGrouping', {
+        facilityId: id
+      }, {
+        fromServer
+      });
+    });
+  })
   .attr('name', ['city'], (city) => `${faker.address.cityPrefix()} ${city}`)
   .attr('organization', ['fromServer'], (fromServer) => {
     return factory.build('organization', null, {
@@ -45,24 +57,15 @@ factory.define('facility')
       });
     });
   })
-  .attr('facilitiesGroupings', ['id', 'fromServer'], (id, fromServer) => {
-    return times(faker.random.number({
-      min: 0,
-      max: 5
-    }), () => {
-      return factory.build('facilityGrouping', {
-        facilityId: id
-      }, {
-        fromServer
-      });
-    });
-  })
   .after((facility, options) => {
     // If building a facility object that comes from the server, transform it to have camel case and
     // capital letters in the right spots
     if (options.fromServer) {
       facility.created_at = facility.createdAt;
       delete facility.createdAt;
+
+      facility.facility_grouping = facility.facilityGrouping;
+      delete facility.facilityGrouping;
 
       facility.geometry_id = facility.geometryId;
       delete facility.geometryId;

--- a/support/fixtures/factories/facility.js
+++ b/support/fixtures/factories/facility.js
@@ -64,9 +64,6 @@ factory.define('facility')
       facility.created_at = facility.createdAt;
       delete facility.createdAt;
 
-      facility.facility_grouping = facility.facilityGrouping;
-      delete facility.facilityGrouping;
-
       facility.geometry_id = facility.geometryId;
       delete facility.geometryId;
 


### PR DESCRIPTION
## Why?
Need the ability to retrieve data of what groupings a facility belongs to.

## What changed?
Adding a method for passing a query param to the facilities service to include facilities groupings data in payload.
Also, prettier ran on the files I touched.


Depends on sustainableis/facilities-service#26