### PR TITLE
Adds Contxt Coordinator Utility functions

### DIFF
--- a/src/utils/coordinator/formatOrganizationFromServer.js
+++ b/src/utils/coordinator/formatOrganizationFromServer.js
@@ -1,0 +1,25 @@
+/**
+ * Normalizes the organization object returned from the API server
+ *
+ * @param {Object} input
+ * @param {string} input.created_at ISO 8601 Extended Format date/time string
+ * @param {string} input.id UUID
+ * @param {number} input.legacy_organization_id
+ * @param {string} input.name
+ * @param {string} input.updated_at ISO 8601 Extended Format date/time string
+ *
+ * @returns {ContxtOrganization}
+ *
+ * @private
+ */
+function formatOrganizationFromServer(input = {}) {
+  return {
+    createdAt: input.created_at,
+    id: input.id,
+    legacyOrganizationId: input.legacy_organization_id,
+    name: input.name,
+    updatedAt: input.updated_at
+  };
+}
+
+export default formatOrganizationFromServer;

--- a/src/utils/coordinator/formatOrganizationFromServer.spec.js
+++ b/src/utils/coordinator/formatOrganizationFromServer.spec.js
@@ -1,0 +1,27 @@
+import omit from 'lodash.omit';
+import formatOrganizationFromServer from './formatOrganizationFromServer';
+
+describe('utils/events/formatOrganizationFromServer', function() {
+  let expectedOrg;
+  let formattedOrg;
+  let org;
+
+  beforeEach(function() {
+    org = fixture.build('contxtOrganization', null, { fromServer: true });
+    expectedOrg = omit(
+      {
+        ...org,
+        createdAt: org.created_at,
+        legacyOrganizationId: org.legacy_organization_id,
+        updatedAt: org.updated_at
+      },
+      ['created_at', 'legacy_organization_id', 'updated_at']
+    );
+
+    formattedOrg = formatOrganizationFromServer(org);
+  });
+
+  it('converts the object keys to camelCase', function() {
+    expect(formattedOrg).to.deep.equal(expectedOrg);
+  });
+});

--- a/src/utils/coordinator/formatUserFromServer.js
+++ b/src/utils/coordinator/formatUserFromServer.js
@@ -1,0 +1,33 @@
+/**
+ * Normalizes the user object returned from the API server
+ *
+ * @param {Object} input
+ * @param {string} input.created_at ISO 8601 Extended Format date/time string
+ * @param {string} input.email
+ * @param {string} input.first_name
+ * @param {string} input.id Auth0 ID for the user
+ * @param {boolean} input.is_activated
+ * @param {boolean} input.is_superuser
+ * @param {string} input.last_name
+ * @param {string} [input.phone_number]
+ * @param {string} input.updated_at ISO 8601 Extended Format date/time string
+ *
+ * @returns {ContxtUser}
+ *
+ * @private
+ */
+function formatUserFromServer(input = {}) {
+  return {
+    createdAt: input.created_at,
+    email: input.email,
+    firstName: input.first_name,
+    id: input.id,
+    isActivated: input.is_activated,
+    isSuperuser: input.is_superuser,
+    lastName: input.last_name,
+    phoneNumber: input.phone_number,
+    updatedAt: input.updated_at
+  };
+}
+
+export default formatUserFromServer;

--- a/src/utils/coordinator/formatUserFromServer.spec.js
+++ b/src/utils/coordinator/formatUserFromServer.spec.js
@@ -1,0 +1,39 @@
+import omit from 'lodash.omit';
+import formatUserFromServer from './formatUserFromServer';
+
+describe('utils/events/formatUserFromServer', function() {
+  let expectedUser;
+  let formattedUser;
+  let user;
+
+  beforeEach(function() {
+    user = fixture.build('contxtUser', null, { fromServer: true });
+    expectedUser = omit(
+      {
+        ...user,
+        createdAt: user.created_at,
+        firstName: user.first_name,
+        isActivated: user.is_activated,
+        isSuperuser: user.is_superuser,
+        lastName: user.last_name,
+        phoneNumber: user.phone_number,
+        updatedAt: user.updated_at
+      },
+      [
+        'created_at',
+        'first_name',
+        'is_activated',
+        'is_superuser',
+        'last_name',
+        'phone_number',
+        'updated_at'
+      ]
+    );
+
+    formattedUser = formatUserFromServer(user);
+  });
+
+  it('converts the object keys to camelCase', function() {
+    expect(formattedUser).to.deep.equal(expectedUser);
+  });
+});

--- a/src/utils/coordinator/index.js
+++ b/src/utils/coordinator/index.js
@@ -1,0 +1,4 @@
+import formatOrganizationFromServer from './formatOrganizationFromServer';
+import formatUserFromServer from './formatUserFromServer';
+
+export { formatOrganizationFromServer, formatUserFromServer };

--- a/support/fixtures/factories/contxtOrganization.js
+++ b/support/fixtures/factories/contxtOrganization.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const factory = require('rosie').Factory;
+const faker = require('faker');
+
+factory
+  .define('contxtOrganization')
+  .option('fromServer', false)
+  .attrs({
+    createdAt: () => faker.date.past().toISOString(),
+    id: () => faker.random.uuid(),
+    legacyOrganizationId: () => faker.random.number(),
+    name: () => faker.name.title(),
+    updatedAt: () => faker.date.recent().toISOString()
+  })
+  .after((org, options) => {
+    // If building an organization object that comes from the server, transform it to have camel
+    // case and capital letters in the right spots
+    if (options.fromServer) {
+      org.created_at = org.createdAt;
+      delete org.createdAt;
+
+      org.legacy_organization_id = org.legacyOrganizationId;
+      delete org.legacyOrganizationId;
+
+      org.updated_at = org.updatedAt;
+      delete org.updatedAt;
+    }
+  });

--- a/support/fixtures/factories/contxtUser.js
+++ b/support/fixtures/factories/contxtUser.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const factory = require('rosie').Factory;
+const faker = require('faker');
+
+factory
+  .define('contxtUser')
+  .option('fromServer', false)
+  .attrs({
+    createdAt: () => faker.date.past().toISOString(),
+    email: () => faker.internet.email(),
+    firstName: () => faker.name.firstName(),
+    id: () => `auth0|${faker.internet.password()}`,
+    isActivated: () => faker.random.boolean(),
+    isSuperuser: () => faker.random.boolean(),
+    lastName: () => faker.name.lastName(),
+    phoneNumber: () => faker.phone.phoneNumber(),
+    updatedAt: () => faker.date.recent().toISOString()
+  })
+  .after((user, options) => {
+    // If building a user object that comes from the server, transform it to have camel
+    // case and capital letters in the right spots
+    if (options.fromServer) {
+      user.created_at = user.createdAt;
+      delete user.createdAt;
+
+      user.first_name = user.firstName;
+      delete user.firstName;
+
+      user.is_activated = user.isActivated;
+      delete user.isActivated;
+
+      user.is_superuser = user.isSuperuser;
+      delete user.isSuperuser;
+
+      user.last_name = user.lastName;
+      delete user.lastName;
+
+      user.phone_number = user.phoneNumber;
+      delete user.phoneNumber;
+
+      user.updated_at = user.updatedAt;
+      delete user.updatedAt;
+    }
+  });

--- a/support/fixtures/factories/index.js
+++ b/support/fixtures/factories/index.js
@@ -7,6 +7,8 @@ require('./assetAttribute');
 require('./assetAttributeValue');
 require('./assetType');
 require('./audience');
+require('./contxtOrganization');
+require('./contxtUser');
 require('./costCenter');
 require('./costCenterFacility');
 require('./defaultAudiences');


### PR DESCRIPTION
## Why?
- In preparation for incorporating a `Coordinator` module to contact the Contxt Coordinator API, I have added some utility functions

## What changed?
- Added a `utils/coordinator` with:
  - `formatOrganizationFromServer`
  - `formatUserFromServer`
- Note: Only doing the `fromServer` part, since we only do `GET` requests to these endpoints
- Added tests