### PR TITLE
Bug Fixes/Enhancements: Session renewal errors & Asset Attribute pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [v0.0.22](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.22) (2018-07-31)
+
+**Changed**
+
+* Started to pass a more robust error when there is a problem renewing tokens with the Auth0WebAuth session adapter
+* Updated AssetAttributes#getAll to pass pagination information along with the request
+
 ## [v0.0.21](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.21) (2018-07-23)
 
 **Fixed**

--- a/docs/AssetAttributes.md
+++ b/docs/AssetAttributes.md
@@ -11,12 +11,12 @@ different asset attributes and their values
     * [.create(assetTypeId, assetAttribute)](#AssetAttributes+create) ⇒ <code>Promise</code>
     * [.delete(assetAttributeId)](#AssetAttributes+delete) ⇒ <code>Promise</code>
     * [.get(assetAttributeId)](#AssetAttributes+get) ⇒ <code>Promise</code>
-    * [.getAll(assetTypeId)](#AssetAttributes+getAll) ⇒ <code>Promise</code>
+    * [.getAll(assetTypeId, [paginationOptions])](#AssetAttributes+getAll) ⇒ <code>Promise</code>
     * [.update(assetAttributeId, update)](#AssetAttributes+update) ⇒ <code>Promise</code>
     * [.createValue(assetId, assetAttributeValue)](#AssetAttributes+createValue) ⇒ <code>Promise</code>
     * [.deleteValue(assetAttributeValueId)](#AssetAttributes+deleteValue) ⇒ <code>Promise</code>
     * [.getEffectiveValuesByAssetId(assetId, [assetAttributeFilters])](#AssetAttributes+getEffectiveValuesByAssetId) ⇒ <code>Promise</code>
-    * [.getValuesByAttributeId(assetId, assetAttributeId, paginationOptions)](#AssetAttributes+getValuesByAttributeId) ⇒ <code>Promise</code>
+    * [.getValuesByAttributeId(assetId, assetAttributeId, [paginationOptions])](#AssetAttributes+getValuesByAttributeId) ⇒ <code>Promise</code>
     * [.updateValue(assetAttributeId, update)](#AssetAttributes+updateValue) ⇒ <code>Promise</code>
 
 <a name="new_AssetAttributes_new"></a>
@@ -111,7 +111,7 @@ contxtSdk.assets.attributes
 ```
 <a name="AssetAttributes+getAll"></a>
 
-### contxtSdk.assets.attributes.getAll(assetTypeId) ⇒ <code>Promise</code>
+### contxtSdk.assets.attributes.getAll(assetTypeId, [paginationOptions]) ⇒ <code>Promise</code>
 Gets a list of asset attributes for a specific asset type
 
 API Endpoint: '/assets/types/:assetTypeId/attributes'
@@ -124,6 +124,7 @@ Method: GET
 | Param | Type | Description |
 | --- | --- | --- |
 | assetTypeId | <code>string</code> | The ID of the asset type (formatted as a UUID) |
+| [paginationOptions] | [<code>PaginationOptions</code>](./Typedefs.md#PaginationOptions) |  |
 
 **Example**  
 ```js
@@ -253,7 +254,7 @@ contxtSdk.assets.attributes
 ```
 <a name="AssetAttributes+getValuesByAttributeId"></a>
 
-### contxtSdk.assets.attributes.getValuesByAttributeId(assetId, assetAttributeId, paginationOptions) ⇒ <code>Promise</code>
+### contxtSdk.assets.attributes.getValuesByAttributeId(assetId, assetAttributeId, [paginationOptions]) ⇒ <code>Promise</code>
 Gets a paginated list of asset attribute values for a particular attribute
 of a particular asset
 
@@ -268,7 +269,7 @@ Method: GET
 | --- | --- | --- |
 | assetId | <code>String</code> | The ID of the asset for which you are looking up   attribute values  (formatted as a UUID) |
 | assetAttributeId | <code>String</code> | The ID of the asset attribute for which you are   looking up attribute values (formatted as a UUID) |
-| paginationOptions | [<code>PaginationOptions</code>](./Typedefs.md#PaginationOptions) |  |
+| [paginationOptions] | [<code>PaginationOptions</code>](./Typedefs.md#PaginationOptions) |  |
 
 **Example**  
 ```js

--- a/src/assets/assetAttributes.js
+++ b/src/assets/assetAttributes.js
@@ -207,6 +207,7 @@ class AssetAttributes {
    * Method: GET
    *
    * @param {string} assetTypeId The ID of the asset type (formatted as a UUID)
+   * @param {PaginationOptions} [paginationOptions]
    *
    * @returns {Promise}
    * @fulfill {AssetAttributeData}
@@ -218,7 +219,7 @@ class AssetAttributes {
    *   .then((assetAttributesData) => console.log(assetAttributesData))
    *   .catch((err) => console.log(err));
    */
-  getAll(assetTypeId) {
+  getAll(assetTypeId, paginationOptions) {
     if (!assetTypeId) {
       return Promise.reject(
         new Error(
@@ -227,10 +228,19 @@ class AssetAttributes {
       );
     }
 
+    const formattedPaginationOptions = formatPaginationOptionsToServer(
+      paginationOptions
+    );
+
     return this._request
-      .get(`${this._baseUrl}/assets/types/${assetTypeId}/attributes`)
-      .then((assetAttributeData) =>
-        formatAssetAttributeDataFromServer(assetAttributeData)
+      .get(`${this._baseUrl}/assets/types/${assetTypeId}/attributes`, {
+        params: formattedPaginationOptions
+      })
+      .then((assetAttributeValueData) =>
+        formatPaginatedDataFromServer(
+          assetAttributeValueData,
+          formatAssetAttributeDataFromServer
+        )
       );
   }
 
@@ -447,7 +457,7 @@ class AssetAttributes {
    *   attribute values  (formatted as a UUID)
    * @param {String} assetAttributeId The ID of the asset attribute for which you are
    *   looking up attribute values (formatted as a UUID)
-   * @param {PaginationOptions}
+   * @param {PaginationOptions} [paginationOptions]
    *
    * @returns {Promise}
    * @fulfill {AssetAttributeValueData}

--- a/src/sessionTypes/auth0WebAuth.js
+++ b/src/sessionTypes/auth0WebAuth.js
@@ -340,9 +340,13 @@ class Auth0WebAuth {
         })
         .catch((err) => {
           if (!(err.response && err.response.status)) {
-            throw new Error(
+            const wrapperError = new Error(
               'There was a problem getting new session info. Please check your configuration settings.'
             );
+            wrapperError.fromSdk = true;
+            wrapperError.originalError = err;
+
+            throw wrapperError;
           }
 
           throw err;


### PR DESCRIPTION
## Why?
1. When there is no valid status code returned when attempting to refresh an Auth0 and/or API token in the Auth0WebAuth session type, we were not including enough relevant information to debug problems that may occur.
2. We were not allowing for pagination information to be sent when requesting all Asset Attributes

## What changed?
- Set up a more robust error that includes the original error when renewing a session
- Start passing pagination info when getting AssetAttributes
