### PR TITLE
Feature/support data type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,18 @@
-## [v0.0.21](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.21) (2018-07-13)
-
-**Changed**
-
-* Now supporting the `data_type` field for `AssetAttributes`
-
-## [v0.0.20](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.20) (2018-07-12)
+## [v0.0.20](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.20) (2018-07-16)
 
 **Added**
 
 * Methods around the display and manipulation of Asset Attributes Values. They are namespaced under assets (i.e. `assets.attributes.methodName()`) and include:
+
   * AssetAttributes#createValue to add an asset attribute value
   * AssetAttributes#deleteValue to delete an asset attribute value
   * AssetAttributes#getValuesByAssetId to get asset attribute values for a particular asset
   * AssetAttributes#getValuesByAttributeId to get a paginated list of asset attribute values for a particular attribute of a particular asset
   * AssetAttributes#updateValue to update an asset attribute value
+
+**Changed**
+
+* Now supporting the `data_type` field for `AssetAttributes`
 
 ## [v0.0.19](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.19) (2018-07-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [v0.0.21](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.21) (2018-07-13)
+
+**Changed**
+
+* Now supporting the `data_type` field for `AssetAttributes`
+
 ## [v0.0.20](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.20) (2018-07-12)
 
 **Added**

--- a/docs/AssetAttributes.md
+++ b/docs/AssetAttributes.md
@@ -45,6 +45,7 @@ Method: POST
 | --- | --- | --- |
 | assetTypeId | <code>string</code> | The ID of the asset type (formatted as a UUID) |
 | assetAttribute | <code>Object</code> |  |
+| assetAttribute.dataType | <code>string</code> |  |
 | assetAttribute.description | <code>string</code> |  |
 | [assetAttribute.isRequired] | <code>boolean</code> |  |
 | assetAttribute.label | <code>string</code> |  |
@@ -55,6 +56,7 @@ Method: POST
 ```js
 contxtSdk.assets.attributes
   .create('4f0e51c6-728b-4892-9863-6d002e61204d', {
+    dataType: 'boolean',
     description: 'Square footage of a facility',
     isRequired: true,
     label: 'Square Footage',
@@ -146,6 +148,7 @@ Method: PUT
 | --- | --- | --- |
 | assetAttributeId | <code>string</code> | The ID of the asset attribute to update (formatted as a UUID) |
 | update | <code>Object</code> | An object containing the updated data for the asset attribute |
+| [update.dataType] | <code>string</code> |  |
 | [update.description] | <code>string</code> |  |
 | [update.isRequired] | <code>boolean</code> |  |
 | [update.label] | <code>string</code> |  |
@@ -155,6 +158,7 @@ Method: PUT
 ```js
 contxtSdk.assets.attributes
   .update('c7f927c3-11a7-4024-9269-e1231baeb765', {
+    dataType: 'boolean',
     description: 'Temperature of a facility',
     isRequired: false,
     label: 'Temperature',

--- a/docs/Typedefs.md
+++ b/docs/Typedefs.md
@@ -24,6 +24,7 @@
 | --- | --- | --- |
 | assetTypeId | <code>string</code> | UUID corresponding with the asset type |
 | createdAt | <code>string</code> | ISO 8601 Extended Format date/time string |
+| dataType | <code>string</code> | Data Type of attribute with options "boolean", "date", "number", "string" |
 | description | <code>string</code> |  |
 | id | <code>string</code> | UUID |
 | isRequired | <code>boolean</code> |  |

--- a/src/assets/assetAttributes.js
+++ b/src/assets/assetAttributes.js
@@ -27,6 +27,7 @@ import {
  * @typedef {Object} AssetAttribute
  * @property {string} assetTypeId UUID corresponding with the asset type
  * @property {string} createdAt ISO 8601 Extended Format date/time string
+ * @property {string} dataType Data Type of attribute with options "boolean", "date", "number", "string"
  * @property {string} description
  * @property {string} id UUID
  * @property {boolean} isRequired
@@ -86,6 +87,7 @@ class AssetAttributes {
    *
    * @param {string} assetTypeId The ID of the asset type (formatted as a UUID)
    * @param {Object} assetAttribute
+   * @param {string} assetAttribute.dataType
    * @param {string} assetAttribute.description
    * @param {boolean} [assetAttribute.isRequired]
    * @param {string} assetAttribute.label
@@ -99,6 +101,7 @@ class AssetAttributes {
    * @example
    * contxtSdk.assets.attributes
    *   .create('4f0e51c6-728b-4892-9863-6d002e61204d', {
+   *     dataType: 'boolean',
    *     description: 'Square footage of a facility',
    *     isRequired: true,
    *     label: 'Square Footage',
@@ -239,6 +242,7 @@ class AssetAttributes {
    *
    * @param {string} assetAttributeId The ID of the asset attribute to update (formatted as a UUID)
    * @param {Object} update An object containing the updated data for the asset attribute
+   * @param {string} [update.dataType]
    * @param {string} [update.description]
    * @param {boolean} [update.isRequired]
    * @param {string} [update.label]
@@ -251,6 +255,7 @@ class AssetAttributes {
    * @example
    * contxtSdk.assets.attributes
    *   .update('c7f927c3-11a7-4024-9269-e1231baeb765', {
+   *     dataType: 'boolean',
    *     description: 'Temperature of a facility',
    *     isRequired: false,
    *     label: 'Temperature',

--- a/src/utils/assets/formatAssetAttributeFromServer.js
+++ b/src/utils/assets/formatAssetAttributeFromServer.js
@@ -4,6 +4,7 @@
  * @param {Object} input
  * @param {string} input.asset_type_id UUID corresponding with the asset type
  * @param {string} input.created_at ISO 8601 Extended Format date/time string
+ * @param {string} input.data_type
  * @param {string} input.description
  * @param {string} input.id UUID
  * @param {boolean} input.is_required
@@ -20,6 +21,7 @@ function formatAssetAttributeFromServer(input = {}) {
   return {
     assetTypeId: input.asset_type_id,
     createdAt: input.created_at,
+    dataType: input.data_type,
     description: input.description,
     id: input.id,
     isRequired: input.is_required,

--- a/src/utils/assets/formatAssetAttributeFromServer.spec.js
+++ b/src/utils/assets/formatAssetAttributeFromServer.spec.js
@@ -15,6 +15,7 @@ describe('utils/assets/formatAssetAttributeFromServer', function() {
         ...assetAttribute,
         assetTypeId: assetAttribute.asset_type_id,
         createdAt: assetAttribute.created_at,
+        dataType: assetAttribute.data_type,
         isRequired: assetAttribute.is_required,
         organizationId: assetAttribute.organization_id,
         updatedAt: assetAttribute.updated_at
@@ -22,6 +23,7 @@ describe('utils/assets/formatAssetAttributeFromServer', function() {
       [
         'asset_type_id',
         'created_at',
+        'data_type',
         'is_required',
         'organization_id',
         'updated_at'

--- a/src/utils/assets/formatAssetAttributeToServer.js
+++ b/src/utils/assets/formatAssetAttributeToServer.js
@@ -4,6 +4,7 @@
  * @param {AssetAttribute} input
  *
  * @returns {Object} output
+ * @returns {string} output.data_type
  * @returns {string} output.description
  * @returns {boolean} [output.is_required]
  * @returns {string} output.label
@@ -14,6 +15,7 @@
  */
 function formatAssetAttributeToServer(input = {}) {
   return {
+    data_type: input.dataType,
     description: input.description,
     is_required: input.isRequired,
     label: input.label,

--- a/src/utils/assets/formatAssetAttributeToServer.spec.js
+++ b/src/utils/assets/formatAssetAttributeToServer.spec.js
@@ -11,12 +11,14 @@ describe('utils/assets/formatAssetAttributeToServer', function() {
     expectedAssetAttribute = omit(
       {
         ...assetAttribute,
+        data_type: assetAttribute.dataType,
         is_required: assetAttribute.isRequired,
         organization_id: assetAttribute.organizationId
       },
       [
         'assetTypeId',
         'createdAt',
+        'dataType',
         'id',
         'isRequired',
         'organizationId',

--- a/support/fixtures/factories/assetAttribute.js
+++ b/support/fixtures/factories/assetAttribute.js
@@ -9,6 +9,8 @@ factory
   .attrs({
     assetTypeId: () => factory.build('assetType').id,
     createdAt: () => faker.date.past().toISOString(),
+    dataType: () =>
+      faker.random.arrayElement(['boolean', 'date', 'number', 'string']),
     description: () => faker.lorem.sentence(),
     id: () => faker.random.uuid(),
     isRequired: () => faker.random.boolean(),
@@ -26,6 +28,9 @@ factory
 
       assetAttribute.created_at = assetAttribute.createdAt;
       delete assetAttribute.createdAt;
+
+      assetAttribute.data_type = assetAttribute.dataType;
+      delete assetAttribute.dataType;
 
       assetAttribute.is_required = assetAttribute.isRequired;
       delete assetAttribute.isRequired;


### PR DESCRIPTION
## Why?

Needs to support `data_type` for `AssetAttribute`s

## What changed?
- Added a `dataType`/`data_type` to the `AssetAttribute` class
- Updated the formatters, fixtures, etc.
- Updated `CHANGELOG.md`
