### PR TITLE
Allow global asset type creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,6 @@
 
 * Updated AssetTypes#create to allow for the creation of global asset types
 
-**Changed**
-
-* Now supporting the `data_type` field for `AssetAttributes`
-
 ## [v0.0.20](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.20) (2018-07-16)
 
 **Added**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [v0.0.20](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.21) (2018-07-23)
+
+**Fixed**
+
+* Updated AssetTypes#create to allow for the creation of global asset types
+
+**Changed**
+
+* Now supporting the `data_type` field for `AssetAttributes`
+
 ## [v0.0.20](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.20) (2018-07-16)
 
 **Added**

--- a/docs/AssetTypes.md
+++ b/docs/AssetTypes.md
@@ -36,12 +36,12 @@ Method: POST
 **Fulfill**: [<code>AssetType</code>](./Typedefs.md#AssetType) Information about the new asset type  
 **Reject**: <code>Error</code>  
 
-| Param | Type |
-| --- | --- |
-| assetType | <code>Object</code> | 
-| assetType.description | <code>string</code> | 
-| assetType.label | <code>string</code> | 
-| assetType.organizationId | <code>string</code> | 
+| Param | Type | Description |
+| --- | --- | --- |
+| assetType | <code>Object</code> |  |
+| assetType.description | <code>string</code> |  |
+| assetType.label | <code>string</code> |  |
+| assetType.organizationId | <code>string</code> | The ID of the asset type's parent organization. Can be   explicitly set to `null` to create a global asset type |
 
 **Example**  
 ```js

--- a/package-lock.json
+++ b/package-lock.json
@@ -4645,6 +4645,11 @@
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
+    "lodash.has": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
+      "integrity": "sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI="
+    },
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "author": "ndustrial.io <dev@ndustrial.io> (ndustrial.io)",
   "license": "ISC",
   "dependencies": {
+    "lodash.has": "^4.5.2",
     "lodash.isplainobject": "^4.0.6",
     "url-parse": "^1.2.0"
   },

--- a/src/assets/assetTypes.js
+++ b/src/assets/assetTypes.js
@@ -1,3 +1,4 @@
+import has from 'lodash.has';
 import isPlainObject from 'lodash.isplainobject';
 import {
   formatAssetTypeFromServer,
@@ -49,7 +50,8 @@ class AssetTypes {
    * @param {Object} assetType
    * @param {string} assetType.description
    * @param {string} assetType.label
-   * @param {string} assetType.organizationId
+   * @param {string} assetType.organizationId The ID of the asset type's parent organization. Can be
+   *   explicitly set to `null` to create a global asset type
    *
    * @returns {Promise}
    * @fulfill {AssetType} Information about the new asset type
@@ -66,12 +68,17 @@ class AssetTypes {
    *   .catch((err) => console.log(err));
    */
   create(assetType = {}) {
+    const hasFieldFns = {
+      default: (object, key) => !!object[key],
+      organizationId: (object, key) => has(object, key)
+    };
     const requiredFields = ['description', 'label', 'organizationId'];
 
     for (let i = 0; i < requiredFields.length; i++) {
       const field = requiredFields[i];
+      const hasField = hasFieldFns[field] || hasFieldFns.default;
 
-      if (!assetType[field]) {
+      if (!hasField(assetType, field)) {
         return Promise.reject(
           new Error(`A ${field} is required to create a new asset type.`)
         );

--- a/src/assets/assetTypes.spec.js
+++ b/src/assets/assetTypes.spec.js
@@ -51,7 +51,75 @@ describe('Assets/Types', function() {
   });
 
   describe('create', function() {
-    context('when all required information is supplied', function() {
+    context(
+      'when creating an asset type tied to a specific organization',
+      function() {
+        let assetTypeFromServerAfterFormat;
+        let assetTypeFromServerBeforeFormat;
+        let assetTypeToServerAfterFormat;
+        let assetTypeToServerBeforeFormat;
+        let formatAssetTypeFromServer;
+        let formatAssetTypeToServer;
+        let promise;
+        let request;
+
+        beforeEach(function() {
+          assetTypeFromServerAfterFormat = fixture.build('assetType');
+          assetTypeFromServerBeforeFormat = fixture.build('assetType', null, {
+            fromServer: true
+          });
+          assetTypeToServerAfterFormat = fixture.build('assetType', null, {
+            fromServer: true
+          });
+          assetTypeToServerBeforeFormat = fixture.build('assetType');
+
+          formatAssetTypeFromServer = this.sandbox
+            .stub(assetsUtils, 'formatAssetTypeFromServer')
+            .returns(assetTypeFromServerAfterFormat);
+          formatAssetTypeToServer = this.sandbox
+            .stub(assetsUtils, 'formatAssetTypeToServer')
+            .returns(assetTypeToServerAfterFormat);
+
+          request = {
+            ...baseRequest,
+            post: this.sandbox.stub().resolves(assetTypeFromServerBeforeFormat)
+          };
+
+          const assetTypes = new AssetTypes(baseSdk, request, expectedHost);
+
+          promise = assetTypes.create(assetTypeToServerBeforeFormat);
+        });
+
+        it('formats the submitted asset type object to send to the server', function() {
+          expect(formatAssetTypeToServer).to.be.deep.calledWith(
+            assetTypeToServerBeforeFormat
+          );
+        });
+
+        it('creates a new asset type', function() {
+          expect(request.post).to.be.deep.calledWith(
+            `${expectedHost}/assets/types`,
+            assetTypeToServerAfterFormat
+          );
+        });
+
+        it('formats the returned asset type object', function() {
+          return promise.then(() => {
+            expect(formatAssetTypeFromServer).to.be.deep.calledWith(
+              assetTypeFromServerBeforeFormat
+            );
+          });
+        });
+
+        it('returns a fulfilled promise with the new asset type information', function() {
+          return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
+            assetTypeFromServerAfterFormat
+          );
+        });
+      }
+    );
+
+    context('when creating a global asset type', function() {
       let assetTypeFromServerAfterFormat;
       let assetTypeFromServerBeforeFormat;
       let assetTypeToServerAfterFormat;
@@ -62,14 +130,22 @@ describe('Assets/Types', function() {
       let request;
 
       beforeEach(function() {
-        assetTypeFromServerAfterFormat = fixture.build('assetType');
-        assetTypeFromServerBeforeFormat = fixture.build('assetType', null, {
-          fromServer: true
+        assetTypeFromServerBeforeFormat = fixture.build('assetType', {
+          organizationId: null
         });
-        assetTypeToServerAfterFormat = fixture.build('assetType', null, {
-          fromServer: true
+        assetTypeFromServerAfterFormat = fixture.build(
+          'assetType',
+          assetTypeToServerBeforeFormat,
+          { fromServer: true }
+        );
+        assetTypeToServerBeforeFormat = fixture.build('assetType', {
+          organizationId: null
         });
-        assetTypeToServerBeforeFormat = fixture.build('assetType');
+        assetTypeToServerAfterFormat = fixture.build(
+          'assetType',
+          assetTypeToServerBeforeFormat,
+          { fromServer: true }
+        );
 
         formatAssetTypeFromServer = this.sandbox
           .stub(assetsUtils, 'formatAssetTypeFromServer')


### PR DESCRIPTION
## Why?
To create a global asset type, `null` is explicitly passed for the organization ID. We were doing a falsey check to make sure the required fields were present, which failed if passing in `null`.

## What changed?
- Wrote custom (and default) "check" functions mechanism to allow for checking if a field is present in different ways