### PR TITLE
Add ability pass paging options to Iot/Outputs#getFieldData

### DIFF
--- a/docs/CostCenters.md
+++ b/docs/CostCenters.md
@@ -65,7 +65,7 @@ Method: POST
 | Param | Type | Description |
 | --- | --- | --- |
 | costCenter | <code>Object</code> |  |
-| costCenter.description | <code>string</code> |  |
+| [costCenter.description] | <code>string</code> |  |
 | costCenter.name | <code>string</code> |  |
 | costCenter.organizationId | <code>string</code> | UUID |
 
@@ -98,7 +98,9 @@ Method: DELETE
 
 **Example**  
 ```js
-contxtSdk.facilities.costCenters.delete('e4fec739-56aa-4b50-8dab-e9d6b9c91a5d')
+contxtSdk.facilities.costCenters.delete(
+  'e4fec739-56aa-4b50-8dab-e9d6b9c91a5d'
+);
 ```
 <a name="CostCenters+getAll"></a>
 
@@ -160,7 +162,8 @@ Method: DELETE
 
 **Example**  
 ```js
-contxtSdk.facilities.costCenters.removeFacility('b3dbaae3-25dd-475b-80dc-66296630a8d0', 4)
+contxtSdk.facilities.costCenters
+  .removeFacility('b3dbaae3-25dd-475b-80dc-66296630a8d0', 4)
   .catch((err) => console.log(err));
 ```
 <a name="CostCenters+update"></a>

--- a/docs/Facilities.md
+++ b/docs/Facilities.md
@@ -59,7 +59,7 @@ contxtSdk.facilities
     name: 'Sherlock Holmes Museum',
     organizationId: 25
   })
-  .then((facilities) => console.log(facilities));
+  .then((facilities) => console.log(facilities))
   .catch((err) => console.log(err));
 ```
 <a name="Facilities+createOrUpdateInfo"></a>
@@ -103,7 +103,7 @@ Method: DELETE
 
 **Example**  
 ```js
-contxtSdk.facilities.delete(25)
+contxtSdk.facilities.delete(25);
 ```
 <a name="Facilities+get"></a>
 
@@ -123,8 +123,9 @@ Method: GET
 
 **Example**  
 ```js
-contxtSdk.facilities.get(25)
-  .then((facility) => console.log(facility));
+contxtSdk.facilities
+  .get(25)
+  .then((facility) => console.log(facility))
   .catch((err) => console.log(err));
 ```
 <a name="Facilities+getAll"></a>
@@ -140,8 +141,9 @@ Method: GET
 **Reject**: <code>Error</code>  
 **Example**  
 ```js
-contxtSdk.facilities.getAll()
-  .then((facilities) => console.log(facilities));
+contxtSdk.facilities
+  .getAll()
+  .then((facilities) => console.log(facilities))
   .catch((err) => console.log(err));
 ```
 <a name="Facilities+getAllByOrganizationId"></a>
@@ -164,8 +166,9 @@ Method: GET
 
 **Example**  
 ```js
-contxtSdk.facilities.getAllByOrganizationId(25, {includeGroupings: true})
-  .then((facilities) => console.log(facilities));
+contxtSdk.facilities
+  .getAllByOrganizationId(25, { includeGroupings: true })
+  .then((facilities) => console.log(facilities))
   .catch((err) => console.log(err));
 ```
 <a name="Facilities+update"></a>

--- a/docs/FacilityGroupings.md
+++ b/docs/FacilityGroupings.md
@@ -45,7 +45,8 @@ Method: POST
 
 **Example**  
 ```js
-contxtSdk.facilities.groupings.addFacility('b3dbaae3-25dd-475b-80dc-66296630a8d0', 4)
+contxtSdk.facilities.groupings
+  .addFacility('b3dbaae3-25dd-475b-80dc-66296630a8d0', 4)
   .then((grouping) => console.log(grouping))
   .catch((err) => console.log(err));
 ```
@@ -77,7 +78,7 @@ contxtSdk.facilities.groupings
     description: 'US States of CT, MA, ME, NH, RI, VT',
     isPrivate: false,
     name: 'New England, USA',
-    organizationId: '61f5fe1d-d202-4ae7-af76-8f37f5bbeec5'
+    organizationId: '61f5fe1d-d202-4ae7-af76-8f37f5bbeec5',
     parentGroupingId: 'e9f8f89c-609c-4c83-8ebc-cea928af661e'
   })
   .then((grouping) => console.log(grouping))
@@ -101,7 +102,9 @@ Method: DELETE
 
 **Example**  
 ```js
-contxtSdk.facilities.groupings.delete('e4fec739-56aa-4b50-8dab-e9d6b9c91a5d')
+contxtSdk.facilities.groupings.delete(
+  'e4fec739-56aa-4b50-8dab-e9d6b9c91a5d'
+);
 ```
 <a name="FacilityGroupings+getAll"></a>
 
@@ -117,7 +120,8 @@ Method: GET
 **Reject**: <code>Error</code>  
 **Example**  
 ```js
-contxtSdk.facilites.groupings.getAll()
+contxtSdk.facilites.groupings
+  .getAll()
   .then((groupings) => console.log(groupings))
   .catch((err) => console.log(err));
 ```
@@ -140,7 +144,8 @@ Method: GET
 
 **Example**  
 ```js
-contxtSdk.facilites.groupings.getAll()
+contxtSdk.facilites.groupings
+  .getAllByOrganizationId('349dbd36-5dca-4a10-b54d-d0f71c3c8709')
   .then((groupings) => console.log(groupings))
   .catch((err) => console.log(err));
 ```
@@ -162,7 +167,8 @@ Method: DELETE
 
 **Example**  
 ```js
-contxtSdk.facilities.groupings.removeFacility('b3dbaae3-25dd-475b-80dc-66296630a8d0', 4)
+contxtSdk.facilities.groupings
+  .removeFacility('b3dbaae3-25dd-475b-80dc-66296630a8d0', 4)
   .catch((err) => console.log(err));
 ```
 <a name="FacilityGroupings+update"></a>

--- a/docs/Fields.md
+++ b/docs/Fields.md
@@ -37,7 +37,8 @@ Method: GET
 
 **Example**  
 ```js
-contxtSdk.iot.fields.get(563)
-  .then((outputField) => console.log(outputField));
+contxtSdk.iot.fields
+  .get(563)
+  .then((outputField) => console.log(outputField))
   .catch((err) => console.log(err));
 ```

--- a/docs/Outputs.md
+++ b/docs/Outputs.md
@@ -28,7 +28,7 @@ API Endpoint: '/outputs/:outputId/fields/:fieldHumanName/data'
 Method: GET
 
 **Kind**: instance method of [<code>Outputs</code>](#Outputs)  
-**Fulfill**: <code>Object</code>  
+**Fulfill**: [<code>OutputFieldDataResponse</code>](./Typedefs.md#OutputFieldDataResponse)  
 **Reject**: <code>Error</code>  
 
 | Param | Type | Default | Description |

--- a/docs/Outputs.md
+++ b/docs/Outputs.md
@@ -7,7 +7,7 @@ Module that provides access to output information
 
 * [Outputs](#Outputs)
     * [new Outputs(sdk, request, baseUrl)](#new_Outputs_new)
-    * [.getFieldData(outputId, fieldHumanName)](#Outputs+getFieldData) ⇒ <code>Promise</code>
+    * [.getFieldData(outputId, fieldHumanName, [options])](#Outputs+getFieldData) ⇒ <code>Promise</code>
 
 <a name="new_Outputs_new"></a>
 
@@ -21,7 +21,7 @@ Module that provides access to output information
 
 <a name="Outputs+getFieldData"></a>
 
-### contxtSdk.iot.outputs.getFieldData(outputId, fieldHumanName) ⇒ <code>Promise</code>
+### contxtSdk.iot.outputs.getFieldData(outputId, fieldHumanName, [options]) ⇒ <code>Promise</code>
 Gets an output's data from a specific field
 
 API Endpoint: '/outputs/:outputId/fields/:fieldHumanName/data'
@@ -31,14 +31,24 @@ Method: GET
 **Fulfill**: <code>Object</code>  
 **Reject**: <code>Error</code>  
 
-| Param | Type | Description |
-| --- | --- | --- |
-| outputId | <code>Number</code> | The ID of an output |
-| fieldHumanName | <code>String</code> | The human readable name of a field |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| outputId | <code>Number</code> |  | The ID of an output |
+| fieldHumanName | <code>String</code> |  | The human readable name of a field |
+| [options] | <code>Object</code> |  |  |
+| [options.limit] | <code>Number</code> | <code>5000</code> | Number of records to return |
+| [options.timeEnd] | <code>Number</code> |  | UNIX timestamp indicating the end of the   query window |
+| [options.timeStart] | <code>Number</code> |  | UNIX timestamp indicating the start of   the query window |
+| [options.window] | <code>Number</code> |  | The sampling window for records.   Required if including a timeEnd or timeStart.   Valid options include: `0`, `60`, `900`, and `3600` |
 
 **Example**  
 ```js
-contxtSdk.iot.outputs.getFieldData(491, 'temperature')
-  .then((outputData) => console.log(outputData));
-  .catch((err) => console.log(err));
+contxtSdk.iot.outputs
+  .getFieldData(491, 'temperature', {
+    limit: 100,
+    timeStart: 1530290218365,
+    window: 3600
+  })
+  .then(outputData => console.log(outputData))
+  .catch(err => console.log(err));
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -90,6 +90,10 @@ for authenticating and communicating with an individual API and the external mod
 <dd></dd>
 <dt><a href="./Typedefs.md#OutputField">OutputField</a> : <code>Object</code></dt>
 <dd></dd>
+<dt><a href="./Typedefs.md#OutputFieldData">OutputFieldData</a> : <code>Object</code></dt>
+<dd></dd>
+<dt><a href="./Typedefs.md#OutputFieldDataResponse">OutputFieldDataResponse</a> : <code>Object</code></dt>
+<dd></dd>
 <dt><a href="./Typedefs.md#SessionType">SessionType</a> : <code>Object</code></dt>
 <dd><p>An adapter that allows the SDK to authenticate with different services and manage various tokens.
 Can authenticate with a service like Auth0 and then with Contxt or can communicate directly

--- a/docs/Typedefs.md
+++ b/docs/Typedefs.md
@@ -106,11 +106,11 @@ for authenticating and communicating with an individual API and the external mod
 
 | Name | Type | Description |
 | --- | --- | --- |
-| address1 | <code>string</code> |  |
-| address2 | <code>string</code> |  |
-| city | <code>string</code> |  |
+| [address1] | <code>string</code> |  |
+| [address2] | <code>string</code> |  |
+| [city] | <code>string</code> |  |
 | createdAt | <code>string</code> | ISO 8601 Extended Format date/time string |
-| geometryId | <code>string</code> | UUID corresponding with a geometry |
+| [geometryId] | <code>string</code> | UUID corresponding with a geometry |
 | id | <code>number</code> |  |
 | [Info] | <code>Object</code> | User declared information |
 | name | <code>string</code> |  |
@@ -119,7 +119,7 @@ for authenticating and communicating with an individual API and the external mod
 | [Organization.id] | <code>string</code> | UUID formatted ID |
 | [Organization.name] | <code>string</code> |  |
 | [Organization.updatedAt] | <code>string</code> | ISO 8601 Extended Format date/time string |
-| state | <code>string</code> |  |
+| [state] | <code>string</code> |  |
 | [tags] | <code>Array.&lt;Object&gt;</code> |  |
 | [tags[].createdAt] | <code>string</code> | ISO 8601 Extended Format date/time string |
 | [tags[].id] | <code>number</code> |  |
@@ -127,8 +127,8 @@ for authenticating and communicating with an individual API and the external mod
 | [tags[].name] | <code>string</code> |  |
 | [tags[].updatedAt] | <code>string</code> | ISO 8601 Extended Format date/time string |
 | timezone | <code>string</code> | An IANA Time Zone Database string, i.e. America/Los_Angeles |
-| weatherLocationId | <code>number</code> |  |
-| zip | <code>string</code> | US Zip Code |
+| [weatherLocationId] | <code>number</code> |  |
+| [zip] | <code>string</code> | US Zip Code |
 
 <a name="FacilityGrouping"></a>
 
@@ -138,14 +138,14 @@ for authenticating and communicating with an individual API and the external mod
 | Param | Type | Description |
 | --- | --- | --- |
 | createdAt | <code>string</code> | ISO 8601 Extended Format date/time string |
-| description | <code>string</code> |  |
+| [description] | <code>string</code> |  |
 | [facilities] | [<code>Array.&lt;Facility&gt;</code>](#Facility) |  |
 | id | <code>string</code> | UUID |
 | isPrivate | <code>boolean</code> |  |
 | name | <code>string</code> |  |
 | organizationId | <code>string</code> | UUID |
 | ownerId | <code>string</code> | Auth0 identifer of the user |
-| parentGroupingId | <code>string</code> | UUID |
+| [parentGroupingId] | <code>string</code> | UUID |
 | updatedAt | <code>string</code> | ISO 8601 Extended Format date/time string |
 
 <a name="FacilityGroupingFacility"></a>
@@ -180,22 +180,22 @@ for authenticating and communicating with an individual API and the external mod
 
 | Name | Type | Description |
 | --- | --- | --- |
-| canAggregate | <code>Boolean</code> |  |
-| divisor | <code>Number</code> |  |
+| [canAggregate] | <code>Boolean</code> |  |
+| [divisor] | <code>Number</code> |  |
 | feedKey | <code>String</code> |  |
 | fieldDescriptor | <code>String</code> |  |
 | fieldHumanName | <code>String</code> |  |
-| fieldName | <code>String</code> |  |
+| [fieldName] | <code>String</code> |  |
 | id | <code>Number</code> |  |
-| isDefault | <code>Boolean</code> |  |
-| isHidden | <code>Boolean</code> |  |
-| isTotalizer | <code>Boolean</code> |  |
-| isWindowed | <code>Boolean</code> |  |
-| label | <code>String</code> |  |
+| [isDefault] | <code>Boolean</code> |  |
+| [isHidden] | <code>Boolean</code> |  |
+| [isTotalizer] | <code>Boolean</code> |  |
+| [isWindowed] | <code>Boolean</code> |  |
+| [label] | <code>String</code> |  |
 | outputId | <code>Number</code> |  |
-| scalar | <code>Number</code> |  |
-| status | <code>String</code> |  |
-| units | <code>String</code> |  |
+| [scalar] | <code>Number</code> |  |
+| [status] | <code>String</code> |  |
+| [units] | <code>String</code> |  |
 | valueType | <code>String</code> | What type of value can be coming from the feed.   One of `boolean`, `numeric`, and `string` |
 
 <a name="SessionType"></a>

--- a/docs/Typedefs.md
+++ b/docs/Typedefs.md
@@ -198,6 +198,35 @@ for authenticating and communicating with an individual API and the external mod
 | [units] | <code>String</code> |  |
 | valueType | <code>String</code> | What type of value can be coming from the feed.   One of `boolean`, `numeric`, and `string` |
 
+<a name="OutputFieldData"></a>
+
+## OutputFieldData : <code>Object</code>
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| eventTime | <code>String</code> | ISO 8601 Extended Format date/time string |
+| value | <code>String</code> |  |
+
+<a name="OutputFieldDataResponse"></a>
+
+## OutputFieldDataResponse : <code>Object</code>
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| meta | <code>Object</code> |  |
+| meta.count | <code>Number</code> | Total number of field data records |
+| meta.hasMore | <code>Boolean</code> | Indicates if there are more records   to retrieve |
+| [meta.limit] | <code>Number</code> | Number of records to return |
+| [nextRecordTime] | <code>Number</code> | UNIX timestamp indicating a   `timeStart` that would return new values |
+| [meta.timeEnd] | <code>Number</code> | UNIX timestamp indicating the end of   the query window |
+| [meta.timeStart] | <code>Number</code> | UNIX timestamp indicating the   start of the query window |
+| [meta.window] | <code>Number</code> | The sampling window for records.   Required if including a timeEnd or timeStart.   Valid options include: `0`, `60`, `900`, and `3600` |
+| records | [<code>Array.&lt;OutputFieldData&gt;</code>](#OutputFieldData) |  |
+
 <a name="SessionType"></a>
 
 ## SessionType : <code>Object</code>

--- a/src/facilities/costCenters.js
+++ b/src/facilities/costCenters.js
@@ -92,7 +92,7 @@ class CostCenters {
    * Method: POST
    *
    * @param {Object} costCenter
-   * @param {string} costCenter.description
+   * @param {string} [costCenter.description]
    * @param {string} costCenter.name
    * @param {string} costCenter.organizationId UUID
    *
@@ -143,7 +143,9 @@ class CostCenters {
    * @reject {Error}
    *
    * @example
-   * contxtSdk.facilities.costCenters.delete('e4fec739-56aa-4b50-8dab-e9d6b9c91a5d')
+   * contxtSdk.facilities.costCenters.delete(
+   *   'e4fec739-56aa-4b50-8dab-e9d6b9c91a5d'
+   * );
    */
   delete(costCenterId) {
     if (!costCenterId) {
@@ -223,7 +225,8 @@ class CostCenters {
    * @reject {Error}
    *
    * @example
-   * contxtSdk.facilities.costCenters.removeFacility('b3dbaae3-25dd-475b-80dc-66296630a8d0', 4)
+   * contxtSdk.facilities.costCenters
+   *   .removeFacility('b3dbaae3-25dd-475b-80dc-66296630a8d0', 4)
    *   .catch((err) => console.log(err));
    */
   removeFacility(costCenterId, facilityId) {

--- a/src/facilities/groupings.js
+++ b/src/facilities/groupings.js
@@ -8,14 +8,14 @@ import {
 /**
  * @typedef {Object} FacilityGrouping
  * @param {string} createdAt ISO 8601 Extended Format date/time string
- * @param {string} description
+ * @param {string} [description]
  * @param {Facility[]} [facilities]
  * @param {string} id UUID
  * @param {boolean} isPrivate
  * @param {string} name
  * @param {string} organizationId UUID
  * @param {string} ownerId Auth0 identifer of the user
- * @param {string} parentGroupingId UUID
+ * @param {string} [parentGroupingId] UUID
  * @param {string} updatedAt ISO 8601 Extended Format date/time string
  */
 
@@ -60,7 +60,8 @@ class FacilityGroupings {
    * @reject {Error}
    *
    * @example
-   * contxtSdk.facilities.groupings.addFacility('b3dbaae3-25dd-475b-80dc-66296630a8d0', 4)
+   * contxtSdk.facilities.groupings
+   *   .addFacility('b3dbaae3-25dd-475b-80dc-66296630a8d0', 4)
    *   .then((grouping) => console.log(grouping))
    *   .catch((err) => console.log(err));
    */
@@ -113,7 +114,7 @@ class FacilityGroupings {
    *     description: 'US States of CT, MA, ME, NH, RI, VT',
    *     isPrivate: false,
    *     name: 'New England, USA',
-   *     organizationId: '61f5fe1d-d202-4ae7-af76-8f37f5bbeec5'
+   *     organizationId: '61f5fe1d-d202-4ae7-af76-8f37f5bbeec5',
    *     parentGroupingId: 'e9f8f89c-609c-4c83-8ebc-cea928af661e'
    *   })
    *   .then((grouping) => console.log(grouping))
@@ -152,7 +153,9 @@ class FacilityGroupings {
    * @reject {Error}
    *
    * @example
-   * contxtSdk.facilities.groupings.delete('e4fec739-56aa-4b50-8dab-e9d6b9c91a5d')
+   * contxtSdk.facilities.groupings.delete(
+   *   'e4fec739-56aa-4b50-8dab-e9d6b9c91a5d'
+   * );
    */
   delete(facilityGroupingId) {
     if (!facilityGroupingId) {
@@ -180,7 +183,8 @@ class FacilityGroupings {
    * @reject {Error}
    *
    * @example
-   * contxtSdk.facilites.groupings.getAll()
+   * contxtSdk.facilites.groupings
+   *   .getAll()
    *   .then((groupings) => console.log(groupings))
    *   .catch((err) => console.log(err));
    */
@@ -204,7 +208,8 @@ class FacilityGroupings {
    * @reject {Error}
    *
    * @example
-   * contxtSdk.facilites.groupings.getAll()
+   * contxtSdk.facilites.groupings
+   *   .getAllByOrganizationId('349dbd36-5dca-4a10-b54d-d0f71c3c8709')
    *   .then((groupings) => console.log(groupings))
    *   .catch((err) => console.log(err));
    */
@@ -235,7 +240,8 @@ class FacilityGroupings {
    * @reject {Error}
    *
    * @example
-   * contxtSdk.facilities.groupings.removeFacility('b3dbaae3-25dd-475b-80dc-66296630a8d0', 4)
+   * contxtSdk.facilities.groupings
+   *   .removeFacility('b3dbaae3-25dd-475b-80dc-66296630a8d0', 4)
    *   .catch((err) => console.log(err));
    */
   removeFacility(facilityGroupingId, facilityId) {

--- a/src/facilities/index.js
+++ b/src/facilities/index.js
@@ -9,11 +9,11 @@ import {
 
 /**
  * @typedef {Object} Facility
- * @property {string} address1
- * @property {string} address2
- * @property {string} city
+ * @property {string} [address1]
+ * @property {string} [address2]
+ * @property {string} [city]
  * @property {string} createdAt ISO 8601 Extended Format date/time string
- * @property {string} geometryId UUID corresponding with a geometry
+ * @property {string} [geometryId] UUID corresponding with a geometry
  * @property {number} id
  * @property {Object} [Info] User declared information
  * @property {string} name
@@ -22,7 +22,7 @@ import {
  * @property {string} [Organization.id] UUID formatted ID
  * @property {string} [Organization.name]
  * @property {string} [Organization.updatedAt] ISO 8601 Extended Format date/time string
- * @property {string} state
+ * @property {string} [state]
  * @property {Object[]} [tags]
  * @property {string} [tags[].createdAt] ISO 8601 Extended Format date/time string
  * @property {number} [tags[].id]
@@ -30,8 +30,8 @@ import {
  * @property {string} [tags[].name]
  * @property {string} [tags[].updatedAt] ISO 8601 Extended Format date/time string
  * @property {string} timezone An IANA Time Zone Database string, i.e. America/Los_Angeles
- * @property {number} weatherLocationId
- * @property {string} zip US Zip Code
+ * @property {number} [weatherLocationId]
+ * @property {string} [zip] US Zip Code
  */
 
 /**
@@ -85,7 +85,7 @@ class Facilities {
    *     name: 'Sherlock Holmes Museum',
    *     organizationId: 25
    *   })
-   *   .then((facilities) => console.log(facilities));
+   *   .then((facilities) => console.log(facilities))
    *   .catch((err) => console.log(err));
    */
   create(facility = {}) {
@@ -173,7 +173,7 @@ class Facilities {
    * @reject {Error}
    *
    * @example
-   * contxtSdk.facilities.delete(25)
+   * contxtSdk.facilities.delete(25);
    */
   delete(facilityId) {
     if (!facilityId) {
@@ -198,8 +198,9 @@ class Facilities {
    * @reject {Error}
    *
    * @example
-   * contxtSdk.facilities.get(25)
-   *   .then((facility) => console.log(facility));
+   * contxtSdk.facilities
+   *   .get(25)
+   *   .then((facility) => console.log(facility))
    *   .catch((err) => console.log(err));
    */
   get(facilityId) {
@@ -227,8 +228,9 @@ class Facilities {
    * @reject {Error}
    *
    * @example
-   * contxtSdk.facilities.getAll()
-   *   .then((facilities) => console.log(facilities));
+   * contxtSdk.facilities
+   *   .getAll()
+   *   .then((facilities) => console.log(facilities))
    *   .catch((err) => console.log(err));
    */
   getAll() {
@@ -254,8 +256,9 @@ class Facilities {
    * @reject {Error}
    *
    * @example
-   * contxtSdk.facilities.getAllByOrganizationId(25, {includeGroupings: true})
-   *   .then((facilities) => console.log(facilities));
+   * contxtSdk.facilities
+   *   .getAllByOrganizationId(25, { includeGroupings: true })
+   *   .then((facilities) => console.log(facilities))
    *   .catch((err) => console.log(err));
    */
   getAllByOrganizationId(organizationId, options) {

--- a/src/iot/fields.js
+++ b/src/iot/fields.js
@@ -2,22 +2,22 @@ import { formatOutputFieldFromServer } from '../utils/iot';
 
 /**
  * @typedef {Object} OutputField
- * @property {Boolean} canAggregate
- * @property {Number} divisor
+ * @property {Boolean} [canAggregate]
+ * @property {Number} [divisor]
  * @property {String} feedKey
  * @property {String} fieldDescriptor
  * @property {String} fieldHumanName
- * @property {String} fieldName
+ * @property {String} [fieldName]
  * @property {Number} id
- * @property {Boolean} isDefault
- * @property {Boolean} isHidden
- * @property {Boolean} isTotalizer
- * @property {Boolean} isWindowed
- * @property {String} label
+ * @property {Boolean} [isDefault]
+ * @property {Boolean} [isHidden]
+ * @property {Boolean} [isTotalizer]
+ * @property {Boolean} [isWindowed]
+ * @property {String} [label]
  * @property {Number} outputId
- * @property {Number} scalar
- * @property {String} status
- * @property {String} units
+ * @property {Number} [scalar]
+ * @property {String} [status]
+ * @property {String} [units]
  * @property {String} valueType What type of value can be coming from the feed.
  *   One of `boolean`, `numeric`, and `string`
  */
@@ -54,8 +54,9 @@ class Fields {
    * @reject {Error}
    *
    * @example
-   * contxtSdk.iot.fields.get(563)
-   *   .then((outputField) => console.log(outputField));
+   * contxtSdk.iot.fields
+   *   .get(563)
+   *   .then((outputField) => console.log(outputField))
    *   .catch((err) => console.log(err));
    */
   get(outputFieldId) {

--- a/src/iot/outputs.js
+++ b/src/iot/outputs.js
@@ -27,17 +27,32 @@ class Outputs {
    *
    * @param {Number} outputId The ID of an output
    * @param {String} fieldHumanName The human readable name of a field
+   * @param {Object} [options]
+   * @param {Number} [options.limit = 5000] Number of records to return
+   * @param {Number} [options.timeEnd] UNIX timestamp indicating the end of the
+   *   query window
+   * @param {Number} [options.timeStart] UNIX timestamp indicating the start of
+   *   the query window
+   * @param {Number} [options.window] The sampling window for records.
+   *   Required if including a timeEnd or timeStart.
+   *   Valid options include: `0`, `60`, `900`, and `3600`
    *
    * @returns {Promise}
    * @fulfill {Object}
    * @reject {Error}
    *
    * @example
-   * contxtSdk.iot.outputs.getFieldData(491, 'temperature')
-   *   .then((outputData) => console.log(outputData));
-   *   .catch((err) => console.log(err));
+   * contxtSdk.iot.outputs
+   *   .getFieldData(491, 'temperature', {
+   *     limit: 100,
+   *     timeStart: 1530290218365,
+   *     window: 3600
+   *   })
+   *   .then(outputData => console.log(outputData))
+   *   .catch(err => console.log(err));
+
    */
-  getFieldData(outputId, fieldHumanName) {
+  getFieldData(outputId, fieldHumanName, options) {
     if (!outputId) {
       return Promise.reject(
         new Error(
@@ -55,7 +70,10 @@ class Outputs {
     }
 
     return this._request
-      .get(`${this._baseUrl}/outputs/${outputId}/fields/${fieldHumanName}/data`)
+      .get(
+        `${this._baseUrl}/outputs/${outputId}/fields/${fieldHumanName}/data`,
+        { params: options }
+      )
       .then((fieldData) => formatOutputFieldDataFromServer(fieldData));
   }
 }

--- a/src/iot/outputs.js
+++ b/src/iot/outputs.js
@@ -1,4 +1,28 @@
 import { formatOutputFieldDataFromServer } from '../utils/iot';
+/**
+ * @typedef {Object} OutputFieldDataResponse
+ * @property {Object} meta
+ * @property {Number} meta.count Total number of field data records
+ * @property {Boolean} meta.hasMore Indicates if there are more records
+ *   to retrieve
+ * @property {Number} [meta.limit] Number of records to return
+ * @property {Number} [nextRecordTime] UNIX timestamp indicating a
+ *   `timeStart` that would return new values
+ * @property {Number} [meta.timeEnd] UNIX timestamp indicating the end of
+ *   the query window
+ * @property {Number} [meta.timeStart] UNIX timestamp indicating the
+ *   start of the query window
+ * @property {Number} [meta.window] The sampling window for records.
+ *   Required if including a timeEnd or timeStart.
+ *   Valid options include: `0`, `60`, `900`, and `3600`
+ * @property {OutputFieldData[]} records
+ */
+
+/**
+ * @typedef {Object} OutputFieldData
+ * @property {String} eventTime ISO 8601 Extended Format date/time string
+ * @property {String} value
+ */
 
 /**
  * Module that provides access to output information
@@ -38,7 +62,7 @@ class Outputs {
    *   Valid options include: `0`, `60`, `900`, and `3600`
    *
    * @returns {Promise}
-   * @fulfill {Object}
+   * @fulfill {OutputFieldDataResponse}
    * @reject {Error}
    *
    * @example

--- a/src/iot/outputs.spec.js
+++ b/src/iot/outputs.spec.js
@@ -52,6 +52,7 @@ describe('Iot/Outputs', function() {
   describe('getFieldData', function() {
     context('when all required information is provided', function() {
       let expectedFieldHumanName;
+      let expectedOptions;
       let expectedOutputFieldData;
       let expectedOutputId;
       let formatOutputFieldDataFromServer;
@@ -61,6 +62,12 @@ describe('Iot/Outputs', function() {
 
       beforeEach(function() {
         expectedFieldHumanName = fixture.build('outputField').fieldHumanName;
+        expectedOptions = {
+          limit: faker.random.number(),
+          timeEnd: Math.floor(faker.date.recent().getTime() / 1000),
+          timeStart: Math.floor(faker.date.past().getTime() / 1000),
+          window: faker.random.arrayElement([0, 60, 900, 3600])
+        };
         expectedOutputFieldData = {
           meta: { count: faker.random.number() },
           records: fixture.buildList(
@@ -88,13 +95,15 @@ describe('Iot/Outputs', function() {
 
         promise = outputs.getFieldData(
           expectedOutputId,
-          expectedFieldHumanName
+          expectedFieldHumanName,
+          expectedOptions
         );
       });
 
       it('gets the output field data from the server', function() {
         expect(request.get).to.be.calledWith(
-          `${expectedHost}/outputs/${expectedOutputId}/fields/${expectedFieldHumanName}/data`
+          `${expectedHost}/outputs/${expectedOutputId}/fields/${expectedFieldHumanName}/data`,
+          { params: expectedOptions }
         );
       });
 

--- a/src/utils/iot/formatOutputFieldDataFromServer.js
+++ b/src/utils/iot/formatOutputFieldDataFromServer.js
@@ -1,3 +1,5 @@
+import URL from 'url-parse';
+
 /**
  * Normalizes the output field data and metadata returned from the API server
  *
@@ -12,19 +14,44 @@
  * @returns {Number} [output.meta.nextRecordTime] UNIX timestamp indicating a
  *   `timeStart` that would return new values
  *
+ * @returns {Object} output
+ * @returns {Object} output.meta Metadata about the request
+ * @returns {Number} output.meta.count Total number of field data records
+ * @returns {Boolean} output.meta.hasMore Indicates if there are more records
+ *   to retrieve
+ * @returns {Number} [output.meta.limit = 5000] Number of records to return
+ * @returns {Number} [output.nextRecordTime] UNIX timestamp indicating a
+ *   `timeStart` that would return new values
+ * @returns {Number} [output.meta.timeEnd] UNIX timestamp indicating the end of
+ *   the query window
+ * @returns {Number} [output.meta.timeStart] UNIX timestamp indicating the
+ *   start of the query window
+ * @returns {Number} [output.meta.window] The sampling window for records.
+ *   Required if including a timeEnd or timeStart.
+ *   Valid options include: `0`, `60`, `900`, and `3600`
  * @returns {OutputFieldData[]} output.records
  *
  * @private
  */
 function formatOutputFieldDataFromServer(input = {}) {
   const meta = input.meta || {};
+  const query = ['limit', 'timeEnd', 'timeStart', 'window'].reduce(
+    (memo, key) => {
+      if (memo[key]) {
+        memo[key] = parseInt(memo[key], 10);
+      }
+
+      return memo;
+    },
+    new URL(meta.next_page_url, true).query
+  );
   const records = input.records || [];
 
   return {
     meta: {
+      ...query,
       count: meta.count,
       hasMore: meta.has_more,
-      nextPageUrl: meta.next_page_url,
       nextRecordTime: meta.next_record_time
     },
     records: records.map((record) => ({

--- a/src/utils/iot/formatOutputFieldDataFromServer.js
+++ b/src/utils/iot/formatOutputFieldDataFromServer.js
@@ -1,17 +1,16 @@
-import URL from 'url-parse';
+import * as iotUtils from './index';
 
 /**
  * Normalizes the output field data and metadata returned from the API server
  *
- *
- * @returns {Object} output
- * @returns {Object} output.meta Metadata about the output field data query
- * @returns {Number} output.meta.count Total number of field data records found
- * @returns {Boolean} output.meta.hasMore Indicates if there are more records
+ * @returns {Object} input
+ * @returns {Object} input.meta Metadata about the output field data query
+ * @returns {Number} input.meta.count Total number of field data records found
+ * @returns {Boolean} input.meta.hasMore Indicates if there are more records
  *   to retrieve
- * @returns {String} [output.meta.nextPageUrl] URL that can be used to request
+ * @returns {String} [input.meta.nextPageUrl] URL that can be used to request
  *   the next page of results
- * @returns {Number} [output.meta.nextRecordTime] UNIX timestamp indicating a
+ * @returns {Number} [input.meta.nextRecordTime] UNIX timestamp indicating a
  *   `timeStart` that would return new values
  *
  * @returns {Object} output
@@ -35,15 +34,8 @@ import URL from 'url-parse';
  */
 function formatOutputFieldDataFromServer(input = {}) {
   const meta = input.meta || {};
-  const query = ['limit', 'timeEnd', 'timeStart', 'window'].reduce(
-    (memo, key) => {
-      if (memo[key]) {
-        memo[key] = parseInt(memo[key], 10);
-      }
-
-      return memo;
-    },
-    new URL(meta.next_page_url, true).query
+  const query = iotUtils.parseOutputFieldNextPageUrlMetadata(
+    meta.next_page_url
   );
   const records = input.records || [];
 

--- a/src/utils/iot/formatOutputFieldDataFromServer.js
+++ b/src/utils/iot/formatOutputFieldDataFromServer.js
@@ -18,7 +18,7 @@ import * as iotUtils from './index';
  * @returns {Number} output.meta.count Total number of field data records
  * @returns {Boolean} output.meta.hasMore Indicates if there are more records
  *   to retrieve
- * @returns {Number} [output.meta.limit = 5000] Number of records to return
+ * @returns {Number} [output.meta.limit] Number of records to return
  * @returns {Number} [output.nextRecordTime] UNIX timestamp indicating a
  *   `timeStart` that would return new values
  * @returns {Number} [output.meta.timeEnd] UNIX timestamp indicating the end of

--- a/src/utils/iot/formatOutputFieldDataFromServer.spec.js
+++ b/src/utils/iot/formatOutputFieldDataFromServer.spec.js
@@ -1,48 +1,67 @@
 import omit from 'lodash.omit';
+import URL from 'url-parse';
 import formatOutputFieldDataFromServer from './formatOutputFieldDataFromServer';
 
 describe('utils/iot/formatOutputFieldDataFromServer', function() {
   let expectedOutputFieldDataRecords;
   let expectedOutputFieldMetadata;
+  let expectedOutputFieldParsedMetadata;
   let formattedOutputFieldData;
-  let outputFieldDataRecords;
-  let outputFieldMetadata;
+  let initialOutputFieldDataRecords;
+  let initialOutputFieldMetadata;
 
   beforeEach(function() {
-    outputFieldDataRecords = fixture.buildList(
-      'outputFieldData',
-      faker.random.number({ min: 1, max: 10 }),
-      null,
-      { fromServer: true }
-    );
-    outputFieldMetadata = {
+    expectedOutputFieldMetadata = {
       count: faker.random.number(),
-      has_more: faker.random.boolean(),
-      next_page_url: faker.internet.url(),
-      next_record_time: faker.date.recent().getTime()
+      hasMore: faker.random.boolean(),
+      nextRecordTime: Math.floor(faker.date.recent().getTime() / 1000)
     };
-    expectedOutputFieldDataRecords = outputFieldDataRecords.map((record) =>
-      omit({ ...record, eventTime: record.event_time }, ['event_time'])
+    expectedOutputFieldParsedMetadata = {
+      limit: faker.random.number(),
+      timeEnd: expectedOutputFieldMetadata.nextRecordTime,
+      timeStart: Math.floor(faker.date.past().getTime() / 1000),
+      window: faker.random.arrayElement([0, 60, 900, 3600])
+    };
+    expectedOutputFieldDataRecords = fixture.buildList(
+      'outputFieldData',
+      faker.random.number({ min: 1, max: 10 })
     );
-    expectedOutputFieldMetadata = omit(
+    initialOutputFieldMetadata = omit(
       {
-        ...outputFieldMetadata,
-        hasMore: outputFieldMetadata.has_more,
-        nextPageUrl: outputFieldMetadata.next_page_url,
-        nextRecordTime: outputFieldMetadata.next_record_time
+        ...expectedOutputFieldMetadata,
+        has_more: expectedOutputFieldMetadata.hasMore,
+        next_page_url:
+          faker.internet.url() +
+          '/outputs/' +
+          faker.random.number() +
+          '/fields/' +
+          faker.hacker.noun() +
+          '/data' +
+          URL.qs.stringify(expectedOutputFieldParsedMetadata, true),
+        next_record_time: expectedOutputFieldMetadata.nextRecordTime
       },
-      ['has_more', 'next_page_url', 'next_record_time']
+      ['hasMore', 'nextRecordTime', 'timeEnd', 'timeStart', 'window']
+    );
+    initialOutputFieldDataRecords = expectedOutputFieldDataRecords.map(
+      (record) =>
+        omit({ ...record, event_time: record.eventTime }, ['eventTime'])
     );
 
     formattedOutputFieldData = formatOutputFieldDataFromServer({
-      meta: outputFieldMetadata,
-      records: outputFieldDataRecords
+      meta: initialOutputFieldMetadata,
+      records: initialOutputFieldDataRecords
     });
   });
 
   it('converts the metadata keys to camelCase', function() {
-    expect(formattedOutputFieldData.meta).to.deep.equal(
+    expect(formattedOutputFieldData.meta).to.include(
       expectedOutputFieldMetadata
+    );
+  });
+
+  it('parses the `next_page_url` query string to be regular metadata', function() {
+    expect(formattedOutputFieldData.meta).to.include(
+      expectedOutputFieldParsedMetadata
     );
   });
 

--- a/src/utils/iot/index.js
+++ b/src/utils/iot/index.js
@@ -1,4 +1,9 @@
 import formatOutputFieldFromServer from './formatOutputFieldFromServer';
 import formatOutputFieldDataFromServer from './formatOutputFieldDataFromServer';
+import parseOutputFieldNextPageUrlMetadata from './parseOutputFieldNextPageUrlMetadata';
 
-export { formatOutputFieldFromServer, formatOutputFieldDataFromServer };
+export {
+  formatOutputFieldFromServer,
+  formatOutputFieldDataFromServer,
+  parseOutputFieldNextPageUrlMetadata
+};

--- a/src/utils/iot/parseOutputFieldMetadata.js
+++ b/src/utils/iot/parseOutputFieldMetadata.js
@@ -1,3 +1,0 @@
-function parseOutputFieldMetadata() {}
-
-export default parseOutputFieldMetadata;

--- a/src/utils/iot/parseOutputFieldMetadata.js
+++ b/src/utils/iot/parseOutputFieldMetadata.js
@@ -1,0 +1,3 @@
+function parseOutputFieldMetadata() {}
+
+export default parseOutputFieldMetadata;

--- a/src/utils/iot/parseOutputFieldNextPageUrlMetadata.js
+++ b/src/utils/iot/parseOutputFieldNextPageUrlMetadata.js
@@ -7,7 +7,7 @@ import URL from 'url-parse';
  * @param {String} url
  *
  * @returns {Object} output
- * @returns {Number} [output.limit = 5000] Number of records to return
+ * @returns {Number} [output.limit] Number of records to return
  * @returns {Number} [output.timeEnd] UNIX timestamp indicating the end of the
  *   query window
  * @returns {Number} [output.timeStart] UNIX timestamp indicating the start of

--- a/src/utils/iot/parseOutputFieldNextPageUrlMetadata.js
+++ b/src/utils/iot/parseOutputFieldNextPageUrlMetadata.js
@@ -1,0 +1,33 @@
+import URL from 'url-parse';
+
+/**
+ * Parses metadata from the provided url. Will coerce fields that should be
+ * numbers from `String` to `Number`
+ *
+ * @param {String} url
+ *
+ * @returns {Object} output
+ * @returns {Number} [output.limit = 5000] Number of records to return
+ * @returns {Number} [output.timeEnd] UNIX timestamp indicating the end of the
+ *   query window
+ * @returns {Number} [output.timeStart] UNIX timestamp indicating the start of
+ *   the query window
+ * @returns {Number} [output.window] The sampling window for records.
+ *   Required if including a timeEnd or timeStart.
+ *   Valid options include: `0`, `60`, `900`, and `3600`
+ *
+ * @private
+ */
+function parseOutputFieldNextPageUrlMetadata(url) {
+  const query = new URL(url, true).query;
+
+  return ['limit', 'timeEnd', 'timeStart', 'window'].reduce((memo, key) => {
+    if (memo[key]) {
+      memo[key] = parseInt(memo[key], 10);
+    }
+
+    return memo;
+  }, query);
+}
+
+export default parseOutputFieldNextPageUrlMetadata;

--- a/src/utils/iot/parseOutputFieldNextPageUrlMetadata.spec.js
+++ b/src/utils/iot/parseOutputFieldNextPageUrlMetadata.spec.js
@@ -1,0 +1,49 @@
+import URL from 'url-parse';
+import parseOutputFieldNextPageUrlMetadata from './parseOutputFieldNextPageUrlMetadata';
+
+describe('utils/iot/parseOutputFieldNextPageUrlMetadata', function() {
+  let expectedMetadata;
+  let metadata;
+
+  beforeEach(function() {
+    expectedMetadata = {
+      limit: faker.random.number(),
+      timeEnd: Math.floor(faker.date.recent().getTime() / 1000),
+      timeStart: Math.floor(faker.date.past().getTime() / 1000),
+      window: faker.random.arrayElement([0, 60, 900, 3600])
+    };
+
+    const url =
+      faker.internet.url() +
+      '/outputs/' +
+      faker.random.number() +
+      '/fields/' +
+      faker.hacker.noun() +
+      '/data' +
+      URL.qs.stringify(expectedMetadata, true);
+    metadata = parseOutputFieldNextPageUrlMetadata(url);
+  });
+
+  it('parses the keys out of the url', function() {
+    expect(metadata).to.include.keys([
+      'limit',
+      'timeEnd',
+      'timeStart',
+      'window'
+    ]);
+  });
+
+  it('converts the number values to numbers', function() {
+    expect(metadata.limit).to.be.a('number');
+    expect(metadata.limit).to.equal(expectedMetadata.limit);
+
+    expect(metadata.timeEnd).to.be.a('number');
+    expect(metadata.timeEnd).to.equal(expectedMetadata.timeEnd);
+
+    expect(metadata.timeStart).to.be.a('number');
+    expect(metadata.timeStart).to.equal(expectedMetadata.timeStart);
+
+    expect(metadata.window).to.be.a('number');
+    expect(metadata.window).to.equal(expectedMetadata.window);
+  });
+});


### PR DESCRIPTION
## Why?
Field data could consist of thousands of records and endusers need the ability to page through them.


## What changed?
- Added the ability to pass options along to the underlying Real Time Feed API when getting field data
- Started parsing the the `next_page_url` that is returned as metadata when requesting field data. The returned data from that url's query string can be directly fed back on a later request as options. This normalizes how options come back from the API to act the same to the enduser as making a request
- Added missing Typedefs related to new Iot module
- Corrected instances where optional keys in objects were marked as required and vice versa
- Ran code examples through Prettier so that the examples matched the rest of the code base
