### PR TITLE
Add asset_id to the facility model

### DIFF
--- a/src/facilities/index.js
+++ b/src/facilities/index.js
@@ -11,6 +11,7 @@ import {
  * @typedef {Object} Facility
  * @property {string} [address1]
  * @property {string} [address2]
+ * @property {string} [assetId] UUID corresponding with an asset
  * @property {string} [city]
  * @property {string} createdAt ISO 8601 Extended Format date/time string
  * @property {string} [geometryId] UUID corresponding with a geometry
@@ -73,6 +74,7 @@ class Facilities {
    * @param {string} facility.timezone
    * @param {number} [facility.weatherLocationId]
    * @param {string} [facility.zip]
+   * @param {string} [facility.assetId] UUID corresponding with an asset
    *
    * @returns {Promise}
    * @fulfill {Facility} Information about the new facility
@@ -300,6 +302,7 @@ class Facilities {
    * @param {string} [update.timezone]
    * @param {number} [update.weatherLocationId]
    * @param {string} [update.zip]
+   * @param {string} [update.assetId] UUID corresponding with an asset
    *
    * @returns {Promise}
    * @fulfill {undefined}

--- a/src/facilities/index.js
+++ b/src/facilities/index.js
@@ -66,6 +66,7 @@ class Facilities {
    * @param {Object} facility
    * @param {string} [facility.address1]
    * @param {string} [facility.address2]
+   * @param {string} [facility.assetId] UUID corresponding with an asset
    * @param {string} [facility.city]
    * @param {string} [facility.geometryId] UUID corresponding with a geometry
    * @param {string} facility.name
@@ -74,7 +75,6 @@ class Facilities {
    * @param {string} facility.timezone
    * @param {number} [facility.weatherLocationId]
    * @param {string} [facility.zip]
-   * @param {string} [facility.assetId] UUID corresponding with an asset
    *
    * @returns {Promise}
    * @fulfill {Facility} Information about the new facility
@@ -293,6 +293,7 @@ class Facilities {
    * @param {Object} update An object containing the updated data for the facility
    * @param {string} [update.address1]
    * @param {string} [update.address2]
+   * @param {string} [update.assetId] UUID corresponding with an asset
    * @param {string} [update.city]
    * @param {string} [update.geometryId] UUID corresponding with a geometry
    * @param {Object} [update.info] User declared information
@@ -302,7 +303,6 @@ class Facilities {
    * @param {string} [update.timezone]
    * @param {number} [update.weatherLocationId]
    * @param {string} [update.zip]
-   * @param {string} [update.assetId] UUID corresponding with an asset
    *
    * @returns {Promise}
    * @fulfill {undefined}

--- a/src/utils/facilities/formatFacilityFromServer.js
+++ b/src/utils/facilities/formatFacilityFromServer.js
@@ -46,6 +46,7 @@ import {
  * @param {string} input.timezone An IANA Time Zone Database string, i.e. America/Los_Angeles
  * @param {string} input.weather_location_id
  * @param {string} input.zip
+ * @param {string} input.asset_id UUID corresponding with an asset
  *
  * @returns {Facility}
  *
@@ -64,7 +65,8 @@ function formatFacilityFromServer(input = {}) {
     state: input.state,
     timezone: input.timezone,
     weatherLocationId: input.weather_location_id,
-    zip: input.zip
+    zip: input.zip,
+    assetId: input.asset_id
   };
 
   if (input.Info) {

--- a/src/utils/facilities/formatFacilityFromServer.js
+++ b/src/utils/facilities/formatFacilityFromServer.js
@@ -11,6 +11,7 @@ import {
  * @param {Object} input
  * @param {string} input.address1
  * @param {string} input.address2
+ * @param {string} [input.asset_id] UUID corresponding with an asset
  * @param {string} input.city
  * @param {Object[]} [input.cost_centers]
  * @param {string} [input.cost_centers[].created_at] ISO 8601 Extended Format date/time string
@@ -46,7 +47,6 @@ import {
  * @param {string} input.timezone An IANA Time Zone Database string, i.e. America/Los_Angeles
  * @param {string} input.weather_location_id
  * @param {string} input.zip
- * @param {string} input.asset_id UUID corresponding with an asset
  *
  * @returns {Facility}
  *
@@ -56,6 +56,7 @@ function formatFacilityFromServer(input = {}) {
   const facility = {
     address1: input.address1,
     address2: input.address2,
+    assetId: input.asset_id,
     city: input.city,
     createdAt: input.created_at,
     geometryId: input.geometry_id,
@@ -65,8 +66,7 @@ function formatFacilityFromServer(input = {}) {
     state: input.state,
     timezone: input.timezone,
     weatherLocationId: input.weather_location_id,
-    zip: input.zip,
-    assetId: input.asset_id
+    zip: input.zip
   };
 
   if (input.Info) {

--- a/src/utils/facilities/formatFacilityFromServer.spec.js
+++ b/src/utils/facilities/formatFacilityFromServer.spec.js
@@ -37,22 +37,22 @@ describe('utils/facilities/formatFacilityFromServer', function() {
       expectedFacility = omit(
         {
           ...facility,
+          assetId: facility.asset_id,
           createdAt: facility.created_at,
           geometryId: facility.geometry_id,
           info: facility.Info,
           organization: facility.Organization,
           organizationId: facility.organization_id,
-          weatherLocationId: facility.weather_location_id,
-          assetId: facility.asset_id
+          weatherLocationId: facility.weather_location_id
         },
         [
+          'asset_id',
           'created_at',
           'geometry_id',
           'Info',
           'Organization',
           'organization_id',
-          'weather_location_id',
-          'asset_id'
+          'weather_location_id'
         ]
       );
 

--- a/src/utils/facilities/formatFacilityFromServer.spec.js
+++ b/src/utils/facilities/formatFacilityFromServer.spec.js
@@ -42,7 +42,8 @@ describe('utils/facilities/formatFacilityFromServer', function() {
           info: facility.Info,
           organization: facility.Organization,
           organizationId: facility.organization_id,
-          weatherLocationId: facility.weather_location_id
+          weatherLocationId: facility.weather_location_id,
+          assetId: facility.asset_id
         },
         [
           'created_at',
@@ -50,7 +51,8 @@ describe('utils/facilities/formatFacilityFromServer', function() {
           'Info',
           'Organization',
           'organization_id',
-          'weather_location_id'
+          'weather_location_id',
+          'asset_id'
         ]
       );
 

--- a/src/utils/facilities/formatFacilityToServer.js
+++ b/src/utils/facilities/formatFacilityToServer.js
@@ -6,6 +6,7 @@
  * @returns {Object} output
  * @returns {string} output.address1
  * @returns {string} output.address2
+ * @returns {string} output.asset_id
  * @returns {string} output.city
  * @returns {string} output.geometry_id UUID corresponding with a geometry
  * @returns {Object} output.Info User declared information
@@ -15,7 +16,6 @@
  * @returns {string} output.timezone An IANA Time Zone Database string, i.e. America/Los_Angeles
  * @returns {string} output.weather_location_id
  * @returns {string} output.zip
- * @returns {string} output.asset_id
  *
  * @private
  */
@@ -23,6 +23,7 @@ function formatFacilityToServer(input = {}) {
   return {
     address1: input.address1,
     address2: input.address2,
+    asset_id: input.assetId,
     city: input.city,
     geometry_id: input.geometryId,
     Info: input.info,
@@ -31,8 +32,7 @@ function formatFacilityToServer(input = {}) {
     state: input.state,
     timezone: input.timezone,
     weather_location_id: input.weatherLocationId,
-    zip: input.zip,
-    asset_id: input.assetId
+    zip: input.zip
   };
 }
 

--- a/src/utils/facilities/formatFacilityToServer.js
+++ b/src/utils/facilities/formatFacilityToServer.js
@@ -15,6 +15,7 @@
  * @returns {string} output.timezone An IANA Time Zone Database string, i.e. America/Los_Angeles
  * @returns {string} output.weather_location_id
  * @returns {string} output.zip
+ * @returns {string{ outout.asset_id
  *
  * @private
  */
@@ -30,7 +31,8 @@ function formatFacilityToServer(input = {}) {
     state: input.state,
     timezone: input.timezone,
     weather_location_id: input.weatherLocationId,
-    zip: input.zip
+    zip: input.zip,
+    asset_id: input.assetId
   };
 }
 

--- a/src/utils/facilities/formatFacilityToServer.js
+++ b/src/utils/facilities/formatFacilityToServer.js
@@ -15,7 +15,7 @@
  * @returns {string} output.timezone An IANA Time Zone Database string, i.e. America/Los_Angeles
  * @returns {string} output.weather_location_id
  * @returns {string} output.zip
- * @returns {string{ outout.asset_id
+ * @returns {string} output.asset_id
  *
  * @private
  */

--- a/src/utils/facilities/formatFacilityToServer.spec.js
+++ b/src/utils/facilities/formatFacilityToServer.spec.js
@@ -11,13 +11,14 @@ describe('utils/facilities/formatFacilityToServer', function() {
     expectedFacility = omit(
       {
         ...facility,
+        asset_id: facility.assetId,
         geometry_id: facility.geometryId,
         Info: facility.info,
         organization_id: facility.organizationId,
-        weather_location_id: facility.weatherLocationId,
-        asset_id: facility.assetId
+        weather_location_id: facility.weatherLocationId
       },
       [
+        'assetId',
         'createdAt',
         'facility_groupings',
         'geometryId',
@@ -26,8 +27,7 @@ describe('utils/facilities/formatFacilityToServer', function() {
         'organization',
         'organizationId',
         'tags',
-        'weatherLocationId',
-        'assetId'
+        'weatherLocationId'
       ]
     );
 

--- a/src/utils/facilities/formatFacilityToServer.spec.js
+++ b/src/utils/facilities/formatFacilityToServer.spec.js
@@ -14,7 +14,8 @@ describe('utils/facilities/formatFacilityToServer', function() {
         geometry_id: facility.geometryId,
         Info: facility.info,
         organization_id: facility.organizationId,
-        weather_location_id: facility.weatherLocationId
+        weather_location_id: facility.weatherLocationId,
+        asset_id: facility.assetId
       },
       [
         'createdAt',
@@ -25,7 +26,8 @@ describe('utils/facilities/formatFacilityToServer', function() {
         'organization',
         'organizationId',
         'tags',
-        'weatherLocationId'
+        'weatherLocationId',
+        'assetId'
       ]
     );
 

--- a/support/fixtures/factories/facility.js
+++ b/support/fixtures/factories/facility.js
@@ -11,6 +11,7 @@ factory
   .attrs({
     address1: () => faker.address.streetAddress(),
     address2: () => faker.address.secondaryAddress(),
+    assetId: () => faker.random.uuid(),
     city: () => faker.address.city(),
     createdAt: () => faker.date.past().toISOString(),
     geometryId: () => faker.random.uuid(),


### PR DESCRIPTION
## Why?
- Need to be able to retrieve the asset reference from the facility model (recently added to the facilities API)

## What changed?
- Added the asset_id field to the facility model

## What's to Come?
- This serves a short term need to just retrieve the asset_id, but we need to make an effort to build the asset framework into this library in the near future.