### PR TITLE
FM-118: Feature/asset attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [v0.0.19](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.19) (2018-07-09)
+
+**Added**
+
+* Methods around the display and manipulation of Asset Attributes. They are namespaced under assets (i.e. `assets.attributes.methodName()`) and include:
+  * AssetAttributes#create to add an asset attribute
+  * AssetAttributes#delete to delete an asset attribute
+  * AssetAttributes#get to get an asset attribute
+  * AssetAttributes#getAll to get a list of all asset attributes
+  * AssetAttributes#update to update an asset attribute
+
 ## [v0.0.18](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.18) (2018-07-06)
 
 **Changed**

--- a/docs/AssetAttributes.md
+++ b/docs/AssetAttributes.md
@@ -11,14 +11,12 @@ different asset attributes and their values
     * [.create(assetTypeId, assetAttribute)](#AssetAttributes+create) ⇒ <code>Promise</code>
     * [.delete(assetAttributeId)](#AssetAttributes+delete) ⇒ <code>Promise</code>
     * [.get(assetAttributeId)](#AssetAttributes+get) ⇒ <code>Promise</code>
-    * [.getAll()](#AssetAttributes+getAll)
-    * [.getAllByOrganizationId()](#AssetAttributes+getAllByOrganizationId)
-    * [.update()](#AssetAttributes+update)
+    * [.getAll(assetTypeId)](#AssetAttributes+getAll) ⇒ <code>Promise</code>
+    * [.update(assetAttributeId, update)](#AssetAttributes+update) ⇒ <code>Promise</code>
     * [.createValue()](#AssetAttributes+createValue)
     * [.deleteValue()](#AssetAttributes+deleteValue)
     * [.getValue()](#AssetAttributes+getValue)
     * [.getAllValues()](#AssetAttributes+getAllValues)
-    * [.getAllValuesByOrganizationId()](#AssetAttributes+getAllValuesByOrganizationId)
     * [.updateValue()](#AssetAttributes+updateValue)
 
 <a name="new_AssetAttributes_new"></a>
@@ -111,22 +109,58 @@ contxtSdk.assets.attributes
 ```
 <a name="AssetAttributes+getAll"></a>
 
-### contxtSdk.assets.attributes.getAll()
-Gets a list of asset attributes
+### contxtSdk.assets.attributes.getAll(assetTypeId) ⇒ <code>Promise</code>
+Gets a list of asset attributes for a specific asset type
+
+API Endpoint: '/assets/types/:assetTypeId/attributes'
+Method: GET
 
 **Kind**: instance method of [<code>AssetAttributes</code>](#AssetAttributes)  
-<a name="AssetAttributes+getAllByOrganizationId"></a>
+**Fulfill**: [<code>AssetAttributeData</code>](./Typedefs.md#AssetAttributeData)  
+**Reject**: <code>Error</code>  
 
-### contxtSdk.assets.attributes.getAllByOrganizationId()
-Gets a list of all asset attributes that belong to a particular organization
+| Param | Type | Description |
+| --- | --- | --- |
+| assetTypeId | <code>string</code> | The ID of the asset type (formatted as a UUID) |
 
-**Kind**: instance method of [<code>AssetAttributes</code>](#AssetAttributes)  
+**Example**  
+```js
+contxtSdk.assets.attributes
+  .getAll('4f0e51c6-728b-4892-9863-6d002e61204d')
+  .then((assetAttributesData) => console.log(assetAttributesData))
+  .catch((err) => console.log(err));
+```
 <a name="AssetAttributes+update"></a>
 
-### contxtSdk.assets.attributes.update()
+### contxtSdk.assets.attributes.update(assetAttributeId, update) ⇒ <code>Promise</code>
 Updates an asset attribute
 
+API Endpoint: '/assets/attributes/:assetAttributeId'
+Method: PUT
+
 **Kind**: instance method of [<code>AssetAttributes</code>](#AssetAttributes)  
+**Fulfill**: <code>undefined</code>  
+**Reject**: <code>Error</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| assetAttributeId | <code>string</code> | The ID of the asset attribute to update (formatted as a UUID) |
+| update | <code>Object</code> | An object containing the updated data for the asset attribute |
+| [update.description] | <code>string</code> |  |
+| [update.isRequired] | <code>boolean</code> |  |
+| [update.label] | <code>string</code> |  |
+| [update.units] | <code>string</code> |  |
+
+**Example**  
+```js
+contxtSdk.assets.attributes
+  .update('c7f927c3-11a7-4024-9269-e1231baeb765', {
+    description: 'Temperature of a facility',
+    isRequired: false,
+    label: 'Temperature',
+    units: 'Celsius'
+  });
+```
 <a name="AssetAttributes+createValue"></a>
 
 ### contxtSdk.assets.attributes.createValue()
@@ -149,12 +183,6 @@ Gets an asset attribute value
 
 ### contxtSdk.assets.attributes.getAllValues()
 Gets a list of all asset attribute values
-
-**Kind**: instance method of [<code>AssetAttributes</code>](#AssetAttributes)  
-<a name="AssetAttributes+getAllValuesByOrganizationId"></a>
-
-### contxtSdk.assets.attributes.getAllValuesByOrganizationId()
-Gets a list of all asset attribute values that belong to a particular organization
 
 **Kind**: instance method of [<code>AssetAttributes</code>](#AssetAttributes)  
 <a name="AssetAttributes+updateValue"></a>

--- a/docs/AssetAttributes.md
+++ b/docs/AssetAttributes.md
@@ -1,0 +1,165 @@
+<a name="AssetAttributes"></a>
+
+## AssetAttributes
+Module that provides access to, and the manipulation of, information about
+different asset attributes and their values
+
+**Kind**: global class  
+
+* [AssetAttributes](#AssetAttributes)
+    * [new AssetAttributes(sdk, request, baseUrl)](#new_AssetAttributes_new)
+    * [.create(assetTypeId, assetAttribute)](#AssetAttributes+create) ⇒ <code>Promise</code>
+    * [.delete(assetAttributeId)](#AssetAttributes+delete) ⇒ <code>Promise</code>
+    * [.get(assetAttributeId)](#AssetAttributes+get) ⇒ <code>Promise</code>
+    * [.getAll()](#AssetAttributes+getAll)
+    * [.getAllByOrganizationId()](#AssetAttributes+getAllByOrganizationId)
+    * [.update()](#AssetAttributes+update)
+    * [.createValue()](#AssetAttributes+createValue)
+    * [.deleteValue()](#AssetAttributes+deleteValue)
+    * [.getValue()](#AssetAttributes+getValue)
+    * [.getAllValues()](#AssetAttributes+getAllValues)
+    * [.getAllValuesByOrganizationId()](#AssetAttributes+getAllValuesByOrganizationId)
+    * [.updateValue()](#AssetAttributes+updateValue)
+
+<a name="new_AssetAttributes_new"></a>
+
+### new AssetAttributes(sdk, request, baseUrl)
+
+| Param | Type | Description |
+| --- | --- | --- |
+| sdk | <code>Object</code> | An instance of the SDK so the module can communicate with other modules. |
+| request | <code>Object</code> | An instance of the request module tied to this module's audience. |
+| baseUrl | <code>string</code> | The base URL provided by the parent module |
+
+<a name="AssetAttributes+create"></a>
+
+### contxtSdk.assets.attributes.create(assetTypeId, assetAttribute) ⇒ <code>Promise</code>
+Creates a new asset attribute
+
+API Endpoint: '/assets/types/:assetTypeId/attributes'
+Method: POST
+
+**Kind**: instance method of [<code>AssetAttributes</code>](#AssetAttributes)  
+**Fulfill**: [<code>AssetAttribute</code>](./Typedefs.md#AssetAttribute)  
+**Reject**: <code>Error</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| assetTypeId | <code>string</code> | The ID of the asset type (formatted as a UUID) |
+| assetAttribute | <code>Object</code> |  |
+| assetAttribute.description | <code>string</code> |  |
+| [assetAttribute.isRequired] | <code>boolean</code> |  |
+| assetAttribute.label | <code>string</code> |  |
+| assetAttribute.organizationId | <code>string</code> |  |
+| [assetAttribute.units] | <code>string</code> |  |
+
+**Example**  
+```js
+contxtSdk.assets.attributes
+  .create('4f0e51c6-728b-4892-9863-6d002e61204d', {
+    description: 'Square footage of a facility',
+    isRequired: true,
+    label: 'Square Footage',
+    organizationId: 'b47e45af-3e18-408a-8070-008f9e6d7b42',
+    units: 'sqft'
+  })
+  .then((assetAttribute) => console.log(assetAttribute))
+  .catch((err) => console.log(err));
+```
+<a name="AssetAttributes+delete"></a>
+
+### contxtSdk.assets.attributes.delete(assetAttributeId) ⇒ <code>Promise</code>
+Deletes an asset attribute
+
+API Endpoint: '/assets/attributes/:assetAttributeId'
+Method: DELETE
+
+**Kind**: instance method of [<code>AssetAttributes</code>](#AssetAttributes)  
+**Fulfill**: <code>undefined</code>  
+**Reject**: <code>Error</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| assetAttributeId | <code>string</code> | The ID of the asset attribute (formatted as a UUID) |
+
+**Example**  
+```js
+contxtSdk.assets.attributes.delete('c7f927c3-11a7-4024-9269-e1231baeb765');
+```
+<a name="AssetAttributes+get"></a>
+
+### contxtSdk.assets.attributes.get(assetAttributeId) ⇒ <code>Promise</code>
+Gets information about an asset attribute
+
+API Endpoint: '/assets/attributes/:assetAttributeId'
+Method: GET
+
+**Kind**: instance method of [<code>AssetAttributes</code>](#AssetAttributes)  
+**Fulfill**: [<code>AssetAttribute</code>](./Typedefs.md#AssetAttribute)  
+**Reject**: <code>Error</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| assetAttributeId | <code>string</code> | The ID of the asset attribute (formatted as a UUID) |
+
+**Example**  
+```js
+contxtSdk.assets.attributes
+  .get('c7f927c3-11a7-4024-9269-e1231baeb765')
+  .then((assetAttribute) => console.log(assetAttribute))
+  .catch((err) => console.log(err));
+```
+<a name="AssetAttributes+getAll"></a>
+
+### contxtSdk.assets.attributes.getAll()
+Gets a list of asset attributes
+
+**Kind**: instance method of [<code>AssetAttributes</code>](#AssetAttributes)  
+<a name="AssetAttributes+getAllByOrganizationId"></a>
+
+### contxtSdk.assets.attributes.getAllByOrganizationId()
+Gets a list of all asset attributes that belong to a particular organization
+
+**Kind**: instance method of [<code>AssetAttributes</code>](#AssetAttributes)  
+<a name="AssetAttributes+update"></a>
+
+### contxtSdk.assets.attributes.update()
+Updates an asset attribute
+
+**Kind**: instance method of [<code>AssetAttributes</code>](#AssetAttributes)  
+<a name="AssetAttributes+createValue"></a>
+
+### contxtSdk.assets.attributes.createValue()
+Creates a new asset attribute value
+
+**Kind**: instance method of [<code>AssetAttributes</code>](#AssetAttributes)  
+<a name="AssetAttributes+deleteValue"></a>
+
+### contxtSdk.assets.attributes.deleteValue()
+Deletes an asset attribute value
+
+**Kind**: instance method of [<code>AssetAttributes</code>](#AssetAttributes)  
+<a name="AssetAttributes+getValue"></a>
+
+### contxtSdk.assets.attributes.getValue()
+Gets an asset attribute value
+
+**Kind**: instance method of [<code>AssetAttributes</code>](#AssetAttributes)  
+<a name="AssetAttributes+getAllValues"></a>
+
+### contxtSdk.assets.attributes.getAllValues()
+Gets a list of all asset attribute values
+
+**Kind**: instance method of [<code>AssetAttributes</code>](#AssetAttributes)  
+<a name="AssetAttributes+getAllValuesByOrganizationId"></a>
+
+### contxtSdk.assets.attributes.getAllValuesByOrganizationId()
+Gets a list of all asset attribute values that belong to a particular organization
+
+**Kind**: instance method of [<code>AssetAttributes</code>](#AssetAttributes)  
+<a name="AssetAttributes+updateValue"></a>
+
+### contxtSdk.assets.attributes.updateValue()
+Updates an asset attribute value
+
+**Kind**: instance method of [<code>AssetAttributes</code>](#AssetAttributes)  

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,10 @@
 ## Classes
 
 <dl>
+<dt><a href="./AssetAttributes.md">AssetAttributes</a></dt>
+<dd><p>Module that provides access to, and the manipulation of, information about
+different asset attributes and their values</p>
+</dd>
 <dt><a href="./AssetTypes.md">AssetTypes</a></dt>
 <dd><p>Module that provides access to, and the manipulation of, information about different asset types</p>
 </dd>
@@ -61,6 +65,10 @@ which are obtained from Auth0.</p>
 
 <dl>
 <dt><a href="./Typedefs.md#Asset">Asset</a> : <code>Object</code></dt>
+<dd></dd>
+<dt><a href="./Typedefs.md#AssetAttribute">AssetAttribute</a> : <code>Object</code></dt>
+<dd></dd>
+<dt><a href="./Typedefs.md#AssetAttributeValue">AssetAttributeValue</a> : <code>Object</code></dt>
 <dd></dd>
 <dt><a href="./Typedefs.md#AssetType">AssetType</a> : <code>Object</code></dt>
 <dd></dd>

--- a/docs/README.md
+++ b/docs/README.md
@@ -68,6 +68,8 @@ which are obtained from Auth0.</p>
 <dd></dd>
 <dt><a href="./Typedefs.md#AssetAttribute">AssetAttribute</a> : <code>Object</code></dt>
 <dd></dd>
+<dt><a href="./Typedefs.md#AssetAttributeData">AssetAttributeData</a> : <code>Object</code></dt>
+<dd></dd>
 <dt><a href="./Typedefs.md#AssetAttributeValue">AssetAttributeValue</a> : <code>Object</code></dt>
 <dd></dd>
 <dt><a href="./Typedefs.md#AssetType">AssetType</a> : <code>Object</code></dt>

--- a/docs/Typedefs.md
+++ b/docs/Typedefs.md
@@ -32,6 +32,19 @@
 | [units] | <code>string</code> |  |
 | updatedAt | <code>string</code> | ISO 8601 Extended Format date/time string |
 
+<a name="AssetAttributeData"></a>
+
+## AssetAttributeData : <code>Object</code>
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| _metadata | <code>Object</code> | Metadata about the pagination settings |
+| _metadata.offset | <code>number</code> | Offset of records in subsequent queries |
+| _metadata.totalRecords | <code>number</code> | Total number of asset attributes found |
+| records | [<code>Array.&lt;AssetAttribute&gt;</code>](#AssetAttribute) |  |
+
 <a name="AssetAttributeValue"></a>
 
 ## AssetAttributeValue : <code>Object</code>

--- a/docs/Typedefs.md
+++ b/docs/Typedefs.md
@@ -14,6 +14,41 @@
 | organizationId | <code>string</code> | UUID corresponding with the organization |
 | updatedAt | <code>string</code> | ISO 8601 Extended Format date/time string |
 
+<a name="AssetAttribute"></a>
+
+## AssetAttribute : <code>Object</code>
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| assetTypeId | <code>string</code> | UUID corresponding with the asset type |
+| createdAt | <code>string</code> | ISO 8601 Extended Format date/time string |
+| description | <code>string</code> |  |
+| id | <code>string</code> | UUID |
+| isRequired | <code>boolean</code> |  |
+| label | <code>string</code> |  |
+| organizationId | <code>string</code> | UUID corresponding with the organization |
+| [units] | <code>string</code> |  |
+| updatedAt | <code>string</code> | ISO 8601 Extended Format date/time string |
+
+<a name="AssetAttributeValue"></a>
+
+## AssetAttributeValue : <code>Object</code>
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| assetId | <code>string</code> | UUID corresponding to the asset |
+| assetAttributeId | <code>string</code> | UUID corresponding to the asset attribute |
+| createdAt | <code>string</code> | ISO 8601 Extended Format date/time string |
+| effectiveDate | <code>string</code> | ISO 8601 Extended Format date/time string |
+| id | <code>string</code> | UUID |
+| [notes] | <code>string</code> |  |
+| updatedAt | <code>string</code> | ISO 8601 Extended Format date/time string |
+| value | <code>string</code> |  |
+
 <a name="AssetType"></a>
 
 ## AssetType : <code>Object</code>

--- a/src/assets/assetAttributes.js
+++ b/src/assets/assetAttributes.js
@@ -1,0 +1,294 @@
+import isPlainObject from 'lodash.isplainobject';
+import {
+  formatAssetAttributeDataFromServer,
+  formatAssetAttributeFromServer,
+  formatAssetAttributeToServer
+} from '../utils/assets';
+
+/**
+ * @typedef {Object} AssetAttribute
+ * @property {string} assetTypeId UUID corresponding with the asset type
+ * @property {string} createdAt ISO 8601 Extended Format date/time string
+ * @property {string} description
+ * @property {string} id UUID
+ * @property {boolean} isRequired
+ * @property {string} label
+ * @property {string} organizationId UUID corresponding with the organization
+ * @property {string} [units]
+ * @property {string} updatedAt ISO 8601 Extended Format date/time string
+ */
+
+/**
+ * @typedef {Object} AssetAttributeData
+ * @property {Object} _metadata Metadata about the pagination settings
+ * @property {number} _metadata.offset Offset of records in subsequent queries
+ * @property {number} _metadata.totalRecords Total number of asset attributes found
+ * @property {AssetAttribute[]} records
+ */
+
+/**
+ * @typedef {Object} AssetAttributeValue
+ * @property {string} assetId UUID corresponding to the asset
+ * @property {string} assetAttributeId UUID corresponding to the asset attribute
+ * @property {string} createdAt ISO 8601 Extended Format date/time string
+ * @property {string} effectiveDate ISO 8601 Extended Format date/time string
+ * @property {string} id UUID
+ * @property {string} [notes]
+ * @property {string} updatedAt ISO 8601 Extended Format date/time string
+ * @property {string} value
+ */
+
+/**
+ * Module that provides access to, and the manipulation of, information about
+ * different asset attributes and their values
+ *
+ * @typicalname contxtSdk.assets.attributes
+ */
+class AssetAttributes {
+  /**
+   * @param {Object} sdk An instance of the SDK so the module can communicate with other modules.
+   * @param {Object} request An instance of the request module tied to this module's audience.
+   * @param {string} baseUrl The base URL provided by the parent module
+   */
+  constructor(sdk, request, baseUrl) {
+    this._baseUrl = baseUrl;
+    this._request = request;
+    this._sdk = sdk;
+  }
+
+  /**
+   * Creates a new asset attribute
+   *
+   * API Endpoint: '/assets/types/:assetTypeId/attributes'
+   * Method: POST
+   *
+   * @param {string} assetTypeId The ID of the asset type (formatted as a UUID)
+   *
+   * @param {Object} assetAttribute
+   * @param {string} assetAttribute.description
+   * @param {boolean} [assetAttribute.isRequired]
+   * @param {string} assetAttribute.label
+   * @param {string} assetAttribute.organizationId
+   * @param {string} [assetAttribute.units]
+   *
+   * @returns {Promise}
+   * @fulfill {AssetAttribute}
+   * @reject {Error}
+   *
+   * @example
+   * contxtSdk.assets.attributes
+   *   .create('4f0e51c6-728b-4892-9863-6d002e61204d', {
+   *     description: 'Square footage of a facility',
+   *     isRequired: true,
+   *     label: 'Square Footage',
+   *     organizationId: 'b47e45af-3e18-408a-8070-008f9e6d7b42',
+   *     units: 'sqft'
+   *   })
+   *   .then((assetAttribute) => console.log(assetAttribute))
+   *   .catch((err) => console.log(err));
+   */
+  create(assetTypeId, assetAttribute = {}) {
+    const requiredFields = ['description', 'label', 'organizationId'];
+
+    if (!assetTypeId) {
+      return Promise.reject(
+        new Error(
+          'An asset type ID is required to create a new asset attribute.'
+        )
+      );
+    }
+
+    for (let i = 0; i < requiredFields.length; i++) {
+      const field = requiredFields[i];
+
+      if (!assetAttribute[field]) {
+        return Promise.reject(
+          new Error(`A ${field} is required to create a new asset attribute.`)
+        );
+      }
+    }
+
+    const data = formatAssetAttributeToServer(assetAttribute);
+
+    return this._request
+      .post(`${this._baseUrl}/assets/types/${assetTypeId}/attributes`, data)
+      .then((assetAttribute) => formatAssetAttributeFromServer(assetAttribute));
+  }
+
+  /**
+   * Deletes an asset attribute
+   *
+   * API Endpoint: '/assets/attributes/:assetAttributeId'
+   * Method: DELETE
+   *
+   * @param {string} assetAttributeId The ID of the asset attribute (formatted as a UUID)
+   *
+   * @returns {Promise}
+   * @fulfill {undefined}
+   * @reject {Error}
+   *
+   * @example
+   * contxtSdk.assets.attributes.delete('c7f927c3-11a7-4024-9269-e1231baeb765');
+   */
+  delete(assetAttributeId) {
+    if (!assetAttributeId) {
+      return Promise.reject(
+        new Error(
+          'An asset attribute ID is required for deleting an asset attribute.'
+        )
+      );
+    }
+
+    return this._request.delete(
+      `${this._baseUrl}/assets/attributes/${assetAttributeId}`
+    );
+  }
+
+  /**
+   * Gets information about an asset attribute
+   *
+   * API Endpoint: '/assets/attributes/:assetAttributeId'
+   * Method: GET
+   *
+   * @param {string} assetAttributeId The ID of the asset attribute (formatted as a UUID)
+   *
+   * @returns {Promise}
+   * @fulfill {AssetAttribute}
+   * @reject {Error}
+   *
+   * @example
+   * contxtSdk.assets.attributes
+   *   .get('c7f927c3-11a7-4024-9269-e1231baeb765')
+   *   .then((assetAttribute) => console.log(assetAttribute))
+   *   .catch((err) => console.log(err));
+   */
+  get(assetAttributeId) {
+    if (!assetAttributeId) {
+      return Promise.reject(
+        new Error(
+          'An asset attribute ID is required for getting information about an asset attribute.'
+        )
+      );
+    }
+
+    return this._request
+      .get(`${this._baseUrl}/assets/attributes/${assetAttributeId}`)
+      .then((assetAttribute) => formatAssetAttributeFromServer(assetAttribute));
+  }
+
+  /**
+   * Gets a list of asset attributes
+   *
+   * API Endpoint: '/assets/types/:assetTypeId/attributes'
+   * Method: GET
+   *
+   * @returns {Promise}
+   * @fulfill {AssetAttributeData}
+   * @reject {Error}
+   *
+   * @example
+   * contxtSdk.assets.attributes
+   *   .getAll('4f0e51c6-728b-4892-9863-6d002e61204d')
+   *   .then((assetAttributesData) => console.log(assetAttributesData))
+   *   .catch((err) => console.log(err));
+   */
+  getAll(assetTypeId) {
+    if (!assetTypeId) {
+      return Promise.reject(
+        new Error(
+          'An asset type ID is required to get a list of all asset attributes.'
+        )
+      );
+    }
+
+    return this._request
+      .get(`${this._baseUrl}/assets/types/${assetTypeId}/attributes`)
+      .then((assetAttributeData) =>
+        formatAssetAttributeDataFromServer(assetAttributeData)
+      );
+  }
+
+  /**
+   * Updates an asset attribute
+   *
+   * API Endpoint: '/assets/attributes/:assetAttributeId'
+   * Method: PUT
+   *
+   * @param {string} assetAttributeId The ID of the asset attribute to update (formatted as a UUID)
+   * @param {Object} update An object containing the updated data for the asset attribute
+   * @param {string} [update.description]
+   * @param {boolean} [update.isRequired]
+   * @param {string} [update.label]
+   * @param {string} [update.units]
+   *
+   * @returns {Promise}
+   * @fulfill {undefined}
+   * @reject {Error}
+   *
+   * @example
+   * contxtSdk.assets.attributes
+   *   .update('c7f927c3-11a7-4024-9269-e1231baeb765', {
+   *     description: 'Temperature of a facility',
+   *     isRequired: false,
+   *     label: 'Temperature',
+   *     units: 'Celsius'
+   *   });
+   */
+  update(assetAttributeId, update) {
+    if (!assetAttributeId) {
+      return Promise.reject(
+        new Error(
+          'An asset attribute ID is required to update an asset attribute.'
+        )
+      );
+    }
+
+    if (!update) {
+      return Promise.reject(
+        new Error('An update is required to update an asset attribute.')
+      );
+    }
+
+    if (!isPlainObject(update)) {
+      return Promise.reject(
+        new Error(
+          'The asset attribute update must be a well-formed object with the data you wish to update.'
+        )
+      );
+    }
+
+    const formattedUpdate = formatAssetAttributeToServer(update);
+
+    return this._request.put(
+      `${this._baseUrl}/assets/attributes/${assetAttributeId}`,
+      formattedUpdate
+    );
+  }
+
+  /**
+   * Creates a new asset attribute value
+   */
+  createValue() {}
+
+  /**
+   * Deletes an asset attribute value
+   */
+  deleteValue() {}
+
+  /**
+   * Gets an asset attribute value
+   */
+  getValue() {}
+
+  /**
+   * Gets a list of all asset attribute values
+   */
+  getAllValues() {}
+
+  /**
+   * Updates an asset attribute value
+   */
+  updateValue() {}
+}
+
+export default AssetAttributes;

--- a/src/assets/assetAttributes.js
+++ b/src/assets/assetAttributes.js
@@ -177,10 +177,12 @@ class AssetAttributes {
   }
 
   /**
-   * Gets a list of asset attributes
+   * Gets a list of asset attributes for a specific asset type
    *
    * API Endpoint: '/assets/types/:assetTypeId/attributes'
    * Method: GET
+   *
+   * @param {string} assetTypeId The ID of the asset type (formatted as a UUID)
    *
    * @returns {Promise}
    * @fulfill {AssetAttributeData}

--- a/src/assets/assetAttributes.spec.js
+++ b/src/assets/assetAttributes.spec.js
@@ -188,7 +188,7 @@ describe('Assets/Attributes', function() {
         promise = assetAttributes.delete(expectedAssetAttributeId);
       });
 
-      it('requres to delete the asset attribute', function() {
+      it('requests to delete the asset attribute', function() {
         expect(baseRequest.delete).to.be.calledWith(
           `${expectedHost}/assets/attributes/${expectedAssetAttributeId}`
         );
@@ -382,6 +382,7 @@ describe('Assets/Attributes', function() {
 
         promise = assetAttributes.getAll();
       });
+
       it('throws an error when the asset type ID is missing', function() {
         expect(promise).to.be.rejectedWith(
           'An asset type ID is required to get a list of all asset attributes.'

--- a/src/assets/assetAttributes.spec.js
+++ b/src/assets/assetAttributes.spec.js
@@ -1,0 +1,498 @@
+import omit from 'lodash.omit';
+import AssetAttributes from './assetAttributes';
+import * as assetsUtils from '../utils/assets';
+
+describe('Assets/Attributes', function() {
+  let baseRequest;
+  let baseSdk;
+  let expectedHost;
+
+  beforeEach(function() {
+    this.sandbox = sandbox.create();
+
+    baseRequest = {
+      delete: this.sandbox.stub().resolves(),
+      get: this.sandbox.stub().resolves(),
+      post: this.sandbox.stub().resolves(),
+      put: this.sandbox.stub().resolves()
+    };
+    baseSdk = {
+      config: {
+        audiences: {
+          facilities: fixture.build('audience')
+        }
+      }
+    };
+    expectedHost = faker.internet.url();
+  });
+
+  afterEach(function() {
+    this.sandbox.restore();
+  });
+
+  describe('constructor', function() {
+    let assetAttributes;
+
+    beforeEach(function() {
+      assetAttributes = new AssetAttributes(baseSdk, baseRequest, expectedHost);
+    });
+
+    it('sets a base url for the class instance', function() {
+      expect(assetAttributes._baseUrl).to.equal(expectedHost);
+    });
+
+    it('appends the supplied request module to the class instance', function() {
+      expect(assetAttributes._request).to.deep.equal(baseRequest);
+    });
+
+    it('appends the supplied sdk to the class instance', function() {
+      expect(assetAttributes._sdk).to.deep.equal(baseSdk);
+    });
+  });
+
+  describe('create', function() {
+    context('when all required information is supplied', function() {
+      let assetAttributeFromServerAfterFormat;
+      let assetAttributeFromServerBeforeFormat;
+      let assetAttributeToServerAfterFormat;
+      let assetAttributeToServerBeforeFormat;
+      let assetTypeId;
+      let formatAssetAttributeFromServer;
+      let formatAssetAttributeToServer;
+      let promise;
+      let request;
+
+      beforeEach(function() {
+        assetAttributeFromServerAfterFormat = fixture.build('assetAttribute');
+        assetAttributeFromServerBeforeFormat = fixture.build(
+          'assetAttribute',
+          null,
+          { fromServer: true }
+        );
+        assetAttributeToServerAfterFormat = fixture.build(
+          'assetAttribute',
+          null,
+          { fromServer: true }
+        );
+        assetAttributeToServerBeforeFormat = fixture.build('assetAttribute');
+
+        assetTypeId = fixture.build('assetType').id;
+
+        formatAssetAttributeFromServer = this.sandbox
+          .stub(assetsUtils, 'formatAssetAttributeFromServer')
+          .returns(assetAttributeFromServerAfterFormat);
+        formatAssetAttributeToServer = this.sandbox
+          .stub(assetsUtils, 'formatAssetAttributeToServer')
+          .returns(assetAttributeToServerAfterFormat);
+
+        request = {
+          ...baseRequest,
+          post: this.sandbox
+            .stub()
+            .resolves(assetAttributeFromServerBeforeFormat)
+        };
+
+        const assetAttributes = new AssetAttributes(
+          baseSdk,
+          request,
+          expectedHost
+        );
+
+        promise = assetAttributes.create(
+          assetTypeId,
+          assetAttributeToServerBeforeFormat
+        );
+      });
+
+      it('formats the submitted asset attribute object to send to the server', function() {
+        expect(formatAssetAttributeToServer).to.be.deep.calledWith(
+          assetAttributeToServerBeforeFormat
+        );
+      });
+
+      it('creates a new asset attribute', function() {
+        expect(request.post).to.be.deep.calledWith(
+          `${expectedHost}/assets/types/${assetTypeId}/attributes`,
+          assetAttributeToServerAfterFormat
+        );
+      });
+
+      it('formats the returned asset attribute object', function() {
+        return promise.then(() => {
+          expect(formatAssetAttributeFromServer).to.be.deep.calledWith(
+            assetAttributeFromServerBeforeFormat
+          );
+        });
+      });
+
+      it('returns a fulfilled promise with the new asset attribute information', function() {
+        return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
+          assetAttributeFromServerAfterFormat
+        );
+      });
+    });
+
+    context('when there is missing required information', function() {
+      let assetAttribute;
+      let assetAttributes;
+      let assetTypeId;
+      let promise;
+
+      beforeEach(function() {
+        assetAttribute = fixture.build('assetAttribute');
+        assetAttributes = new AssetAttributes(
+          baseSdk,
+          baseRequest,
+          expectedHost
+        );
+        assetTypeId = fixture.build('assetType').id;
+      });
+
+      it('throws an error if there is no asset type ID provided', function() {
+        promise = assetAttributes.create(null, assetAttribute);
+
+        return expect(promise).to.be.rejectedWith(
+          'An asset type ID is required to create a new asset attribute.'
+        );
+      });
+
+      ['description', 'label', 'organizationId'].forEach((field) => {
+        it(`throws an error when ${field} is missing`, function() {
+          promise = assetAttributes.create(
+            assetTypeId,
+            omit(assetAttribute, [field])
+          );
+
+          return expect(promise).to.be.rejectedWith(
+            `A ${field} is required to create a new asset attribute.`
+          );
+        });
+      });
+    });
+  });
+
+  describe('delete', function() {
+    context('when all required information is supplied', function() {
+      let expectedAssetAttributeId;
+      let promise;
+
+      beforeEach(function() {
+        expectedAssetAttributeId = fixture.build('assetAttribute').id;
+
+        const assetAttributes = new AssetAttributes(
+          baseSdk,
+          baseRequest,
+          expectedHost
+        );
+
+        promise = assetAttributes.delete(expectedAssetAttributeId);
+      });
+
+      it('requres to delete the asset attribute', function() {
+        expect(baseRequest.delete).to.be.calledWith(
+          `${expectedHost}/assets/attributes/${expectedAssetAttributeId}`
+        );
+      });
+
+      it('returns a fulfilled promise', function() {
+        return expect(promise).to.be.fulfilled;
+      });
+    });
+
+    context('when there is missing required information', function() {
+      it('throws an error when the asset attribute ID is missing', function() {
+        const assetAttributes = new AssetAttributes(
+          baseSdk,
+          baseRequest,
+          expectedHost
+        );
+
+        const promise = assetAttributes.delete();
+
+        return expect(promise).to.be.rejectedWith(
+          'An asset attribute ID is required for deleting an asset attribute.'
+        );
+      });
+    });
+  });
+
+  describe('get', function() {
+    context('the asset attribute ID is provided', function() {
+      let assetAttributeFromServerAfterFormat;
+      let assetAttributeFromServerBeforeFormat;
+      let expectedAssetAttributeId;
+      let formatAssetAttributeFromServer;
+      let promise;
+      let request;
+
+      beforeEach(function() {
+        expectedAssetAttributeId = fixture.build('assetAttribute').id;
+        assetAttributeFromServerAfterFormat = fixture.build('assetAttribute', {
+          id: expectedAssetAttributeId
+        });
+        assetAttributeFromServerBeforeFormat = fixture.build(
+          'assetAttribute',
+          assetAttributeFromServerAfterFormat,
+          { fromServer: true }
+        );
+
+        formatAssetAttributeFromServer = this.sandbox
+          .stub(assetsUtils, 'formatAssetAttributeFromServer')
+          .returns(assetAttributeFromServerAfterFormat);
+
+        request = {
+          ...baseRequest,
+          get: this.sandbox
+            .stub()
+            .resolves(assetAttributeFromServerBeforeFormat)
+        };
+
+        const assetAttributes = new AssetAttributes(
+          baseSdk,
+          request,
+          expectedHost
+        );
+
+        promise = assetAttributes.get(expectedAssetAttributeId);
+      });
+
+      it('gets the asset attribute from the server', function() {
+        expect(request.get).to.be.calledWith(
+          `${expectedHost}/assets/attributes/${expectedAssetAttributeId}`
+        );
+      });
+
+      it('formats the asset attribute object', function() {
+        return promise.then(() => {
+          expect(formatAssetAttributeFromServer).to.be.deep.calledWith(
+            assetAttributeFromServerBeforeFormat
+          );
+        });
+      });
+
+      it('returns the requested asset attribute', function() {
+        return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
+          assetAttributeFromServerAfterFormat
+        );
+      });
+    });
+
+    context('the asset attribute ID is not provided', function() {
+      it('throws an error', function() {
+        const assetAttributes = new AssetAttributes(
+          baseSdk,
+          baseRequest,
+          expectedHost
+        );
+        const promise = assetAttributes.get();
+
+        return expect(promise).to.be.rejectedWith(
+          'An asset attribute ID is required for getting information about an asset attribute.'
+        );
+      });
+    });
+  });
+
+  describe('getAll', function() {
+    context('when all required information is supplied', function() {
+      let assetAttributesFromServerAfterFormat;
+      let assetAttributesFromServerBeforeFormat;
+      let assetTypeId;
+      let formatAssetAttributeDataFromServer;
+      let numberOfAssetAttributes;
+      let offset;
+      let promise;
+      let request;
+
+      beforeEach(function() {
+        offset = faker.random.number({ min: 0, max: 100 });
+        numberOfAssetAttributes = faker.random.number({ min: 1, max: 10 });
+        assetTypeId = fixture.build('assetType').id;
+        assetAttributesFromServerAfterFormat = fixture.buildList(
+          'assetAttribute',
+          numberOfAssetAttributes,
+          { assetTypeId }
+        );
+        assetAttributesFromServerBeforeFormat = fixture.buildList(
+          'assetAttribute',
+          numberOfAssetAttributes,
+          { assetTypeId },
+          { fromServer: true }
+        );
+
+        formatAssetAttributeDataFromServer = this.sandbox
+          .stub(assetsUtils, 'formatAssetAttributeDataFromServer')
+          .returns({
+            _metadata: {
+              offset,
+              totalRecords: numberOfAssetAttributes
+            },
+            records: assetAttributesFromServerAfterFormat
+          });
+
+        request = {
+          ...baseRequest,
+          get: this.sandbox.stub().resolves({
+            _metadata: { offset, totalRecords: numberOfAssetAttributes },
+            records: assetAttributesFromServerBeforeFormat
+          })
+        };
+
+        const assetAttributes = new AssetAttributes(
+          baseSdk,
+          request,
+          expectedHost
+        );
+
+        promise = assetAttributes.getAll(assetTypeId);
+      });
+
+      it('gets a list of the asset attributes from the server', function() {
+        expect(request.get).to.be.calledWith(
+          `${expectedHost}/assets/types/${assetTypeId}/attributes`
+        );
+      });
+
+      it('formats the asset attribute data', function() {
+        return promise.then(() => {
+          expect(formatAssetAttributeDataFromServer).to.be.calledOnce;
+        });
+      });
+
+      it('returns a list of asset attributes', function() {
+        return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal({
+          _metadata: {
+            offset,
+            totalRecords: numberOfAssetAttributes
+          },
+          records: assetAttributesFromServerAfterFormat
+        });
+      });
+    });
+
+    context('when there is missing required information', function() {
+      let promise;
+
+      beforeEach(function() {
+        const assetAttributes = new AssetAttributes(
+          baseSdk,
+          baseRequest,
+          expectedHost
+        );
+
+        promise = assetAttributes.getAll();
+      });
+      it('throws an error when the asset type ID is missing', function() {
+        expect(promise).to.be.rejectedWith(
+          'An asset type ID is required to get a list of all asset attributes.'
+        );
+      });
+    });
+  });
+
+  describe('update', function() {
+    context('when all required information is supplied', function() {
+      let assetAttributeToServerAfterFormat;
+      let assetAttributeToServerBeforeFormat;
+      let formatAssetAttributeToServer;
+      let promise;
+
+      beforeEach(function() {
+        assetAttributeToServerAfterFormat = fixture.build(
+          'assetAttribute',
+          null,
+          { fromServer: true }
+        );
+        assetAttributeToServerBeforeFormat = fixture.build('assetAttribute');
+
+        formatAssetAttributeToServer = this.sandbox
+          .stub(assetsUtils, 'formatAssetAttributeToServer')
+          .returns(assetAttributeToServerAfterFormat);
+
+        const assetAttributes = new AssetAttributes(
+          baseSdk,
+          baseRequest,
+          expectedHost
+        );
+
+        promise = assetAttributes.update(
+          assetAttributeToServerBeforeFormat.id,
+          assetAttributeToServerBeforeFormat
+        );
+      });
+
+      it('formats the data into the right format', function() {
+        expect(formatAssetAttributeToServer).to.be.deep.calledWith(
+          assetAttributeToServerBeforeFormat
+        );
+      });
+
+      it('updates the asset attribute', function() {
+        expect(baseRequest.put).to.be.deep.calledWith(
+          `${expectedHost}/assets/attributes/${
+            assetAttributeToServerBeforeFormat.id
+          }`,
+          assetAttributeToServerAfterFormat
+        );
+      });
+
+      it('returns a fulfilled promise', function() {
+        return expect(promise).to.be.fulfilled;
+      });
+    });
+
+    context(
+      'when there is missing or malformed required information',
+      function() {
+        let assetAttributes;
+
+        beforeEach(function() {
+          assetAttributes = new AssetAttributes(
+            baseSdk,
+            baseRequest,
+            expectedHost
+          );
+        });
+
+        it('throws an error when there is not provided asset attribute ID', function() {
+          const assetAttributeUpdate = fixture.build('assetAttribute');
+          const promise = assetAttributes.update(null, assetAttributeUpdate);
+
+          return expect(promise).to.be.rejectedWith(
+            'An asset attribute ID is required to update an asset attribute.'
+          );
+        });
+
+        it('throws an error when there is no update provided', function() {
+          const assetAttributeUpdate = fixture.build('assetAttribute');
+          const promise = assetAttributes.update(assetAttributeUpdate.id);
+
+          return expect(promise).to.be.rejectedWith(
+            'An update is required to update an asset attribute.'
+          );
+        });
+
+        it('throws an error when the update is not a well-formed object', function() {
+          const assetAttributeUpdate = fixture.build('assetAttribute');
+          const promise = assetAttributes.update(assetAttributeUpdate.id, [
+            assetAttributeUpdate
+          ]);
+
+          return expect(promise).to.be.rejectedWith(
+            'The asset attribute update must be a well-formed object with the data you wish to update.'
+          );
+        });
+      }
+    );
+  });
+
+  describe('createValue', function() {});
+
+  describe('deleteValue', function() {});
+
+  describe('getValue', function() {});
+
+  describe('getAllValues', function() {});
+
+  describe('updateValue', function() {});
+});

--- a/src/assets/index.js
+++ b/src/assets/index.js
@@ -1,4 +1,5 @@
 import isPlainObject from 'lodash.isplainobject';
+import AssetAttributes from './assetAttributes';
 import AssetTypes from './assetTypes';
 import {
   formatAssetFromServer,
@@ -43,6 +44,7 @@ class Assets {
     this._request = request;
     this._sdk = sdk;
 
+    this.attributes = new AssetAttributes(sdk, request, baseUrl);
     this.types = new AssetTypes(sdk, request, baseUrl);
   }
 

--- a/src/utils/assets/formatAssetAttributeDataFromServer.js
+++ b/src/utils/assets/formatAssetAttributeDataFromServer.js
@@ -1,0 +1,33 @@
+import { formatAssetAttributeFromServer } from './index';
+/**
+ * Normalizes the paginated asset attribute data returned from the API server
+ *
+ * @param {Object} input
+ * @param {string} input._metadata Metadata about the pagination settings
+ * @param {number} input._metadata.offset Offset of records in subsequent queries
+ * @param {number} input._metadata.totalRecords Total number of asset attributes found
+ * @param {AssetAttribute[]} input.records
+ *
+ * @returns {Object} output
+ * @returns {Object} output._metadata
+ * @returns {number} output._metadata.offset
+ * @returns {number} output._metadata.totalRecords
+ * @returns {AssetAttribute[]} output.records
+ *
+ *
+ * @private
+ */
+function formatAssetAttributeDataFromServer(input) {
+  const _metadata = input._metadata || {};
+  const records = input.records || [];
+
+  return {
+    _metadata: {
+      offset: _metadata.offset,
+      totalRecords: _metadata.totalRecords
+    },
+    records: records.map((record) => formatAssetAttributeFromServer(record))
+  };
+}
+
+export default formatAssetAttributeDataFromServer;

--- a/src/utils/assets/formatAssetAttributeDataFromServer.spec.js
+++ b/src/utils/assets/formatAssetAttributeDataFromServer.spec.js
@@ -1,0 +1,80 @@
+import formatAssetAttributeDataFromServer from './formatAssetAttributeDataFromServer';
+import * as assetsUtils from './index';
+
+describe('utils/assets/formatAssetAttributeDataFromServer', function() {
+  let assetAttributesData;
+  let assetAttributesFromServerBeforeFormat;
+  let assetAttributesFromServerAfterFormat;
+  let expectedAssetAttributesData;
+  let formatAssetAttributeFromServer;
+  let formattedAssetAttributesData;
+  let offset;
+  let totalRecords;
+
+  beforeEach(function() {
+    this.sandbox = sandbox.create();
+
+    offset = faker.random.number({ min: 0, max: 100 });
+    totalRecords = faker.random.number({ min: 1, max: 10 });
+
+    assetAttributesFromServerAfterFormat = fixture.buildList(
+      'assetAttribute',
+      totalRecords
+    );
+    assetAttributesFromServerBeforeFormat = fixture.buildList(
+      'assetAttribute',
+      totalRecords,
+      null,
+      { fromServer: true }
+    );
+
+    assetAttributesData = {
+      _metadata: {
+        offset,
+        totalRecords
+      },
+      records: assetAttributesFromServerBeforeFormat
+    };
+
+    expectedAssetAttributesData = {
+      ...assetAttributesData,
+      records: assetAttributesFromServerAfterFormat
+    };
+
+    formatAssetAttributeFromServer = this.sandbox
+      .stub(assetsUtils, 'formatAssetAttributeFromServer')
+      .callsFake((asset) => {
+        const index = assetAttributesFromServerBeforeFormat.findIndex(
+          (assetBeforeFormat) => {
+            return assetBeforeFormat.id === asset.id;
+          }
+        );
+
+        return assetAttributesFromServerAfterFormat[index];
+      });
+
+    formattedAssetAttributesData = formatAssetAttributeDataFromServer(
+      assetAttributesData
+    );
+  });
+
+  afterEach(function() {
+    this.sandbox.restore();
+  });
+
+  it('formats the asset attribute object', function() {
+    expect(formatAssetAttributeFromServer).to.have.callCount(
+      assetAttributesFromServerBeforeFormat.length
+    );
+
+    assetAttributesFromServerBeforeFormat.forEach((asset) => {
+      expect(formatAssetAttributeFromServer).to.be.deep.calledWith(asset);
+    });
+  });
+
+  it('returns the formatted data', function() {
+    expect(formattedAssetAttributesData).to.deep.equal(
+      expectedAssetAttributesData
+    );
+  });
+});

--- a/src/utils/assets/formatAssetAttributeFromServer.js
+++ b/src/utils/assets/formatAssetAttributeFromServer.js
@@ -1,0 +1,33 @@
+/**
+ * Normalizes the asset attribute object returned from the API server
+ *
+ * @param {Object} input
+ * @param {string} input.asset_type_id UUID corresponding with the asset type
+ * @param {string} input.created_at ISO 8601 Extended Format date/time string
+ * @param {string} input.description
+ * @param {string} input.id UUID
+ * @param {boolean} input.is_required
+ * @param {string} input.label
+ * @param {string} input.organization_id UUID corresponding with the organization
+ * @param {string} [input.units]
+ * @param {string} input.updated_at ISO 8601 Extended Format date/time string
+ *
+ * @returns {Asset}
+ *
+ * @private
+ */
+function formatAssetAttributeFromServer(input = {}) {
+  return {
+    assetTypeId: input.asset_type_id,
+    createdAt: input.created_at,
+    description: input.description,
+    id: input.id,
+    isRequired: input.is_required,
+    label: input.label,
+    organizationId: input.organization_id,
+    units: input.units,
+    updatedAt: input.updated_at
+  };
+}
+
+export default formatAssetAttributeFromServer;

--- a/src/utils/assets/formatAssetAttributeFromServer.spec.js
+++ b/src/utils/assets/formatAssetAttributeFromServer.spec.js
@@ -1,0 +1,37 @@
+import omit from 'lodash.omit';
+import formatAssetAttributeFromServer from './formatAssetAttributeFromServer';
+
+describe('utils/assets/formatAssetAttributeFromServer', function() {
+  let assetAttribute;
+  let expectedAssetAttribute;
+  let formattedAssetAttribute;
+
+  beforeEach(function() {
+    assetAttribute = fixture.build('assetAttribute', null, {
+      fromServer: true
+    });
+    expectedAssetAttribute = omit(
+      {
+        ...assetAttribute,
+        assetTypeId: assetAttribute.asset_type_id,
+        createdAt: assetAttribute.created_at,
+        isRequired: assetAttribute.is_required,
+        organizationId: assetAttribute.organization_id,
+        updatedAt: assetAttribute.updated_at
+      },
+      [
+        'asset_type_id',
+        'created_at',
+        'is_required',
+        'organization_id',
+        'updated_at'
+      ]
+    );
+
+    formattedAssetAttribute = formatAssetAttributeFromServer(assetAttribute);
+  });
+
+  it('converts the object keys to camel case', function() {
+    expect(formattedAssetAttribute).to.deep.equal(expectedAssetAttribute);
+  });
+});

--- a/src/utils/assets/formatAssetAttributeToServer.js
+++ b/src/utils/assets/formatAssetAttributeToServer.js
@@ -1,0 +1,25 @@
+/**
+ * Normalizes the asset attribute object being sent to the API server
+ *
+ * @param {AssetAttribute} input
+ *
+ * @returns {Object} output
+ * @returns {string} output.description
+ * @returns {boolean} [output.is_required]
+ * @returns {string} output.label
+ * @returns {string} output.organization_id UUID corresponding with the organization
+ * @returns {string} [output.units]
+ *
+ * @private
+ */
+function formatAssetAttributeToServer(input = {}) {
+  return {
+    description: input.description,
+    is_required: input.isRequired,
+    label: input.label,
+    organization_id: input.organizationId,
+    units: input.units
+  };
+}
+
+export default formatAssetAttributeToServer;

--- a/src/utils/assets/formatAssetAttributeToServer.spec.js
+++ b/src/utils/assets/formatAssetAttributeToServer.spec.js
@@ -1,0 +1,33 @@
+import omit from 'lodash.omit';
+import formatAssetAttributeToServer from './formatAssetAttributeToServer';
+
+describe('utils/assets/formatAssetAttributeToServer', function() {
+  let assetAttribute;
+  let expectedAssetAttribute;
+  let formattedAssetAttribute;
+
+  beforeEach(function() {
+    assetAttribute = fixture.build('assetAttribute');
+    expectedAssetAttribute = omit(
+      {
+        ...assetAttribute,
+        is_required: assetAttribute.isRequired,
+        organization_id: assetAttribute.organizationId
+      },
+      [
+        'assetTypeId',
+        'createdAt',
+        'id',
+        'isRequired',
+        'organizationId',
+        'updatedAt'
+      ]
+    );
+
+    formattedAssetAttribute = formatAssetAttributeToServer(assetAttribute);
+  });
+
+  it('converts the object keys to snake case', function() {
+    expect(formattedAssetAttribute).to.deep.equal(expectedAssetAttribute);
+  });
+});

--- a/src/utils/assets/index.js
+++ b/src/utils/assets/index.js
@@ -1,3 +1,6 @@
+import formatAssetAttributeDataFromServer from './formatAssetAttributeDataFromServer';
+import formatAssetAttributeFromServer from './formatAssetAttributeFromServer';
+import formatAssetAttributeToServer from './formatAssetAttributeToServer';
 import formatAssetFromServer from './formatAssetFromServer';
 import formatAssetOptionsToServer from './formatAssetOptionsToServer';
 import formatAssetsDataFromServer from './formatAssetsDataFromServer';
@@ -7,6 +10,9 @@ import formatAssetTypesDataFromServer from './formatAssetTypesDataFromServer';
 import formatAssetTypeToServer from './formatAssetTypeToServer';
 
 export {
+  formatAssetAttributeDataFromServer,
+  formatAssetAttributeFromServer,
+  formatAssetAttributeToServer,
   formatAssetFromServer,
   formatAssetOptionsToServer,
   formatAssetsDataFromServer,

--- a/support/fixtures/factories/assetAttribute.js
+++ b/support/fixtures/factories/assetAttribute.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const factory = require('rosie').Factory;
+const faker = require('faker');
+
+factory
+  .define('assetAttribute')
+  .attrs({
+    assetTypeId: () => factory.build('assetType').id,
+    createdAt: () => faker.date.past().toISOString(),
+    description: () => faker.lorem.sentence(),
+    id: () => faker.random.uuid(),
+    isRequired: () => faker.random.boolean(),
+    label: () => faker.hacker.phrase(),
+    organizationId: () => factory.build('organization').id,
+    units: () => faker.lorem.sentence(),
+    updatedAt: () => faker.date.recent().toISOString()
+  })
+  .after((assetAttribute, options) => {
+    // If building an asset attribute object that comes from the server,
+    // transform it to have camel case
+    if (options.fromServer) {
+      assetAttribute.asset_type_id = assetAttribute.assetTypeId;
+      delete assetAttribute.assetTypeId;
+
+      assetAttribute.created_at = assetAttribute.createdAt;
+      delete assetAttribute.createdAt;
+
+      assetAttribute.is_required = assetAttribute.isRequired;
+      delete assetAttribute.isRequired;
+
+      assetAttribute.organization_id = assetAttribute.organizationId;
+      delete assetAttribute.organizationId;
+
+      assetAttribute.updated_at = assetAttribute.updatedAt;
+      delete assetAttribute.updatedAt;
+    }
+  });

--- a/support/fixtures/factories/assetAttribute.js
+++ b/support/fixtures/factories/assetAttribute.js
@@ -5,6 +5,7 @@ const faker = require('faker');
 
 factory
   .define('assetAttribute')
+  .option('fromServer', false)
   .attrs({
     assetTypeId: () => factory.build('assetType').id,
     createdAt: () => faker.date.past().toISOString(),

--- a/support/fixtures/factories/index.js
+++ b/support/fixtures/factories/index.js
@@ -3,6 +3,7 @@
 const factory = require('rosie').Factory;
 
 require('./asset');
+require('./assetAttribute');
 require('./assetType');
 require('./audience');
 require('./costCenter');


### PR DESCRIPTION
## Why?

https://ndustrialio.atlassian.net/browse/FM-118

Add in methods for asset attributes to the sdk

## What changed?
- Add in CRUD methods for asset attributes
  - `create`, `delete`, `get`, `getAll`, `update`
- Add specs, formatters, etc.
- Update `CHANGELOG.md`