### PR TITLE
Fix issue in MachineAuth#_getNewSessionInfo test where two audiences were accidentally named the same occasionally

### DIFF
--- a/src/sessionTypes/machineAuth.spec.js
+++ b/src/sessionTypes/machineAuth.spec.js
@@ -332,7 +332,7 @@ describe('sessionTypes/MachineAuth', function() {
 
         beforeEach(function() {
           const audienceNameOne = faker.hacker.adjective();
-          const audienceNameTwo = faker.hacker.adjective();
+          const audienceNameTwo = faker.lorem.word();
           expectedPromiseOne = Promise.resolve();
           expectedPromiseTwo = Promise.resolve();
           sdk.config.audiences[audienceNameOne] = fixture.build('audience');


### PR DESCRIPTION
## Why?
A test that checked that two separate promises were returned from MachineAuth#_getNewSessionInfo was failing because occasionally, the audiences requested were accidentally named the same.

## What changed?
- Changed one of the audiences to be named differently

Fixes #52