### PR TITLE
Renames edgeNodeId to edgeNodeClientId

### DIFF
--- a/docs/EdgeNodes.md
+++ b/docs/EdgeNodes.md
@@ -7,7 +7,7 @@ Module that provides access to contxt edge nodes
 
 * [EdgeNodes](#EdgeNodes)
     * [new EdgeNodes(sdk, request, baseUrl)](#new_EdgeNodes_new)
-    * [.get(organizationId, edgeNodeId)](#EdgeNodes+get) ⇒ <code>Promise</code>
+    * [.get(organizationId, edgeNodeClientId)](#EdgeNodes+get) ⇒ <code>Promise</code>
 
 <a name="new_EdgeNodes_new"></a>
 
@@ -21,10 +21,10 @@ Module that provides access to contxt edge nodes
 
 <a name="EdgeNodes+get"></a>
 
-### contxtSdk.coordinator.edgeNodes.get(organizationId, edgeNodeId) ⇒ <code>Promise</code>
+### contxtSdk.coordinator.edgeNodes.get(organizationId, edgeNodeClientId) ⇒ <code>Promise</code>
 Get an edge node
 
-API Endpoint: '/organizations/:organizationId/edgenodes/:edgeNodeId'
+API Endpoint: '/organizations/:organizationId/edgenodes/:edgeNodeClientId'
 METHOD: GET
 
 **Kind**: instance method of [<code>EdgeNodes</code>](#EdgeNodes)  
@@ -34,7 +34,7 @@ METHOD: GET
 | Param | Type | Description |
 | --- | --- | --- |
 | organizationId | <code>string</code> | UUID |
-| edgeNodeId | <code>string</code> |  |
+| edgeNodeClientId | <code>string</code> |  |
 
 **Example**  
 ```js

--- a/src/coordinator/edgeNodes.js
+++ b/src/coordinator/edgeNodes.js
@@ -31,11 +31,11 @@ class EdgeNodes {
   /**
    * Get an edge node
    *
-   * API Endpoint: '/organizations/:organizationId/edgenodes/:edgeNodeId'
+   * API Endpoint: '/organizations/:organizationId/edgenodes/:edgeNodeClientId'
    * METHOD: GET
    *
    * @param {string} organizationId UUID
-   * @param {string} edgeNodeId
+   * @param {string} edgeNodeClientId
    *
    * @returns {Promise}
    * @fulfill {EdgeNode}
@@ -47,16 +47,16 @@ class EdgeNodes {
    *   .then((edgeNode) => console.log(edgeNode))
    *   .catch((err) => console.log(err));
    */
-  get(organizationId, edgeNodeId) {
+  get(organizationId, edgeNodeClientId) {
     if (!organizationId) {
       return Promise.reject(
         new Error('An organizationId is required for getting an edge node.')
       );
     }
 
-    if (!edgeNodeId) {
+    if (!edgeNodeClientId) {
       return Promise.reject(
-        new Error('An edgeNodeId is required for getting an edge node.')
+        new Error('An edgeNodeClientId is required for getting an edge node.')
       );
     }
 
@@ -64,7 +64,7 @@ class EdgeNodes {
       .get(
         `${
           this._baseUrl
-        }/organizations/${organizationId}/edgenodes/${edgeNodeId}`
+        }/organizations/${organizationId}/edgenodes/${edgeNodeClientId}`
       )
       .then((edgeNode) => toCamelCase(edgeNode));
   }

--- a/src/coordinator/edgeNodes.spec.js
+++ b/src/coordinator/edgeNodes.spec.js
@@ -112,13 +112,13 @@ describe('edgeNodes', function() {
       });
     });
 
-    context('the edge node ID is not provided', function() {
+    context('the edge node client ID is not provided', function() {
       it('throws an error', function() {
         const edgeNodes = new EdgeNodes(baseSdk, baseRequest);
         const promise = edgeNodes.get('1');
 
         return expect(promise).to.be.rejectedWith(
-          'An edgeNodeId is required for getting an edge node.'
+          'An edgeNodeClientId is required for getting an edge node.'
         );
       });
     });


### PR DESCRIPTION
## Why?
- The API endpoint changed slightly for edge nodes so that the second parameter is actually `client_id` rather than `id.

## What changed?
- Renamed `edgeNodeId` to `edgeNodeClientId`
- Updated docs
