### PR TITLE
Adds Edge Nodes submodule to Coordinator

### DIFF
--- a/docs/EdgeNodes.md
+++ b/docs/EdgeNodes.md
@@ -1,0 +1,45 @@
+<a name="EdgeNodes"></a>
+
+## EdgeNodes
+Module that provides access to contxt edge nodes
+
+**Kind**: global class  
+
+* [EdgeNodes](#EdgeNodes)
+    * [new EdgeNodes(sdk, request, baseUrl)](#new_EdgeNodes_new)
+    * [.get(organizationId, edgeNodeId)](#EdgeNodes+get) ⇒ <code>Promise</code>
+
+<a name="new_EdgeNodes_new"></a>
+
+### new EdgeNodes(sdk, request, baseUrl)
+
+| Param | Type | Description |
+| --- | --- | --- |
+| sdk | <code>Object</code> | An instance of the SDK so the module can communicate with other modules |
+| request | <code>Object</code> | An instance of the request module tied to this module's audience. |
+| baseUrl | <code>string</code> | The base URL provided by the parent module |
+
+<a name="EdgeNodes+get"></a>
+
+### contxtSdk.coordinator.edgeNodes.get(organizationId, edgeNodeId) ⇒ <code>Promise</code>
+Get an edge node
+
+API Endpoint: '/organizations/:organizationId/edgenodes/:edgeNodeId'
+METHOD: GET
+
+**Kind**: instance method of [<code>EdgeNodes</code>](#EdgeNodes)  
+**Fulfill**: [<code>EdgeNode</code>](./Typedefs.md#EdgeNode)  
+**Reject**: <code>Error</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| organizationId | <code>string</code> | UUID |
+| edgeNodeId | <code>string</code> |  |
+
+**Example**  
+```js
+contxtSdk.coordinator.edgeNodes
+  .get('59270c25-4de9-4b22-8e0b-ab287ac344ce', 'abc123')
+  .then((edgeNode) => console.log(edgeNode))
+  .catch((err) => console.log(err));
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,9 @@ enabled in Auth0.</p>
 <dd><p>Module that provides access to cost centers, and helps manage
 the relationship between those cost centers and facilities</p>
 </dd>
+<dt><a href="./EdgeNodes.md">EdgeNodes</a></dt>
+<dd><p>Module that provides access to contxt edge nodes</p>
+</dd>
 <dt><a href="./Events.md">Events</a></dt>
 <dd><p>Module that provides access to, and the manipulation
 of, information about different events</p>
@@ -115,6 +118,8 @@ More information at <a href="https://github.com/axios/axios#interceptors">axios 
 either a reference to an environment that already exists or a clientId and host for a
 custom environment.</p>
 </dd>
+<dt><a href="./Typedefs.md#EdgeNode">EdgeNode</a> : <code>Object</code></dt>
+<dd></dd>
 <dt><a href="./Typedefs.md#Environments">Environments</a> : <code>Object.&lt;string, Audience&gt;</code></dt>
 <dd><p>An object of audiences that corresponds to all the different environments available for a
 single module.</p>

--- a/docs/Typedefs.md
+++ b/docs/Typedefs.md
@@ -226,6 +226,21 @@ custom environment.
 | [config.env] | <code>string</code> | The SDK provided environment name you are trying to reach |
 | [config.host] | <code>string</code> | Hostname for the API that corresponds with the clientId provided |
 
+<a name="EdgeNode"></a>
+
+## EdgeNode : <code>Object</code>
+**Kind**: global typedef  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| clientId | <code>string</code> |  |
+| createdAt | <code>string</code> | ISO 8601 Extended Format date/time string |
+| [description] | <code>string</code> |  |
+| id | <code>string</code> | UUID |
+| name | <code>string</code> |  |
+| organizationId | <code>string</code> | UUID |
+| updatedAt | <code>string</code> | ISO 8601 Extended Format date/time string |
+
 <a name="Environments"></a>
 
 ## Environments : <code>Object.&lt;string, Audience&gt;</code>

--- a/src/coordinator/edgeNodes.js
+++ b/src/coordinator/edgeNodes.js
@@ -1,0 +1,73 @@
+import { formatEdgeNodeFromServer } from '../utils/coordinator';
+
+/**
+ * @typedef {Object} EdgeNode
+ * @param {string} clientId
+ * @param {string} createdAt ISO 8601 Extended Format date/time string
+ * @param {string} [description]
+ * @param {string} id UUID
+ * @param {string} name
+ * @param {string} organizationId UUID
+ * @param {string} updatedAt ISO 8601 Extended Format date/time string
+ */
+
+/**
+ * Module that provides access to contxt edge nodes
+ *
+ * @typicalname contxtSdk.coordinator.edgeNodes
+ */
+class EdgeNodes {
+  /**
+   * @param {Object} sdk An instance of the SDK so the module can communicate with other modules
+   * @param {Object} request An instance of the request module tied to this module's audience.
+   * @param {string} baseUrl The base URL provided by the parent module
+   */
+  constructor(sdk, request, baseUrl) {
+    this._baseUrl = baseUrl;
+    this._request = request;
+    this._sdk = sdk;
+  }
+
+  /**
+   * Get an edge node
+   *
+   * API Endpoint: '/organizations/:organizationId/edgenodes/:edgeNodeId'
+   * METHOD: GET
+   *
+   * @param {string} organizationId UUID
+   * @param {string} edgeNodeId
+   *
+   * @returns {Promise}
+   * @fulfill {EdgeNode}
+   * @reject {Error}
+   *
+   * @example
+   * contxtSdk.coordinator.edgeNodes
+   *   .get('59270c25-4de9-4b22-8e0b-ab287ac344ce', 'abc123')
+   *   .then((edgeNode) => console.log(edgeNode))
+   *   .catch((err) => console.log(err));
+   */
+  get(organizationId, edgeNodeId) {
+    if (!organizationId) {
+      return Promise.reject(
+        new Error('An organizationId is required for getting an edge node.')
+      );
+    }
+
+    if (!edgeNodeId) {
+      return Promise.reject(
+        new Error('An edgeNodeId is required for getting an edge node.')
+      );
+    }
+
+    return this._request
+      .get(
+        `${
+          this._baseUrl
+        }/organizations/${organizationId}/edgenodes/${edgeNodeId}`
+      )
+      .then((edgeNode) => formatEdgeNodeFromServer(edgeNode));
+  }
+}
+
+export default EdgeNodes;

--- a/src/coordinator/edgeNodes.spec.js
+++ b/src/coordinator/edgeNodes.spec.js
@@ -1,0 +1,130 @@
+import EdgeNodes from './edgeNodes';
+
+import * as coordinatorUtils from '../utils/coordinator';
+
+describe('edgeNodes', function() {
+  let baseRequest;
+  let baseSdk;
+  let expectedHost;
+
+  beforeEach(function() {
+    this.sandbox = sandbox.create();
+
+    baseRequest = {
+      delete: this.sandbox.stub().resolves(),
+      get: this.sandbox.stub().resolves(),
+      post: this.sandbox.stub().resolves(),
+      put: this.sandbox.stub().resolves()
+    };
+    baseSdk = {
+      config: {
+        audiences: {
+          edgeNodes: fixture.build('audience')
+        }
+      }
+    };
+    expectedHost = faker.internet.url();
+  });
+
+  afterEach(function() {
+    this.sandbox.restore();
+  });
+
+  describe('constructor', function() {
+    let edgeNodes;
+
+    beforeEach(function() {
+      edgeNodes = new EdgeNodes(baseSdk, baseRequest, expectedHost);
+    });
+
+    it('sets a base url for the class instance', function() {
+      expect(edgeNodes._baseUrl).to.equal(expectedHost);
+    });
+
+    it('appends the supplied request module to the class instance', function() {
+      expect(edgeNodes._request).to.deep.equal(baseRequest);
+    });
+
+    it('appends the supplied sdk to the class instance', function() {
+      expect(edgeNodes._sdk).to.deep.equal(baseSdk);
+    });
+  });
+
+  describe('get', function() {
+    context('all required params are provided', function() {
+      let edgeNodeFromServerAfterFormat;
+      let edgeNodeFromServerBeforeFormat;
+      let expectedEdgeNodeId;
+      let expectedOrganizationId;
+      let formatEdgeNodeFromServer;
+      let promise;
+      let request;
+
+      beforeEach(function() {
+        edgeNodeFromServerAfterFormat = fixture.build('edgeNode');
+        expectedEdgeNodeId = edgeNodeFromServerAfterFormat.id;
+        expectedOrganizationId = edgeNodeFromServerAfterFormat.organizationId;
+        edgeNodeFromServerBeforeFormat = fixture.build(
+          'edgeNode',
+          edgeNodeFromServerAfterFormat,
+          { fromServer: true }
+        );
+
+        formatEdgeNodeFromServer = this.sandbox
+          .stub(coordinatorUtils, 'formatEdgeNodeFromServer')
+          .returns(edgeNodeFromServerAfterFormat);
+
+        request = {
+          ...baseRequest,
+          get: this.sandbox.stub().resolves(edgeNodeFromServerBeforeFormat)
+        };
+
+        const edgeNodes = new EdgeNodes(baseSdk, request);
+        edgeNodes._baseUrl = expectedHost;
+        promise = edgeNodes.get(expectedOrganizationId, expectedEdgeNodeId);
+      });
+
+      it('gets the edge node from the server', function() {
+        expect(request.get).to.be.calledWith(
+          `${expectedHost}/organizations/${expectedOrganizationId}/edgenodes/${expectedEdgeNodeId}`
+        );
+      });
+
+      it('formats the edge node object', function() {
+        return promise.then(() => {
+          expect(formatEdgeNodeFromServer).to.be.calledWith(
+            edgeNodeFromServerBeforeFormat
+          );
+        });
+      });
+
+      it('returns the requested edge node', function() {
+        return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
+          edgeNodeFromServerAfterFormat
+        );
+      });
+    });
+
+    context('the organization ID is not provided', function() {
+      it('throws an error', function() {
+        const edgeNodes = new EdgeNodes(baseSdk, baseRequest);
+        const promise = edgeNodes.get();
+
+        return expect(promise).to.be.rejectedWith(
+          'An organizationId is required for getting an edge node.'
+        );
+      });
+    });
+
+    context('the edge node ID is not provided', function() {
+      it('throws an error', function() {
+        const edgeNodes = new EdgeNodes(baseSdk, baseRequest);
+        const promise = edgeNodes.get('1');
+
+        return expect(promise).to.be.rejectedWith(
+          'An edgeNodeId is required for getting an edge node.'
+        );
+      });
+    });
+  });
+});

--- a/src/coordinator/index.js
+++ b/src/coordinator/index.js
@@ -1,3 +1,5 @@
+import EdgeNodes from './edgeNodes';
+
 import {
   formatOrganizationFromServer,
   formatUserFromServer
@@ -41,6 +43,8 @@ class Coordinator {
     this._baseUrl = baseUrl;
     this._request = request;
     this._sdk = sdk;
+
+    this.edgeNodes = new EdgeNodes(sdk, request, baseUrl);
   }
 
   /**

--- a/src/utils/coordinator/formatEdgeNodeFromServer.js
+++ b/src/utils/coordinator/formatEdgeNodeFromServer.js
@@ -1,0 +1,29 @@
+/**
+ * Normalizes the edge node object returned from the API server
+ *
+ * @param {Object} input
+ * @param {string} input.client_id
+ * @param {string} input.created_at ISO 8601 Extended Format date/time string
+ * @param {string} [input.description]
+ * @param {string} input.id UUID
+ * @param {string} input.name
+ * @param {string} input.organization_id UUID
+ * @param {string} input.updated_at ISO 8601 Extended Format date/time string
+ *
+ * @returns {EdgeNode}
+ *
+ * @private
+ */
+function formatEdgeNodeFromServer(input = {}) {
+  return {
+    clientId: input.client_id,
+    createdAt: input.created_at,
+    description: input.description,
+    id: input.id,
+    name: input.name,
+    organizationId: input.organization_id,
+    updatedAt: input.updated_at
+  };
+}
+
+export default formatEdgeNodeFromServer;

--- a/src/utils/coordinator/formatEdgeNodeFromServer.spec.js
+++ b/src/utils/coordinator/formatEdgeNodeFromServer.spec.js
@@ -1,0 +1,28 @@
+import omit from 'lodash.omit';
+import formatEdgeNodeFromServer from './formatEdgeNodeFromServer';
+
+describe('utils/coordinator/formatEdgeNodeFromServer', function() {
+  let expected;
+  let formatted;
+  let edgeNode;
+
+  beforeEach(function() {
+    edgeNode = fixture.build('edgeNode', null, { fromServer: true });
+    expected = omit(
+      {
+        ...edgeNode,
+        clientId: edgeNode.client_id,
+        createdAt: edgeNode.created_at,
+        organizationId: edgeNode.organization_id,
+        updatedAt: edgeNode.updated_at
+      },
+      ['client_id', 'created_at', 'organization_id', 'updated_at']
+    );
+
+    formatted = formatEdgeNodeFromServer(edgeNode);
+  });
+
+  it('converts the object keys to camelCase', function() {
+    expect(formatted).to.deep.equal(expected);
+  });
+});

--- a/src/utils/coordinator/index.js
+++ b/src/utils/coordinator/index.js
@@ -1,4 +1,9 @@
+import formatEdgeNodeFromServer from './formatEdgeNodeFromServer';
 import formatOrganizationFromServer from './formatOrganizationFromServer';
 import formatUserFromServer from './formatUserFromServer';
 
-export { formatOrganizationFromServer, formatUserFromServer };
+export {
+  formatEdgeNodeFromServer,
+  formatOrganizationFromServer,
+  formatUserFromServer
+};

--- a/support/fixtures/factories/edgeNode.js
+++ b/support/fixtures/factories/edgeNode.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const factory = require('rosie').Factory;
+const faker = require('faker');
+
+factory
+  .define('edgeNode')
+  .option('fromServer', false)
+  .attrs({
+    clientId: () => faker.internet.password(),
+    createdAt: () => faker.date.past().toISOString(),
+    description: () => faker.lorem.sentence(),
+    id: () => faker.random.uuid(),
+    name: () => faker.commerce.productMaterial(),
+    organizationId: () => factory.build('organization').id,
+    updatedAt: () => faker.date.recent().toISOString()
+  })
+  .after((edgeNode, options) => {
+    // If building an edge node that comes from the server, transform it to have camel
+    // case and capital letters in the right spots
+    if (options.fromServer) {
+      edgeNode.client_id = edgeNode.clientId;
+      delete edgeNode.clientId;
+
+      edgeNode.created_at = edgeNode.createdAt;
+      delete edgeNode.createdAt;
+
+      edgeNode.organization_id = edgeNode.organizationId;
+      delete edgeNode.organizationId;
+
+      edgeNode.updated_at = edgeNode.updatedAt;
+      delete edgeNode.updatedAt;
+    }
+  });

--- a/support/fixtures/factories/index.js
+++ b/support/fixtures/factories/index.js
@@ -13,6 +13,7 @@ require('./contxtUser');
 require('./costCenter');
 require('./costCenterFacility');
 require('./defaultAudiences');
+require('./edgeNode');
 require('./event');
 require('./eventType');
 require('./facility');


### PR DESCRIPTION
## Why?
- Need to be able to fetch info about an Edge Node from Contxt Coordinator

## What changed?
- Added an `edgeNodes` submodule to the `coordinator` module, with a single `get` function
- Added tests
- Updated docs