### PR TITLE
Fixes issue with machineAuth getSessionInfo for multiple audiences

### DIFF
--- a/src/sessionTypes/machineAuth.js
+++ b/src/sessionTypes/machineAuth.js
@@ -101,8 +101,12 @@ class MachineAuth {
       return Promise.reject(new Error('No valid audience found'));
     }
 
-    if (!this._tokenPromise) {
-      this._tokenPromise = axios
+    if (!this.tokenPromises) {
+      this.tokenPromises = {};
+    }
+
+    if (!this.tokenPromises[audienceName]) {
+      this.tokenPromises[audienceName] = axios
         .post(`${this._sdk.config.audiences.contxtAuth.host}/v1/oauth/token`, {
           audience: audience.clientId,
           client_id: this._sdk.config.auth.clientId,
@@ -117,7 +121,7 @@ class MachineAuth {
         })
         .then((sessionInfo) => {
           this._saveSession(audienceName, sessionInfo);
-          this._tokenPromise = null;
+          this.tokenPromises[audienceName] = null;
 
           return sessionInfo;
         })
@@ -132,7 +136,7 @@ class MachineAuth {
         });
     }
 
-    return this._tokenPromise;
+    return this.tokenPromises[audienceName];
   }
 
   /**

--- a/src/sessionTypes/machineAuth.js
+++ b/src/sessionTypes/machineAuth.js
@@ -35,6 +35,7 @@ class MachineAuth {
   constructor(sdk) {
     this._sdk = sdk;
     this._sessionInfo = {};
+    this._tokenPromises = {};
 
     if (!this._sdk.config.auth.clientId) {
       throw new Error('clientId is required for the MachineAuth config');
@@ -101,12 +102,8 @@ class MachineAuth {
       return Promise.reject(new Error('No valid audience found'));
     }
 
-    if (!this.tokenPromises) {
-      this.tokenPromises = {};
-    }
-
-    if (!this.tokenPromises[audienceName]) {
-      this.tokenPromises[audienceName] = axios
+    if (!this._tokenPromises[audienceName]) {
+      this._tokenPromises[audienceName] = axios
         .post(`${this._sdk.config.audiences.contxtAuth.host}/v1/oauth/token`, {
           audience: audience.clientId,
           client_id: this._sdk.config.auth.clientId,
@@ -121,7 +118,7 @@ class MachineAuth {
         })
         .then((sessionInfo) => {
           this._saveSession(audienceName, sessionInfo);
-          this.tokenPromises[audienceName] = null;
+          this._tokenPromises[audienceName] = null;
 
           return sessionInfo;
         })
@@ -136,7 +133,7 @@ class MachineAuth {
         });
     }
 
-    return this.tokenPromises[audienceName];
+    return this._tokenPromises[audienceName];
   }
 
   /**

--- a/src/sessionTypes/machineAuth.spec.js
+++ b/src/sessionTypes/machineAuth.spec.js
@@ -276,7 +276,7 @@ describe('sessionTypes/MachineAuth', function() {
       });
 
       it('saves the axios promise to the instance', function() {
-        expect(machineAuth.tokenPromises[audienceName]).to.equal(promise);
+        expect(machineAuth._tokenPromises[audienceName]).to.equal(promise);
       });
 
       it("saves the new session info the module's instance", function() {
@@ -290,7 +290,7 @@ describe('sessionTypes/MachineAuth', function() {
 
       it('clears out the reference to the axios promise when complete', function() {
         return promise.then(() => {
-          expect(machineAuth.tokenPromises[audienceName]).to.be.null;
+          expect(machineAuth._tokenPromises[audienceName]).to.be.null;
         });
       });
 
@@ -311,7 +311,7 @@ describe('sessionTypes/MachineAuth', function() {
         sdk.config.audiences[audienceName] = fixture.build('audience');
 
         const machineAuth = new MachineAuth(sdk);
-        machineAuth.tokenPromises = {
+        machineAuth._tokenPromises = {
           [audienceName]: expectedPromise
         };
         promise = machineAuth._getNewSessionInfo(audienceName);
@@ -339,7 +339,7 @@ describe('sessionTypes/MachineAuth', function() {
           sdk.config.audiences[audienceNameTwo] = fixture.build('audience');
 
           const machineAuth = new MachineAuth(sdk);
-          machineAuth.tokenPromises = {
+          machineAuth._tokenPromises = {
             [audienceNameOne]: expectedPromiseOne,
             [audienceNameTwo]: expectedPromiseTwo
           };

--- a/src/sessionTypes/machineAuth.spec.js
+++ b/src/sessionTypes/machineAuth.spec.js
@@ -276,7 +276,7 @@ describe('sessionTypes/MachineAuth', function() {
       });
 
       it('saves the axios promise to the instance', function() {
-        expect(machineAuth._tokenPromise).to.equal(promise);
+        expect(machineAuth.tokenPromises[audienceName]).to.equal(promise);
       });
 
       it("saves the new session info the module's instance", function() {
@@ -290,7 +290,7 @@ describe('sessionTypes/MachineAuth', function() {
 
       it('clears out the reference to the axios promise when complete', function() {
         return promise.then(() => {
-          expect(machineAuth._tokenPromise).to.be.null;
+          expect(machineAuth.tokenPromises[audienceName]).to.be.null;
         });
       });
 
@@ -311,7 +311,9 @@ describe('sessionTypes/MachineAuth', function() {
         sdk.config.audiences[audienceName] = fixture.build('audience');
 
         const machineAuth = new MachineAuth(sdk);
-        machineAuth._tokenPromise = expectedPromise;
+        machineAuth.tokenPromises = {
+          [audienceName]: expectedPromise
+        };
         promise = machineAuth._getNewSessionInfo(audienceName);
       });
 
@@ -319,6 +321,38 @@ describe('sessionTypes/MachineAuth', function() {
         expect(promise).to.equal(expectedPromise);
       });
     });
+
+    context(
+      'when tokens are requested for two different audiences',
+      function() {
+        let expectedPromiseOne;
+        let expectedPromiseTwo;
+        let promiseOne;
+        let promiseTwo;
+
+        beforeEach(function() {
+          const audienceNameOne = faker.hacker.adjective();
+          const audienceNameTwo = faker.hacker.adjective();
+          expectedPromiseOne = Promise.resolve();
+          expectedPromiseTwo = Promise.resolve();
+          sdk.config.audiences[audienceNameOne] = fixture.build('audience');
+          sdk.config.audiences[audienceNameTwo] = fixture.build('audience');
+
+          const machineAuth = new MachineAuth(sdk);
+          machineAuth.tokenPromises = {
+            [audienceNameOne]: expectedPromiseOne,
+            [audienceNameTwo]: expectedPromiseTwo
+          };
+          promiseOne = machineAuth._getNewSessionInfo(audienceNameOne);
+          promiseTwo = machineAuth._getNewSessionInfo(audienceNameTwo);
+        });
+
+        it('should return two different promises', function() {
+          expect(promiseOne).to.equal(expectedPromiseOne);
+          expect(promiseTwo).to.equal(expectedPromiseTwo);
+        });
+      }
+    );
 
     context(
       'when there is not a configuration for chosen audience',


### PR DESCRIPTION
## Why?
- Small bug with using `machineAuth` that I discovered while working on EMS API. When calling two functions from two different modules at the same time (for the first time), the incorrect token would get utilized for the second function call.

## What changed?
- Adjusted the function `getSessionInfo` to return a hash of promises, rather than a single promise
