### PR TITLE
Add ability to attach custom Axios interceptors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## [v0.0.12](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.12) (2018-06-13)
+## [v0.0.13](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.13) (2018-06-14)
+
+* Adds the ability to set up custom axios interceptors to be used on each request and response made to an API. (More information available at at {@link https://github.com/axios/axios#interceptors axios Interceptors})
+
+## [v0.0.12](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.12) (2018-06-14)
 
 **Changed**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [v0.0.13](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.13) (2018-06-14)
+## [v0.0.13](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.13) (2018-06-16)
 
 * Adds the ability to set up custom axios interceptors to be used on each request and response made to an API. (More information available at at {@link https://github.com/axios/axios#interceptors axios Interceptors})
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,10 @@ which are obtained from Auth0.</p>
 </dd>
 <dt><a href="./Typedefs.md#Auth0WebAuthSessionInfo">Auth0WebAuthSessionInfo</a> : <code>Object</code></dt>
 <dd></dd>
+<dt><a href="./Typedefs.md#AxiosInterceptor">AxiosInterceptor</a> : <code>Object</code></dt>
+<dd><p>An object of interceptors that get called on every request or response.
+More information at <a href="https://github.com/axios/axios#interceptors">axios Interceptors</a></p>
+</dd>
 <dt><a href="./Typedefs.md#CostCenter">CostCenter</a> : <code>Object</code></dt>
 <dd></dd>
 <dt><a href="./Typedefs.md#CostCenterFacility">CostCenterFacility</a> : <code>Object</code></dt>

--- a/docs/Typedefs.md
+++ b/docs/Typedefs.md
@@ -24,6 +24,20 @@ A single audience used for authenticating and communicating with an individual A
 | apiToken    | <code>string</code> |
 | expiresAt   | <code>number</code> |
 
+<a name="AxiosInterceptor"></a>
+
+## AxiosInterceptor : <code>Object</code>
+
+An object of interceptors that get called on every request or response.
+More information at [axios Interceptors](https://github.com/axios/axios#interceptors)
+
+**Kind**: global typedef
+
+| Param                 | Type                  | Description                                                    |
+| --------------------- | --------------------- | -------------------------------------------------------------- |
+| interceptor.fulfilled | <code>function</code> | A function that is run on every successful request or response |
+| interceptor.rejected  | <code>function</code> | A function that is run on every failed request or response     |
+
 <a name="CostCenter"></a>
 
 ## CostCenter : <code>Object</code>
@@ -201,16 +215,19 @@ User provided configuration options
 **Kind**: global typedef  
 **Properties**
 
-| Name                          | Type                                               | Default                                                                 | Description                                                                                                                                                            |
-| ----------------------------- | -------------------------------------------------- | ----------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| auth                          | <code>Object</code>                                |                                                                         | User assigned configurations specific for their authentication methods                                                                                                 |
-| [auth.authorizationPath]      | <code>string</code>                                |                                                                         | Path Auth0WebAuth process should redirect to after a successful sign in attempt                                                                                        |
-| auth.clientId                 | <code>string</code>                                |                                                                         | Client Id provided by Auth0 for this application                                                                                                                       |
-| [auth.clientSecret]           | <code>string</code>                                |                                                                         | Client secret provided by Auth0 for this application. This is optional for the auth0WebAuth SessionType, but required for the machineAuth SessionType                  |
-| [auth.customModuleConfigs]    | <code>Object.&lt;string, CustomAudience&gt;</code> |                                                                         | Custom environment setups for individual modules. Requires clientId/host or env                                                                                        |
-| [auth.env]                    | <code>string</code>                                | <code>&quot;&#x27;production&#x27;&quot;</code>                         | The environment that every module should use for their clientId and host                                                                                               |
-| [auth.onRedirect]             | <code>function</code>                              | <code>(pathname) &#x3D;&gt; { window.location &#x3D; pathname; }</code> | A redirect method used for navigating through Auth0 callbacks in Web applications                                                                                      |
-| [auth.tokenExpiresAtBufferMs] | <code>number</code>                                | <code>300000</code>                                                     | The time (in milliseconds) before a token truly expires that we consider it expired (i.e. the token's expiresAt - this = calculated expiresAt). Defaults to 5 minutes. |
+| Name                          | Type                                                             | Default                                                                 | Description                                                                                                                                                            |
+| ----------------------------- | ---------------------------------------------------------------- | ----------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| auth                          | <code>Object</code>                                              |                                                                         | User assigned configurations specific for their authentication methods                                                                                                 |
+| [auth.authorizationPath]      | <code>string</code>                                              |                                                                         | Path Auth0WebAuth process should redirect to after a successful sign in attempt                                                                                        |
+| auth.clientId                 | <code>string</code>                                              |                                                                         | Client Id provided by Auth0 for this application                                                                                                                       |
+| [auth.clientSecret]           | <code>string</code>                                              |                                                                         | Client secret provided by Auth0 for this application. This is optional for the auth0WebAuth SessionType, but required for the machineAuth SessionType                  |
+| [auth.customModuleConfigs]    | <code>Object.&lt;string, CustomAudience&gt;</code>               |                                                                         | Custom environment setups for individual modules. Requires clientId/host or env                                                                                        |
+| [auth.env]                    | <code>string</code>                                              | <code>&quot;&#x27;production&#x27;&quot;</code>                         | The environment that every module should use for their clientId and host                                                                                               |
+| [auth.onRedirect]             | <code>function</code>                                            | <code>(pathname) &#x3D;&gt; { window.location &#x3D; pathname; }</code> | A redirect method used for navigating through Auth0 callbacks in Web applications                                                                                      |
+| [auth.tokenExpiresAtBufferMs] | <code>number</code>                                              | <code>300000</code>                                                     | The time (in milliseconds) before a token truly expires that we consider it expired (i.e. the token's expiresAt - this = calculated expiresAt). Defaults to 5 minutes. |
+| [interceptors]                | <code>Object</code>                                              |                                                                         | Axios interceptors that can transform requests and responses. More information at [axios Interceptors](https://github.com/axios/axios#interceptors)                    |
+| [interceptors.request]        | [<code>Array.&lt;AxiosInterceptor&gt;</code>](#AxiosInterceptor) |                                                                         | Interceptors that act on every request                                                                                                                                 |
+| [intercepotrs.response]       | [<code>Array.&lt;AxiosInterceptor&gt;</code>](#AxiosInterceptor) |                                                                         | Intereptors that act on every response                                                                                                                                 |
 
 <a name="UserProfile"></a>
 

--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -2,5 +2,9 @@ export default {
   auth: {
     authorizationPath: '/callback',
     tokenExpiresAtBufferMs: 5 * 60 * 1000 // 5 minutes
+  },
+  interceptors: {
+    request: [],
+    response: []
   }
 };

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -99,6 +99,11 @@ class Config {
       ...defaultConfigs.auth,
       ...userConfig.auth
     };
+
+    this.interceptors = {
+      ...defaultConfigs.interceptors,
+      ...userConfig.interceptors
+    };
   }
 
   /**

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -41,6 +41,16 @@ import defaultConfigs from './defaults';
  */
 
 /**
+ * An object of interceptors that get called on every request or response.
+ * More information at {@link https://github.com/axios/axios#interceptors axios Interceptors}
+ *
+ * @typedef {Object} AxiosInterceptor
+ * @param {function} interceptor.fulfilled A function that is run on every successful request or
+ *   response
+ * @param {function} interceptor.rejected A function that is run on every failed request or response
+ */
+
+/**
  * User provided configuration options
  *
  * @typedef {Object} UserConfig
@@ -59,6 +69,10 @@ import defaultConfigs from './defaults';
  * @property {number} [auth.tokenExpiresAtBufferMs = 300000] The time (in milliseconds) before a
  *   token truly expires that we consider it expired (i.e. the token's expiresAt - this = calculated
  *   expiresAt). Defaults to 5 minutes.
+ * @property {Object} [interceptors] Axios interceptors that can transform requests and responses.
+ *   More information at {@link https://github.com/axios/axios#interceptors axios Interceptors}
+ * @property {AxiosInterceptor[]} [interceptors.request] Interceptors that act on every request
+ * @property {AxiosInterceptor[]} [intercepotrs.response] Intereptors that act on every response
  */
 
 /**

--- a/src/config/index.spec.js
+++ b/src/config/index.spec.js
@@ -13,15 +13,16 @@ describe('Config', function() {
   });
 
   describe('constructor', function() {
-    let baseAuthConfigs;
+    let authConfigs;
     let baseConfigs;
     let config;
     let expectedAudiences;
     let expectedExternalModules;
     let getAudiences;
+    let interceptorConfigs;
 
     beforeEach(function() {
-      baseAuthConfigs = {
+      authConfigs = {
         clientId: faker.internet.password(),
         customModuleConfigs: {
           [faker.hacker.adjective()]: fixture.build('audience')
@@ -38,13 +39,21 @@ describe('Config', function() {
           module: function() {}
         }
       };
+      interceptorConfigs = {
+        [faker.lorem.word()]: [
+          {
+            fulfilled: function() {},
+            rejected: function() {}
+          }
+        ]
+      };
 
       getAudiences = this.sandbox
         .stub(Config.prototype, '_getAudiences')
         .returns(expectedAudiences);
 
       config = new Config(
-        { ...baseConfigs, auth: baseAuthConfigs },
+        { ...baseConfigs, auth: authConfigs, interceptors: interceptorConfigs },
         expectedExternalModules
       );
     });
@@ -55,8 +64,8 @@ describe('Config', function() {
 
     it('gets a list of audiences for the environment', function() {
       expect(getAudiences).to.be.calledWith({
-        customModuleConfigs: baseAuthConfigs.customModuleConfigs,
-        env: baseAuthConfigs.env,
+        customModuleConfigs: authConfigs.customModuleConfigs,
+        env: authConfigs.env,
         externalModules: expectedExternalModules
       });
     });
@@ -70,7 +79,15 @@ describe('Config', function() {
     });
 
     it('assigns the provided user auth configurations to the new config', function() {
-      expect(config.auth).to.include(baseAuthConfigs);
+      expect(config.auth).to.include(authConfigs);
+    });
+
+    it('assigns the default interceptors to the new config', function() {
+      expect(config.interceptors).to.include(defaultConfigs.interceptors);
+    });
+
+    it('assings the provided user interceptors to the new config', function() {
+      expect(config.interceptors).to.include(interceptorConfigs);
     });
   });
 

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -129,7 +129,10 @@ describe('ContxtSdk', function() {
       expectedAudienceName = faker.hacker.noun();
       expectedInstance = {
         config: {
-          interceptors: {}
+          interceptors: {
+            request: [],
+            response: []
+          }
         }
       };
 

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -127,7 +127,11 @@ describe('ContxtSdk', function() {
 
     beforeEach(function() {
       expectedAudienceName = faker.hacker.noun();
-      expectedInstance = {};
+      expectedInstance = {
+        config: {
+          interceptors: {}
+        }
+      };
 
       request = ContxtSdk.prototype._createRequest.call(
         expectedInstance,

--- a/src/request.js
+++ b/src/request.js
@@ -12,7 +12,7 @@ class Request {
     this._insertHeaders = this._insertHeaders.bind(this);
     this._sdk = sdk;
 
-    this._attachInterceptors(this._axios);
+    this._attachInterceptors();
   }
 
   /**

--- a/src/request.js
+++ b/src/request.js
@@ -112,11 +112,9 @@ class Request {
   _attachInterceptors() {
     const requestInterceptors = [
       { fulfilled: this._insertHeaders },
-      ...(this._sdk.config.interceptors.request || [])
+      ...this._sdk.config.interceptors.request
     ];
-    const responseInterceptors = [
-      ...(this._sdk.config.interceptors.response || [])
-    ];
+    const responseInterceptors = [...this._sdk.config.interceptors.response];
 
     requestInterceptors.forEach(({ fulfilled, rejected }) => {
       this._axios.interceptors.request.use(fulfilled, rejected);

--- a/src/request.spec.js
+++ b/src/request.spec.js
@@ -13,10 +13,17 @@ describe('Request', function() {
       interceptors: {
         request: {
           use: this.sandbox.stub()
+        },
+        response: {
+          use: this.sandbox.stub()
         }
       }
     };
-    baseSdk = {};
+    baseSdk = {
+      config: {
+        interceptors: {}
+      }
+    };
   });
 
   afterEach(function() {
@@ -24,6 +31,7 @@ describe('Request', function() {
   });
 
   describe('constructor', function() {
+    let attachInterceptors;
     let create;
     let expectedAudienceName;
     let request;
@@ -31,6 +39,10 @@ describe('Request', function() {
     beforeEach(function() {
       expectedAudienceName = faker.hacker.noun();
 
+      attachInterceptors = this.sandbox.stub(
+        Request.prototype,
+        '_attachInterceptors'
+      );
       create = this.sandbox.stub(axios, 'create').returns(baseAxiosInstance);
 
       request = new Request(baseSdk, expectedAudienceName);
@@ -40,22 +52,21 @@ describe('Request', function() {
       expect(request._audienceName).to.equal(expectedAudienceName);
     });
 
-    it('appends the supplied sdk to the class instance', function() {
-      expect(request._sdk).to.equal(baseSdk);
-    });
-
     it('creates an axios instance and appends it to the class instance', function() {
       expect(create).to.be.calledOnce;
       expect(request._axios).to.equal(baseAxiosInstance);
     });
 
+    it('binds and appends the `insertHeaders` method to the class instance', function() {
+      expect(request._insertHeaders.name).to.equal('bound _insertHeaders');
+    });
+
+    it('appends the supplied sdk to the class instance', function() {
+      expect(request._sdk).to.equal(baseSdk);
+    });
+
     it("sets up axios's interceptors", function() {
-      expect(baseAxiosInstance.interceptors.request.use).to.be.calledOnce;
-      const [
-        requestInterceptor
-      ] = baseAxiosInstance.interceptors.request.use.firstCall.args;
-      expect(requestInterceptor).to.be.a('function');
-      expect(requestInterceptor).to.equal(request._insertHeaders);
+      expect(attachInterceptors).to.be.calledWith(request._axios);
     });
   });
 
@@ -101,6 +112,73 @@ describe('Request', function() {
         return expect(response).to.be.fulfilled.and.to.eventually.equal(
           expectedResponse
         );
+      });
+    });
+  });
+
+  describe('_attachInterceptors', function() {
+    let expectedRequestInterceptors;
+    let expectedResponseInterceptors;
+    let requestUse;
+    let responseUse;
+
+    beforeEach(function() {
+      /* eslint-disable no-new-func */
+      const requestInterceptors = times(
+        faker.random.number({ min: 0, max: 10 }),
+        () => {
+          return {
+            fulfilled: new Function(),
+            rejected: new Function()
+          };
+        }
+      );
+      const responseInterceptors = times(
+        faker.random.number({ min: 0, max: 10 }),
+        () => {
+          return {
+            fulfilled: new Function(),
+            rejected: new Function()
+          };
+        }
+      );
+      /* eslint-enable no-new-func */
+      expectedRequestInterceptors = [
+        { fulfilled: Request.prototype._insertHeaders }
+      ].concat(requestInterceptors);
+      expectedResponseInterceptors = responseInterceptors;
+
+      requestUse = this.sandbox.stub();
+      responseUse = this.sandbox.stub();
+
+      Request.prototype._attachInterceptors.call({
+        _axios: {
+          interceptors: {
+            request: { use: requestUse },
+            response: { use: responseUse }
+          }
+        },
+        _insertHeaders: Request.prototype._insertHeaders,
+        _sdk: {
+          config: {
+            interceptors: {
+              request: requestInterceptors,
+              response: responseInterceptors
+            }
+          }
+        }
+      });
+    });
+
+    it('sets up the request interceptors', function() {
+      expectedRequestInterceptors.forEach(({ fulfilled, rejected }) => {
+        expect(requestUse).to.be.calledWith(fulfilled, rejected);
+      });
+    });
+
+    it('sets up the response interceptors', function() {
+      expectedResponseInterceptors.forEach(({ fulfilled, rejected }) => {
+        expect(responseUse).to.be.calledWith(fulfilled, rejected);
       });
     });
   });

--- a/src/request.spec.js
+++ b/src/request.spec.js
@@ -21,7 +21,10 @@ describe('Request', function() {
     };
     baseSdk = {
       config: {
-        interceptors: {}
+        interceptors: {
+          request: [],
+          response: []
+        }
       }
     };
   });

--- a/src/request.spec.js
+++ b/src/request.spec.js
@@ -69,7 +69,7 @@ describe('Request', function() {
     });
 
     it("sets up axios's interceptors", function() {
-      expect(attachInterceptors).to.be.calledWith(request._axios);
+      expect(attachInterceptors).to.be.calledOnce;
     });
   });
 
@@ -126,13 +126,12 @@ describe('Request', function() {
     let responseUse;
 
     beforeEach(function() {
-      /* eslint-disable no-new-func */
       const requestInterceptors = times(
         faker.random.number({ min: 0, max: 10 }),
         () => {
           return {
-            fulfilled: new Function(),
-            rejected: new Function()
+            fulfilled: this.sandbox.stub(),
+            rejected: this.sandbox.stub()
           };
         }
       );
@@ -140,12 +139,11 @@ describe('Request', function() {
         faker.random.number({ min: 0, max: 10 }),
         () => {
           return {
-            fulfilled: new Function(),
-            rejected: new Function()
+            fulfilled: this.sandbox.stub(),
+            rejected: this.sandbox.stub()
           };
         }
       );
-      /* eslint-enable no-new-func */
       expectedRequestInterceptors = [
         { fulfilled: Request.prototype._insertHeaders }
       ].concat(requestInterceptors);


### PR DESCRIPTION
## Why?
It is important that requests and responses can be handled in custom ways (e.g. to automatically call a custom error handler on every response).

## What changed?
- Added a way to add custom Axios interceptors to the Request module