### PR TITLE
Adds Coordinator module

### DIFF
--- a/docs/Coordinator.md
+++ b/docs/Coordinator.md
@@ -1,0 +1,67 @@
+<a name="Coordinator"></a>
+
+## Coordinator
+Module that provides access to information about Contxt
+
+**Kind**: global class  
+
+* [Coordinator](#Coordinator)
+    * [new Coordinator(sdk, request)](#new_Coordinator_new)
+    * [.getOrganization(organizationId)](#Coordinator+getOrganization) ⇒ <code>Promise</code>
+    * [.getUser(userId)](#Coordinator+getUser) ⇒ <code>Promise</code>
+
+<a name="new_Coordinator_new"></a>
+
+### new Coordinator(sdk, request)
+
+| Param | Type | Description |
+| --- | --- | --- |
+| sdk | <code>Object</code> | An instance of the SDK so the module can communicate with other modules |
+| request | <code>Object</code> | An instance of the request module tied to this module's audience. |
+
+<a name="Coordinator+getOrganization"></a>
+
+### contxtSdk.coordinator.getOrganization(organizationId) ⇒ <code>Promise</code>
+Gets information about a contxt organization
+
+API Endpoint: '/organizations/:organizationId'
+Method: GET
+
+**Kind**: instance method of [<code>Coordinator</code>](#Coordinator)  
+**Fulfill**: [<code>ContxtOrganization</code>](./Typedefs.md#ContxtOrganization) Information about a contxt organization  
+**Reject**: <code>Error</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| organizationId | <code>string</code> | The ID of the organization |
+
+**Example**  
+```js
+contxtSdk.coordinator
+  .getOrganization('36b8421a-cc4a-4204-b839-1397374fb16b')
+  .then((org) => console.log(org))
+  .catch((err) => console.log(err));
+```
+<a name="Coordinator+getUser"></a>
+
+### contxtSdk.coordinator.getUser(userId) ⇒ <code>Promise</code>
+Gets information about a contxt user
+
+API Endpoint: '/users/:userId'
+Method: GET
+
+**Kind**: instance method of [<code>Coordinator</code>](#Coordinator)  
+**Fulfill**: [<code>ContxtUser</code>](./Typedefs.md#ContxtUser) Information about a contxt user  
+**Reject**: <code>Error</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| userId | <code>string</code> | The ID of the user |
+
+**Example**  
+```js
+contxtSdk.coordinator
+  .getUser('auth0|12345')
+  .then((user) => console.log(user))
+  .catch((err) => console.log(err));
+```

--- a/docs/Coordinator.md
+++ b/docs/Coordinator.md
@@ -7,7 +7,8 @@ Module that provides access to information about Contxt
 
 * [Coordinator](#Coordinator)
     * [new Coordinator(sdk, request)](#new_Coordinator_new)
-    * [.getOrganization(organizationId)](#Coordinator+getOrganization) ⇒ <code>Promise</code>
+    * [.getAllOrganizations()](#Coordinator+getAllOrganizations) ⇒ <code>Promise</code>
+    * [.getOrganizationById(organizationId)](#Coordinator+getOrganizationById) ⇒ <code>Promise</code>
     * [.getUser(userId)](#Coordinator+getUser) ⇒ <code>Promise</code>
 
 <a name="new_Coordinator_new"></a>
@@ -19,9 +20,27 @@ Module that provides access to information about Contxt
 | sdk | <code>Object</code> | An instance of the SDK so the module can communicate with other modules |
 | request | <code>Object</code> | An instance of the request module tied to this module's audience. |
 
-<a name="Coordinator+getOrganization"></a>
+<a name="Coordinator+getAllOrganizations"></a>
 
-### contxtSdk.coordinator.getOrganization(organizationId) ⇒ <code>Promise</code>
+### contxtSdk.coordinator.getAllOrganizations() ⇒ <code>Promise</code>
+Gets information about all contxt organizations
+
+API Endpoint: '/organizations'
+Method: GET
+
+**Kind**: instance method of [<code>Coordinator</code>](#Coordinator)  
+**Fulfill**: <code>ContxtOrganization[]</code> Information about all contxt organizations  
+**Reject**: <code>Error</code>  
+**Example**  
+```js
+contxtSdk.coordinator
+  .getAllOrganizations()
+  .then((orgs) => console.log(orgs))
+  .catch((err) => console.log(err));
+```
+<a name="Coordinator+getOrganizationById"></a>
+
+### contxtSdk.coordinator.getOrganizationById(organizationId) ⇒ <code>Promise</code>
 Gets information about a contxt organization
 
 API Endpoint: '/organizations/:organizationId'
@@ -38,7 +57,7 @@ Method: GET
 **Example**  
 ```js
 contxtSdk.coordinator
-  .getOrganization('36b8421a-cc4a-4204-b839-1397374fb16b')
+  .getOrganizationById('36b8421a-cc4a-4204-b839-1397374fb16b')
   .then((org) => console.log(org))
   .catch((err) => console.log(err));
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,9 @@ enabled in Auth0.</p>
 <dt><a href="./ContxtSdk.md">ContxtSdk</a></dt>
 <dd><p>ContxtSdk constructor</p>
 </dd>
+<dt><a href="./Coordinator.md">Coordinator</a></dt>
+<dd><p>Module that provides access to information about Contxt</p>
+</dd>
 <dt><a href="./CostCenters.md">CostCenters</a></dt>
 <dd><p>Module that provides access to cost centers, and helps manage
 the relationship between those cost centers and facilities</p>
@@ -93,6 +96,10 @@ which are obtained from Auth0.</p>
 <dd><p>An object of interceptors that get called on every request or response.
 More information at <a href="https://github.com/axios/axios#interceptors">axios Interceptors</a></p>
 </dd>
+<dt><a href="./Typedefs.md#ContxtOrganization">ContxtOrganization</a> : <code>Object</code></dt>
+<dd></dd>
+<dt><a href="./Typedefs.md#ContxtUser">ContxtUser</a> : <code>Object</code></dt>
+<dd></dd>
 <dt><a href="./Typedefs.md#CostCenter">CostCenter</a> : <code>Object</code></dt>
 <dd></dd>
 <dt><a href="./Typedefs.md#CostCenterFacility">CostCenterFacility</a> : <code>Object</code></dt>

--- a/docs/Typedefs.md
+++ b/docs/Typedefs.md
@@ -152,6 +152,38 @@ More information at [axios Interceptors](https://github.com/axios/axios#intercep
 | interceptor.fulfilled | <code>function</code> | A function that is run on every successful request or   response |
 | interceptor.rejected | <code>function</code> | A function that is run on every failed request or response |
 
+<a name="ContxtOrganization"></a>
+
+## ContxtOrganization : <code>Object</code>
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| createdAt | <code>string</code> | ISO 8601 Extended Format date/time string |
+| id | <code>string</code> | UUID formatted ID |
+| legacyOrganizationId | <code>number</code> |  |
+| name | <code>string</code> |  |
+| updatedAt | <code>string</code> | ISO 8601 Extended Format date/time string |
+
+<a name="ContxtUser"></a>
+
+## ContxtUser : <code>Object</code>
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| createdAt | <code>string</code> | ISO 8601 Extended Format date/time string |
+| email | <code>string</code> |  |
+| firstName | <code>string</code> |  |
+| id | <code>string</code> |  |
+| isActivated | <code>boolean</code> |  |
+| isSuperuser | <code>boolean</code> |  |
+| lastName | <code>string</code> |  |
+| [phoneNumber] | <code>string</code> |  |
+| updatedAt | <code>string</code> | ISO 8601 Extended Format date/time string |
+
 <a name="CostCenter"></a>
 
 ## CostCenter : <code>Object</code>

--- a/src/config/audiences.js
+++ b/src/config/audiences.js
@@ -9,6 +9,16 @@ export default {
       host: 'https://contxt-auth-staging.api.ndustrial.io'
     }
   },
+  coordinator: {
+    production: {
+      clientId: '8qY2xJob1JAxhmVhIDLCNnGriTM9bct8',
+      host: 'https://contxt.api.ndustrial.io'
+    },
+    staging: {
+      clientId: '8qY2xJob1JAxhmVhIDLCNnGriTM9bct8',
+      host: 'https://contxt-staging.api.ndustrial.io'
+    }
+  },
   events: {
     staging: {
       clientId: 'dn4MaocJFdKtsBy9sFFaTeuJWL1nt5xu',

--- a/src/coordinator/index.js
+++ b/src/coordinator/index.js
@@ -44,6 +44,28 @@ class Coordinator {
   }
 
   /**
+   * Gets information about all contxt organizations
+   *
+   * API Endpoint: '/organizations'
+   * Method: GET
+   *
+   * @returns {Promise}
+   * @fulfill {ContxtOrganization[]} Information about all contxt organizations
+   * @reject {Error}
+   *
+   * @example
+   * contxtSdk.coordinator
+   *   .getAllOrganizations()
+   *   .then((orgs) => console.log(orgs))
+   *   .catch((err) => console.log(err));
+   */
+  getAllOrganizations() {
+    return this._request
+      .get(`${this._baseUrl}/organizations`)
+      .then((orgs) => orgs.map(formatOrganizationFromServer));
+  }
+
+  /**
    * Gets information about a contxt organization
    *
    * API Endpoint: '/organizations/:organizationId'
@@ -57,11 +79,11 @@ class Coordinator {
    *
    * @example
    * contxtSdk.coordinator
-   *   .getOrganization('36b8421a-cc4a-4204-b839-1397374fb16b')
+   *   .getOrganizationById('36b8421a-cc4a-4204-b839-1397374fb16b')
    *   .then((org) => console.log(org))
    *   .catch((err) => console.log(err));
    */
-  getOrganization(organizationId) {
+  getOrganizationById(organizationId) {
     if (!organizationId) {
       return Promise.reject(
         new Error(

--- a/src/coordinator/index.js
+++ b/src/coordinator/index.js
@@ -1,0 +1,109 @@
+import {
+  formatOrganizationFromServer,
+  formatUserFromServer
+} from '../utils/coordinator';
+
+/**
+ * @typedef {Object} ContxtOrganization
+ * @property {string} createdAt ISO 8601 Extended Format date/time string
+ * @property {string} id UUID formatted ID
+ * @property {number} legacyOrganizationId
+ * @property {string} name
+ * @property {string} updatedAt ISO 8601 Extended Format date/time string
+ */
+
+/**
+ * @typedef {Object} ContxtUser
+ * @property {string} createdAt ISO 8601 Extended Format date/time string
+ * @property {string} email
+ * @property {string} firstName
+ * @property {string} id
+ * @property {boolean} isActivated
+ * @property {boolean} isSuperuser
+ * @property {string} lastName
+ * @property {string} [phoneNumber]
+ * @property {string} updatedAt ISO 8601 Extended Format date/time string
+ */
+
+/**
+ * Module that provides access to information about Contxt
+ *
+ * @typicalname contxtSdk.coordinator
+ */
+class Coordinator {
+  /**
+   * @param {Object} sdk An instance of the SDK so the module can communicate with other modules
+   * @param {Object} request An instance of the request module tied to this module's audience.
+   */
+  constructor(sdk, request) {
+    const baseUrl = `${sdk.config.audiences.coordinator.host}/v1`;
+
+    this._baseUrl = baseUrl;
+    this._request = request;
+    this._sdk = sdk;
+  }
+
+  /**
+   * Gets information about a contxt organization
+   *
+   * API Endpoint: '/organizations/:organizationId'
+   * Method: GET
+   *
+   * @param {string} organizationId The ID of the organization
+   *
+   * @returns {Promise}
+   * @fulfill {ContxtOrganization} Information about a contxt organization
+   * @reject {Error}
+   *
+   * @example
+   * contxtSdk.coordinator
+   *   .getOrganization('36b8421a-cc4a-4204-b839-1397374fb16b')
+   *   .then((org) => console.log(org))
+   *   .catch((err) => console.log(err));
+   */
+  getOrganization(organizationId) {
+    if (!organizationId) {
+      return Promise.reject(
+        new Error(
+          'An organization ID is required for getting information about an organization'
+        )
+      );
+    }
+
+    return this._request
+      .get(`${this._baseUrl}/organizations/${organizationId}`)
+      .then((org) => formatOrganizationFromServer(org));
+  }
+
+  /**
+   * Gets information about a contxt user
+   *
+   * API Endpoint: '/users/:userId'
+   * Method: GET
+   *
+   * @param {string} userId The ID of the user
+   *
+   * @returns {Promise}
+   * @fulfill {ContxtUser} Information about a contxt user
+   * @reject {Error}
+   *
+   * @example
+   * contxtSdk.coordinator
+   *   .getUser('auth0|12345')
+   *   .then((user) => console.log(user))
+   *   .catch((err) => console.log(err));
+   */
+  getUser(userId) {
+    if (!userId) {
+      return Promise.reject(
+        new Error('A user ID is required for getting information about a user')
+      );
+    }
+
+    return this._request
+      .get(`${this._baseUrl}/users/${userId}`)
+      .then((user) => formatUserFromServer(user));
+  }
+}
+
+export default Coordinator;

--- a/src/coordinator/index.spec.js
+++ b/src/coordinator/index.spec.js
@@ -1,0 +1,192 @@
+import Coordinator from './index';
+import * as coordinatorUtils from '../utils/coordinator';
+
+describe('Coordinator', function() {
+  let baseRequest;
+  let baseSdk;
+  let expectedHost;
+
+  beforeEach(function() {
+    this.sandbox = sandbox.create();
+
+    baseRequest = {
+      delete: this.sandbox.stub().resolves(),
+      get: this.sandbox.stub().resolves(),
+      post: this.sandbox.stub().resolves(),
+      put: this.sandbox.stub().resolves()
+    };
+    baseSdk = {
+      config: {
+        audiences: {
+          coordinator: fixture.build('audience')
+        }
+      }
+    };
+    expectedHost = faker.internet.url();
+  });
+
+  afterEach(function() {
+    this.sandbox.restore();
+  });
+
+  describe('constructor', function() {
+    let coordinator;
+
+    beforeEach(function() {
+      coordinator = new Coordinator(baseSdk, baseRequest);
+    });
+
+    it('sets a base url for the class instance', function() {
+      expect(coordinator._baseUrl).to.equal(
+        `${baseSdk.config.audiences.coordinator.host}/v1`
+      );
+    });
+
+    it('appends the supplied request module to the class instance', function() {
+      expect(coordinator._request).to.deep.equal(baseRequest);
+    });
+
+    it('appends the supplied sdk to the class instance', function() {
+      expect(coordinator._sdk).to.deep.equal(baseSdk);
+    });
+  });
+
+  describe('getOrganization', function() {
+    context('the organization ID is provided', function() {
+      let organizationFromServerAfterFormat;
+      let organizationFromServerBeforeFormat;
+      let expectedOrganizationId;
+      let formatOrganizationFromServer;
+      let promise;
+      let request;
+
+      beforeEach(function() {
+        expectedOrganizationId = faker.random.uuid();
+        organizationFromServerAfterFormat = fixture.build(
+          'contxtOrganization',
+          {
+            id: expectedOrganizationId
+          }
+        );
+        organizationFromServerBeforeFormat = fixture.build(
+          'event',
+          { id: expectedOrganizationId },
+          { fromServer: true }
+        );
+
+        formatOrganizationFromServer = this.sandbox
+          .stub(coordinatorUtils, 'formatOrganizationFromServer')
+          .returns(organizationFromServerAfterFormat);
+
+        request = {
+          ...baseRequest,
+          get: this.sandbox.stub().resolves(organizationFromServerBeforeFormat)
+        };
+
+        const coordinator = new Coordinator(baseSdk, request);
+        coordinator._baseUrl = expectedHost;
+
+        promise = coordinator.getOrganization(expectedOrganizationId);
+      });
+
+      it('gets the organization from the server', function() {
+        expect(request.get).to.be.calledWith(
+          `${expectedHost}/organizations/${expectedOrganizationId}`
+        );
+      });
+
+      it('formats the organization object', function() {
+        return promise.then(() => {
+          expect(formatOrganizationFromServer).to.be.calledWith(
+            organizationFromServerBeforeFormat
+          );
+        });
+      });
+
+      it('returns the requested organization', function() {
+        return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
+          organizationFromServerAfterFormat
+        );
+      });
+    });
+
+    context('the organization ID is not provided', function() {
+      it('throws an error', function() {
+        const coordinator = new Coordinator(baseSdk, baseRequest);
+        const promise = coordinator.getOrganization();
+
+        return expect(promise).to.be.rejectedWith(
+          'An organization ID is required for getting information about an organization'
+        );
+      });
+    });
+  });
+
+  describe('getUser', function() {
+    context('the user ID is provided', function() {
+      let userFromServerAfterFormat;
+      let userFromServerBeforeFormat;
+      let expectedUserId;
+      let formatUserFromServer;
+      let promise;
+      let request;
+
+      beforeEach(function() {
+        expectedUserId = faker.random.uuid();
+        userFromServerAfterFormat = fixture.build('contxtUser', {
+          id: expectedUserId
+        });
+        userFromServerBeforeFormat = fixture.build(
+          'event',
+          { id: expectedUserId },
+          { fromServer: true }
+        );
+
+        formatUserFromServer = this.sandbox
+          .stub(coordinatorUtils, 'formatUserFromServer')
+          .returns(userFromServerAfterFormat);
+
+        request = {
+          ...baseRequest,
+          get: this.sandbox.stub().resolves(userFromServerBeforeFormat)
+        };
+
+        const coordinator = new Coordinator(baseSdk, request);
+        coordinator._baseUrl = expectedHost;
+
+        promise = coordinator.getUser(expectedUserId);
+      });
+
+      it('gets the user from the server', function() {
+        expect(request.get).to.be.calledWith(
+          `${expectedHost}/users/${expectedUserId}`
+        );
+      });
+
+      it('formats the user object', function() {
+        return promise.then(() => {
+          expect(formatUserFromServer).to.be.calledWith(
+            userFromServerBeforeFormat
+          );
+        });
+      });
+
+      it('returns the requested user', function() {
+        return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
+          userFromServerAfterFormat
+        );
+      });
+    });
+
+    context('the user ID is not provided', function() {
+      it('throws an error', function() {
+        const coordinator = new Coordinator(baseSdk, baseRequest);
+        const promise = coordinator.getUser();
+
+        return expect(promise).to.be.rejectedWith(
+          'A user ID is required for getting information about a user'
+        );
+      });
+    });
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import Assets from './assets';
 import Config from './config';
+import Coordinator from './coordinator';
 import Events from './events';
 import Facilities from './facilities';
 import Iot from './iot';
@@ -71,6 +72,10 @@ class ContxtSdk {
 
     this.assets = new Assets(this, this._createRequest('facilities'));
     this.auth = this._createAuthSession(sessionType);
+    this.coordinator = new Coordinator(
+      this,
+      this._createRequest('coordinator')
+    );
     this.events = new Events(this, this._createRequest('events'));
     this.facilities = new Facilities(this, this._createRequest('facilities'));
     this.iot = new Iot(this, this._createRequest('iot'));

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -1,6 +1,7 @@
 import times from 'lodash.times';
 import Config from './config';
 import ContxtSdk from './index';
+import Coordinator from './coordinator';
 import Events from './events';
 import Facilities from './facilities';
 import Iot from './iot';
@@ -60,6 +61,14 @@ describe('ContxtSdk', function() {
 
     it('sets an instance of Config', function() {
       expect(contxtSdk.config).to.be.an.instanceof(Config);
+    });
+
+    it('creates an instance of the request module for Coordinator', function() {
+      expect(createRequest).to.be.calledWith('coordinator');
+    });
+
+    it('sets an instance of Coordinator', function() {
+      expect(contxtSdk.coordinator).to.be.an.instanceof(Coordinator);
     });
 
     it('sets an instance of Auth', function() {

--- a/src/utils/coordinator/formatOrganizationFromServer.spec.js
+++ b/src/utils/coordinator/formatOrganizationFromServer.spec.js
@@ -1,7 +1,7 @@
 import omit from 'lodash.omit';
 import formatOrganizationFromServer from './formatOrganizationFromServer';
 
-describe('utils/events/formatOrganizationFromServer', function() {
+describe('utils/coordinator/formatOrganizationFromServer', function() {
   let expectedOrg;
   let formattedOrg;
   let org;

--- a/src/utils/coordinator/formatUserFromServer.spec.js
+++ b/src/utils/coordinator/formatUserFromServer.spec.js
@@ -1,7 +1,7 @@
 import omit from 'lodash.omit';
 import formatUserFromServer from './formatUserFromServer';
 
-describe('utils/events/formatUserFromServer', function() {
+describe('utils/coordinator/formatUserFromServer', function() {
   let expectedUser;
   let formattedUser;
   let user;


### PR DESCRIPTION
## Why?
- Adds a `Coordinator` module to get user and organization info from the Contxt Coordinator API

## What changed?
- Added a new `Coordinator` module with THREE functions:
  - `getAllOrganizations`
  - `getOrganizationById`
  - `getUser`
- Added tests
- Updated the documentation
- **Note**: I'm not grabbing _all_ of the data returned on the `user` object from `getUser.` I've only pulled out the fields that I have an immediate need for. This can be further expanded later