### PR TITLE
Add AssetMetrics#getByAssetId and AssetMetrics#getValuesByAssetId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,268 +1,279 @@
+## [v0.0.33](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.33) (2018-xx-xx)
+
+**Added**
+
+- Additional methods for Asset Metrics and Asset Metric Values
+
+  - `AssetMetrics#getByAssetId` for getting all Asset Metrics for a specific Asset ID
+    - Allows filtering by `assetMetricLabel`
+  - `AssetMetrics#getValuesByAssetId` for getting Asset Metric Values by for a specific Asset ID
+    - Allows filtering by `assetMetricLabel`, `effectiveEndDate`, and `effectiveStartDate`
+
 ## [v0.0.32](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.32) (2018-09-17)
 
 **Added**
 
-* Methods around Asset Metrics and Asset Metric Values. They are namespaced under `metrics` and include:
-  * AssetMetrics#create for creating an Asset Metric
-  * AssetMetrics#delete for removing an Asset Metric
-  * AssetMetrics#get for getting an Asset Metric by its ID
-  * AssetMetrics#getByAssetTypeId for getting all Asset Metrics by Asset Type
-  * AssetMetrics#update for updating an Asset Metric
-  * AssetMetrics#createValue for creating an Asset Metric Value
-  * AssetMetrics#deleteValue for deleting an Asset Metric Value
-  * AssetMetrics#getValuesByMetricId for getting Asset Metric Values by Asset Metric ID
-  * AssetMetrics#updateValue for updating an Asset Metric Value
+- Methods around Asset Metrics and Asset Metric Values. They are namespaced under `metrics` and include:
+  - `AssetMetrics#create` for creating an Asset Metric
+  - `AssetMetrics#delete` for removing an Asset Metric
+  - `AssetMetrics#get` for getting an Asset Metric by its ID
+  - `AssetMetrics#getByAssetTypeId` for getting all Asset Metrics by Asset Type
+  - `AssetMetrics#update` for updating an Asset Metric
+  - `AssetMetrics#createValue` for creating an Asset Metric Value
+  - `AssetMetrics#deleteValue` for deleting an Asset Metric Value
+  - `AssetMetrics#getValuesByMetricId` for getting Asset Metric Values by Asset Metric ID
+  - `AssetMetrics#updateValue` for updating an Asset Metric Value
 
 ## [v0.0.31](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.31) (2018-09-10)
 
 **Added**
 
-* Added AssetAttributes#getEffectiveValuesByOrganizationId to retrieve all effective attribute values for a given organization.
+- Added `AssetAttributes#getEffectiveValuesByOrganizationId` to retrieve all effective attribute values for a given organization.
 
 ## [v0.0.30](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.30) (2018-08-20)
 
 **Changed**
 
-* Started normalizing Silent Authentication errors from Auth0 in the Auth0WebAuth session type to match Axios errors.
-  * Additionally, started logging the user out when one of these errors is encountered.
+- Started normalizing Silent Authentication errors from Auth0 in the Auth0WebAuth session type to match Axios errors.
+  - Additionally, started logging the user out when one of these errors is encountered.
 
 ## [v0.0.29](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.29) (2018-08-16)
 
 **Changed**
 
-* Added generic methods to normalize data moving between the API and the SDK consumer.
-  * Removed most formatters that were "brute forcing" the same task. Only remaining formatters are for specific edge cases.
+- Added generic methods to normalize data moving between the API and the SDK consumer.
+  - Removed most formatters that were "brute forcing" the same task. Only remaining formatters are for specific edge cases.
 
 ## [v0.0.28](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.28) (2018-08-15)
 
 **Added**
 
-* Methods around Edge Nodes. They are namespaced under coordinator (i.e. `coordinator.edgeNodes()`) and include:
-  * EdgeNodes#get for getting info about a specific Edge Node
+- Methods around Edge Nodes. They are namespaced under coordinator (i.e. `coordinator.edgeNodes()`) and include:
+  - `EdgeNodes#get` for getting info about a specific Edge Node
 
 ## [v0.0.27](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.27) (2018-08-14)
 
 **Added**
 
-* Added Bus, Channel module with the ability to perform create, read, update and delete on Message Bus Channels
+- Added Bus, Channel module with the ability to perform create, read, update and delete on Message Bus Channels
 
 ## [v0.0.26](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.26) (2018-08-13)
 
 **Changed**
 
-* Set specific engine versions for Node and NPM
-* Audited and updated dependencies
-* Updated AssetAttributes#createValue to use an updated API endpoint
+- Set specific engine versions for Node and NPM
+- Audited and updated dependencies
+- Updated `AssetAttributes#createValue` to use an updated API endpoint
 
 **Fixed**
 
-* Fixed documentation building process to support Node 6
+- Fixed documentation building process to support Node 6
 
 ## [v0.0.25](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.25) (2018-08-08)
 
 **Added**
 
-* Added Coordinator module with ability to get info about organizations and users from Contxt Coordinator
+- Added Coordinator module with ability to get info about organizations and users from Contxt Coordinator
 
 ## [v0.0.24](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.24) (2018-08-07)
 
 **Added**
 
-* Added Events module with ability to create, read, update, and delete events
+- Added Events module with ability to create, read, update, and delete events
 
 **Changed**
 
-* Added `assetLabel` and `label` as fields associated with `AssetAttributeValues`
+- Added `assetLabel` and `label` as fields associated with `AssetAttributeValues`
 
 ## [v0.0.23](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.23) (2018-08-01)
 
 **Fixed**
 
-* Fixed how results were returned from AssetAttributes#getAll
+- Fixed how results were returned from `AssetAttributes#getAll`
 
 ## [v0.0.22](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.22) (2018-07-30)
 
 **Changed**
 
-* Started to pass a more robust error when there is a problem renewing tokens with the Auth0WebAuth session adapter
-* Updated AssetAttributes#getAll to pass pagination information along with the request
+- Started to pass a more robust error when there is a problem renewing tokens with the Auth0WebAuth session adapter
+- Updated `AssetAttributes#getAll` to pass pagination information along with the request
 
 ## [v0.0.21](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.21) (2018-07-23)
 
 **Fixed**
 
-* Updated AssetTypes#create to allow for the creation of global asset types
+- Updated `AssetTypes#create` to allow for the creation of global asset types
 
 ## [v0.0.20](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.20) (2018-07-16)
 
 **Added**
 
-* Methods around the display and manipulation of Asset Attributes Values. They are namespaced under assets (i.e. `assets.attributes.methodName()`) and include:
+- Methods around the display and manipulation of Asset Attributes Values. They are namespaced under assets (i.e. `assets.attributes.methodName()`) and include:
 
-  * AssetAttributes#createValue to add an asset attribute value
-  * AssetAttributes#deleteValue to delete an asset attribute value
-  * AssetAttributes#getEffectiveValuesByAssetId to get the effective asset attribute values for a particular asset
-  * AssetAttributes#getValuesByAttributeId to get a paginated list of asset attribute values for a particular attribute of a particular asset
-  * AssetAttributes#updateValue to update an asset attribute value
+  - `AssetAttributes#createValue` to add an asset attribute value
+  - `AssetAttributes#deleteValue` to delete an asset attribute value
+  - `AssetAttributes#getEffectiveValuesByAssetId` to get the effective asset attribute values for a particular asset
+  - `AssetAttributes#getValuesByAttributeId` to get a paginated list of asset attribute values for a particular attribute of a particular asset
+  - `AssetAttributes#updateValue` to update an asset attribute value
 
 **Changed**
 
-* Now supporting the `data_type` field for `AssetAttributes`
+- Now supporting the `data_type` field for `AssetAttributes`
 
 ## [v0.0.19](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.19) (2018-07-09)
 
 **Added**
 
-* Methods around the display and manipulation of Asset Attributes. They are namespaced under assets (i.e. `assets.attributes.methodName()`) and include:
-  * AssetAttributes#create to add an asset attribute
-  * AssetAttributes#delete to delete an asset attribute
-  * AssetAttributes#get to get an asset attribute
-  * AssetAttributes#getAll to get a list of all asset attributes
-  * AssetAttributes#update to update an asset attribute
+- Methods around the display and manipulation of Asset Attributes. They are namespaced under assets (i.e. `assets.attributes.methodName()`) and include:
+  - `AssetAttributes#create` to add an asset attribute
+  - `AssetAttributes#delete` to delete an asset attribute
+  - `AssetAttributes#get` to get an asset attribute
+  - `AssetAttributes#getAll` to get a list of all asset attributes
+  - `AssetAttributes#update` to update an asset attribute
 
 ## [v0.0.18](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.18) (2018-07-06)
 
 **Changed**
 
-* External Modules can now have a `clientId` or `host` set to `null` if the values are not needed for the module. (_NOTE:_ Some SessionType adapters, like the MachineAuth adapter, require a `clientId` if the built-in `request` module is used since contxt auth tokens for those adapters are generated on a per-clientId basis).
+- External Modules can now have a `clientId` or `host` set to `null` if the values are not needed for the module. (_NOTE:_ Some SessionType adapters, like the MachineAuth adapter, require a `clientId` if the built-in `request` module is used since contxt auth tokens for those adapters are generated on a per-clientId basis).
 
 ## [v0.0.17](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.17) (2018-07-03)
 
 **Added**
 
-* Methods around the display and manipulation of Assets. They are namespaced under assets (i.e. `assets.methodName()`) and include:
-  * Assets#create to add an asset
-  * Assets#delete to delete an asset
-  * Assets#get to get an asset
-  * Assets#getAll to get a list of all assets
-  * Assets#getAllByOrganizationId to get a list of all assets for a specific organization
-  * Assets#update to update an asset
-* Methods around the display and manipulation of Asset Types. They are namespaced under assets (i.e. `assets.types.methodName()`) and include:
-  * AssetTypes#create to add an asset type
-  * AssetTypes#delete to delete an asset type
-  * AssetTypes#get to get an asset type
-  * AssetTypes#getAll to get a list of all asset types
-  * AssetTypes#getAllByOrganizationId to get a list of all asset types for a specific organization
-  * AssetTypes#update to update an asset type
+- Methods around the display and manipulation of Assets. They are namespaced under assets (i.e. `assets.methodName()`) and include:
+  - `Assets#create` to add an asset
+  - `Assets#delete` to delete an asset
+  - `Assets#get` to get an asset
+  - `Assets#getAll` to get a list of all assets
+  - `Assets#getAllByOrganizationId` to get a list of all assets for a specific organization
+  - `Assets#update` to update an asset
+- Methods around the display and manipulation of Asset Types. They are namespaced under assets (i.e. `assets.types.methodName()`) and include:
+  - `AssetTypes#create` to add an asset type
+  - `AssetTypes#delete` to delete an asset type
+  - `AssetTypes#get` to get an asset type
+  - `AssetTypes#getAll` to get a list of all asset types
+  - `AssetTypes#getAllByOrganizationId` to get a list of all asset types for a specific organization
+  - `AssetTypes#update` to update an asset type
 
 ## [v0.0.16](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.16) (2018-07-02)
 
 **Added**
 
-* Added IOT module, with ability to get field data and field information
+- Added IOT module, with ability to get field data and field information
 
 **Changed**
 
-* `asset_id` added as an optional field when getting facilities
+- `asset_id` added as an optional field when getting facilities
 
 **Fixed**
 
-* Fixed bug where calls would return with a 401 when making simultanous requests while using the `MachineAuth` session typ.
+- Fixed bug where calls would return with a 401 when making simultaneous requests while using the `MachineAuth` session typ.
 
 ## [v0.0.15](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.15) (2018-06-21)
 
 **Changed**
 
-* Auth0WebAuth now automatically handles refreshing Access and API tokens instead of forcing the user to log in again every two hours.
+- Auth0WebAuth now automatically handles refreshing Access and API tokens instead of forcing the user to log in again every two hours.
 
 ## [v0.0.14](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.14) (2018-06-18)
 
 **Changed**
 
-* Facilities#getAllByOrganizationId to accept parameters to include cost centers information
-* Facilities#get to include cost centers information for that specific facility
+- `Facilities#getAllByOrganizationId` to accept parameters to include cost centers information
+- `Facilities#get` to include cost centers information for that specific facility
 
 ## [v0.0.13](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.13) (2018-06-16)
 
 **Added**
 
-* The ability to set up custom axios interceptors to be used on each request and response made to an API. (More information available at at {@link https://github.com/axios/axios#interceptors axios Interceptors})
+- The ability to set up custom axios interceptors to be used on each request and response made to an API. (More information available at at {@link https://github.com/axios/axios#interceptors axios Interceptors})
 
 ## [v0.0.12](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.12) (2018-06-14)
 
 **Added**
 
-* Methods around the display and manipulation of Cost Centers. They are namespaced under facilities (i.e. `facilities.costCenters.methodName()`) and include:
-  * CostCenters#addFacility to add a facility to a cost center
-  * CostCenters#create for creating a new cost center
-  * CostCenters#getAll for getting a list of all cost centers
-  * CostCenters#getAllByOrganizationId for getting all cost centers for a specific organization
-  * CostCenters#remove to remove an existing cost center
-  * CostCenters#removeFacility to remove a facility from a cost center
-  * CostCenters#update to update an existing cost center
+- Methods around the display and manipulation of Cost Centers. They are namespaced under facilities (i.e. `facilities.costCenters.methodName()`) and include:
+  - `CostCenters#addFacility` to add a facility to a cost center
+  - `CostCenters#create` for creating a new cost center
+  - `CostCenters#getAll` for getting a list of all cost centers
+  - `CostCenters#getAllByOrganizationId` for getting all cost centers for a specific organization
+  - `CostCenters#remove` to remove an existing cost center
+  - `CostCenters#removeFacility` to remove a facility from a cost center
+  - `CostCenters#update` to update an existing cost center
 
 ## [v0.0.11](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.11) (2018-05-16)
 
 **Changed**
 
-* Facilities#getAllByOrganizationId to accept parameters to include facility grouping information
+- `Facilities#getAllByOrganizationId` to accept parameters to include facility grouping information
 
 ## [v0.0.10](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.10) (2018-05-01)
 
 **Added**
 
-* FacilityGroupings#remove to remove an existing facility grouping
-* FacilityGroupings#update to update an existing facility grouping
+- `FacilityGroupings#remove` to remove an existing facility grouping
+- `FacilityGroupings#update` to update an existing facility grouping
 
 ## [v0.0.9](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.9) (2018-04-19)
 
 **Added**
 
-* FacilityGroupings#getAllByOrganizationId for getting all facility groupings for a specific organization
+- `FacilityGroupings#getAllByOrganizationId` for getting all facility groupings for a specific organization
 
 ## [v0.0.8](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.8) (2018-04-16)
 
 **Added**
 
-* Added some methods to help out when working with facility groupings. They are namespaced under facilities (i.e. `facilities.groupings.methodName()`) and include:
-  * FacilityGroupings#addFacility to add a facility to a facility grouping
-  * FacilityGroupings#create for creating new facility groupings
-  * FacilityGroupings#getAll for getting a list of all facility groupings
-  * FacilityGroupings#removeFacility to remove a facility from a facility grouping
+- Added some methods to help out when working with facility groupings. They are namespaced under facilities (i.e. `facilities.groupings.methodName()`) and include:
+  - `FacilityGroupings#addFacility` to add a facility to a facility grouping
+  - `FacilityGroupings#create` for creating new facility groupings
+  - `FacilityGroupings#getAll` for getting a list of all facility groupings
+  - `FacilityGroupings#removeFacility` to remove a facility from a facility grouping
 
 ## [v0.0.7](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.7) (2018-03-29)
 
 **Renamed**
 
-* Facilities#updateInfo to Facilities#createOrUpdateInfo so that what the method does is more obvious
+- `Facilities#updateInfo` to `Facilities#createOrUpdateInfo` so that what the method does is more obvious
 
 ## [v0.0.6](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.6) (2018-03-28)
 
 **Added**
 
-* Facilities#updateInfo for updating a facility's facilily info
+- `Facilities#updateInfo` for updating a facility's facilily info
 
 ## [v0.0.5](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.5) (2018-03-20)
 
 **Added**
 
-* Facilities#create, Facilities#delete, Facilities#getAllByOrganizationId, and Facilities#update
+- Facilities#create, Facilities#delete, Facilities#getAllByOrganizationId, and Facilities#update
 
 ## [v0.0.4](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.4) (2018-03-08)
 
 **Added**
 
-* MachineAuth SessionType for use on Node.js projects
+- MachineAuth SessionType for use on Node.js projects
 
 **Changed**
 
-* Split API documentation into multiple files for easy reading and navigation
+- Split API documentation into multiple files for easy reading and navigation
 
 **Fixed**
 
-* Updated required version of `auth0-js` to fix [CVS-2018-7307](https://auth0.com/docs/security/bulletins/cve-2018-7307)
+- Updated required version of `auth0-js` to fix [CVS-2018-7307](https://auth0.com/docs/security/bulletins/cve-2018-7307)
 
 ## v0.0.3 (2018-02-26)
 
-* Adds documentation!
-* Fixes bug where placement of customModuleConfigs and the chosen environment in the user config did not match up with what was in documentation
+- Adds documentation!
+- Fixes bug where placement of customModuleConfigs and the chosen environment in the user config did not match up with what was in documentation
 
 ## v0.0.2 (2018-02-26)
 
-* Fixes publication process so that the built files are in the package grabbed from NPM
+- Fixes publication process so that the built files are in the package grabbed from NPM
 
 ## v0.0.1 (2018-02-23)
 
-* Initial release
-* Provides Request, Config and an initial SessionType, Auth0WebAuth
-* Provides Facilities#get and Facilities#getAll
+- Initial release
+- Provides Request, Config and an initial SessionType, Auth0WebAuth
+- Provides `Facilities#get` and Facilities#getAll

--- a/docs/AssetMetrics.md
+++ b/docs/AssetMetrics.md
@@ -278,12 +278,12 @@ Method: GET
 | Param | Type | Description |
 | --- | --- | --- |
 | assetId | <code>String</code> | The ID of the asset (formatted as a UUID) |
-| [assetMetricValuesFilters] | <code>Object</code> | Specific information that is used to   filter the list of asset metric values |
-| [assetMetricValuesFilters.assetMetricLabel] | <code>String</code> | The label of the   associated asset metrics |
-| [assetMetricValuesFilters.effectiveEndDate] | <code>String</code> | Effective end date   of the asset metric values |
-| [assetMetricValuesFilters.effectiveStartDate] | <code>String</code> | Effective start   date of the asset metric values |
-| [assetMetricValuesFilters.limit] | <code>Number</code> | Maximum number of records to   return per query |
-| [assetMetricValuesFilters.offset] | <code>Number</code> | How many records from the first   record to start the query |
+| [assetMetricValuesFilters] | <code>Object</code> | Specific information that is   used to filter the list of asset metric values |
+| [assetMetricValuesFilters.assetMetricLabel] | <code>String</code> | The label of   the associated asset metrics |
+| [assetMetricValuesFilters.effectiveEndDate] | <code>String</code> | Effective end   date (ISO 8601 Extended formatted) of the asset metric values |
+| [assetMetricValuesFilters.effectiveStartDate] | <code>String</code> | Effective   start date (ISO 8601 Extended formatted) of the asset metric values |
+| [assetMetricValuesFilters.limit] | <code>Number</code> | Maximum number of records   to return per query |
+| [assetMetricValuesFilters.offset] | <code>Number</code> | How many records from the   first record to start the query |
 
 **Example**  
 ```js
@@ -316,10 +316,10 @@ Method: GET
 | Param | Type | Description |
 | --- | --- | --- |
 | assetId | <code>String</code> | The ID of the asset (formatted as a UUID) |
-| assetMetricId | <code>String</code> | The ID of the asset metric (formatted as a UUID) |
+| assetMetricId | <code>String</code> | The ID of the asset metric (formatted as a   UUID) |
 | [assetMetricValuesFilters] | <code>Object</code> | Specific information that is   used to filter the list of asset metric values |
-| [assetMetricValuesFilters.effectiveEndDate] | <code>String</code> | Effective end   date of the asset metric values |
-| [assetMetricValuesFilters.effectiveStartDate] | <code>String</code> | Effective   start date of the asset metric values |
+| [assetMetricValuesFilters.effectiveEndDate] | <code>String</code> | Effective end   date (ISO 8601 Extended formatted) of the asset metric values |
+| [assetMetricValuesFilters.effectiveStartDate] | <code>String</code> | Effective   start date (ISO 8601 Extended formatted) of the asset metric values |
 | [assetMetricValuesFilters.limit] | <code>Number</code> | Maximum number of records   to return per query |
 | [assetMetricValuesFilters.offset] | <code>Number</code> | How many records from the   first record to start the query |
 

--- a/docs/AssetMetrics.md
+++ b/docs/AssetMetrics.md
@@ -10,11 +10,13 @@ Module that provides access to, and the manipulation of, information about diffe
     * [.create(assetTypeId, assetMetric)](#AssetMetrics+create) ⇒ <code>Promise</code>
     * [.delete(assetMetricId)](#AssetMetrics+delete) ⇒ <code>Promise</code>
     * [.get(assetMetricId)](#AssetMetrics+get) ⇒ <code>Promise</code>
-    * [.getByAssetTypeId(assetTypeId, [paginationOptions])](#AssetMetrics+getByAssetTypeId) ⇒ <code>Promise</code>
+    * [.getByAssetId(assetId, [assetMetricsFilters])](#AssetMetrics+getByAssetId) ⇒ <code>Promise</code>
+    * [.getByAssetTypeId(assetTypeId, [assetMetricsFilters])](#AssetMetrics+getByAssetTypeId) ⇒ <code>Promise</code>
     * [.update(assetMetricId, update)](#AssetMetrics+update) ⇒ <code>Promise</code>
     * [.createValue(assetId, assetMetricValue)](#AssetMetrics+createValue) ⇒ <code>Promise</code>
     * [.deleteValue(assetMetricValueId)](#AssetMetrics+deleteValue) ⇒ <code>Promise</code>
-    * [.getValuesByMetricId(assetId, assetMetricId, [assetMetricFilters])](#AssetMetrics+getValuesByMetricId) ⇒ <code>Promise</code>
+    * [.getValuesByAssetId(assetId, [assetMetricValuesFilters])](#AssetMetrics+getValuesByAssetId) ⇒ <code>Promise</code>
+    * [.getValuesByMetricId(assetId, assetMetricId, [assetMetricValuesFilters])](#AssetMetrics+getValuesByMetricId) ⇒ <code>Promise</code>
     * [.updateValue(assetMetricValueId, update)](#AssetMetrics+updateValue) ⇒ <code>Promise</code>
 
 <a name="new_AssetMetrics_new"></a>
@@ -105,9 +107,43 @@ contxtSdk.assets.metrics
   .then((assetMetric) => console.log(assetMetric))
   .catch((err) => console.log(err));
 ```
+<a name="AssetMetrics+getByAssetId"></a>
+
+### contxtSdk.assets.metrics.getByAssetId(assetId, [assetMetricsFilters]) ⇒ <code>Promise</code>
+Gets a list of all asset metrics that belong to a given asset
+
+API Endpoint: '/assets/:assetId/metrics
+Method: GET
+
+**Kind**: instance method of [<code>AssetMetrics</code>](#AssetMetrics)  
+**Fulfill**: [<code>AssetMetricsFromServer</code>](./Typedefs.md#AssetMetricsFromServer)  
+**Reject**: <code>Error</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| assetId | <code>string</code> | The UUID formatted ID of the asset type |
+| [assetMetricsFilters] | <code>Object</code> | Specific information that is used to   filter the list of asset metrics |
+| [assetMetricsFilters.assetMetricLabel] | <code>String</code> | The label of the   associated asset metrics |
+| [assetMetricsFilters.limit] | <code>Number</code> | Maximum number of records to   return per query |
+| [assetMetricsFilters.offset] | <code>Number</code> | How many records from the first   record to start the query |
+
+**Example**  
+```js
+contxtSdk.assets.metrics
+  .getByAssetId(
+    'f3be81fd-4494-443b-87a3-320b1c9aa495',
+     {
+       assetMetricLabel: 'Square Footage',
+       limit: 50,
+       offset: 150
+     }
+   )
+  .then((assetMetricData) => console.log(assetMetricData))
+  .catch((err) => console.log(err));
+```
 <a name="AssetMetrics+getByAssetTypeId"></a>
 
-### contxtSdk.assets.metrics.getByAssetTypeId(assetTypeId, [paginationOptions]) ⇒ <code>Promise</code>
+### contxtSdk.assets.metrics.getByAssetTypeId(assetTypeId, [assetMetricsFilters]) ⇒ <code>Promise</code>
 Gets a list of all asset metrics that belong to a given type
 
 API Endpoint: '/assets/types/:assetTypeId/metrics
@@ -120,12 +156,21 @@ Method: GET
 | Param | Type | Description |
 | --- | --- | --- |
 | assetTypeId | <code>string</code> | The UUID formatted ID of the asset type |
-| [paginationOptions] | [<code>PaginationOptions</code>](./Typedefs.md#PaginationOptions) |  |
+| [assetMetricsFilters] | <code>Object</code> | Specific information that is used to   filter the list of asset metrics |
+| [assetMetricsFilters.limit] | <code>Number</code> | Maximum number of records to   return per query |
+| [assetMetricsFilters.offset] | <code>Number</code> | How many records from the first   record to start the query |
+| [assetMetricsFilters.organizationId] | <code>String</code> | The UUID formatted ID   of the organization to filter asset metrics by |
 
 **Example**  
 ```js
 contxtSdk.assets.metrics
-  .getByAssetTypeId('4f0e51c6-728b-4892-9863-6d002e61204d')
+  .getByAssetTypeId(
+    '4f0e51c6-728b-4892-9863-6d002e61204d'
+     {
+       limit: 50,
+       offset: 150
+     }
+   )
   .then((assetMetrics) => console.log(assetMetrics))
   .catch((err) => console.log(err));
 ```
@@ -218,27 +263,65 @@ contxtSdk.assets.metrics.deleteValue(
   'f4cd0d84-6c61-4d19-9322-7c1ab226dc83'
 );
 ```
+<a name="AssetMetrics+getValuesByAssetId"></a>
+
+### contxtSdk.assets.metrics.getValuesByAssetId(assetId, [assetMetricValuesFilters]) ⇒ <code>Promise</code>
+Gets asset metric values for a particular asset
+
+API Endpoint: '/assets/:assetId/metrics/values'
+Method: GET
+
+**Kind**: instance method of [<code>AssetMetrics</code>](#AssetMetrics)  
+**Fulfill**: [<code>AssetMetricValuesFromServer</code>](./Typedefs.md#AssetMetricValuesFromServer)  
+**Rejects**: <code>Error</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| assetId | <code>String</code> | The ID of the asset (formatted as a UUID) |
+| [assetMetricValuesFilters] | <code>Object</code> | Specific information that is used to   filter the list of asset metric values |
+| [assetMetricValuesFilters.assetMetricLabel] | <code>String</code> | The label of the   associated asset metrics |
+| [assetMetricValuesFilters.effectiveEndDate] | <code>String</code> | Effective end date   of the asset metric values |
+| [assetMetricValuesFilters.effectiveStartDate] | <code>String</code> | Effective start   date of the asset metric values |
+| [assetMetricValuesFilters.limit] | <code>Number</code> | Maximum number of records to   return per query |
+| [assetMetricValuesFilters.offset] | <code>Number</code> | How many records from the first   record to start the query |
+
+**Example**  
+```js
+contxtSdk.assets.metrics
+  .getValuesByAssetId(
+     'f9c606f3-d270-4623-bf3b-b085424d9a8b',
+     {
+       assetMetricLabel: 'Square Footage',
+       effectiveEndDate: '2018-04-13T15:44:51.943Z'
+       effectiveStartDate: '2017-12-13T15:42:01.376Z'
+       limit: 10,
+       offset: 200
+     }
+   )
+  .then((assetMetricValuesData) => console.log(assetMetricValuesData))
+  .catch((err) => console.log(err));
+```
 <a name="AssetMetrics+getValuesByMetricId"></a>
 
-### contxtSdk.assets.metrics.getValuesByMetricId(assetId, assetMetricId, [assetMetricFilters]) ⇒ <code>Promise</code>
+### contxtSdk.assets.metrics.getValuesByMetricId(assetId, assetMetricId, [assetMetricValuesFilters]) ⇒ <code>Promise</code>
 Gets asset metric values for a particular asset and metric
 
 API Endpoint: '/assets/:assetId/metrics/:assetMetricId/values'
 Method: GET
 
 **Kind**: instance method of [<code>AssetMetrics</code>](#AssetMetrics)  
-**Fulfill**: <code>AssetMetricValue[]</code>  
+**Fulfill**: [<code>AssetMetricValuesFromServer</code>](./Typedefs.md#AssetMetricValuesFromServer)  
 **Rejects**: <code>Error</code>  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | assetId | <code>String</code> | The ID of the asset (formatted as a UUID) |
 | assetMetricId | <code>String</code> | The ID of the asset metric (formatted as a UUID) |
-| [assetMetricFilters] | <code>Object</code> | Specific information that is used to   filter the list of asset attribute values |
-| [assetMetricFilters.effectiveEndDate] | <code>String</code> | Effective end date   of the asset metric values |
-| [assetMetricFilters.effectiveStartDate] | <code>String</code> | Effective start date   of the asset metric values |
-| [assetMetricFilters.limit] | <code>Number</code> | Maximum number of records to return per query |
-| [assetMetricFilters.offset] | <code>Number</code> | How many records from the first record to start the query |
+| [assetMetricValuesFilters] | <code>Object</code> | Specific information that is   used to filter the list of asset metric values |
+| [assetMetricValuesFilters.effectiveEndDate] | <code>String</code> | Effective end   date of the asset metric values |
+| [assetMetricValuesFilters.effectiveStartDate] | <code>String</code> | Effective   start date of the asset metric values |
+| [assetMetricValuesFilters.limit] | <code>Number</code> | Maximum number of records   to return per query |
+| [assetMetricValuesFilters.offset] | <code>Number</code> | How many records from the   first record to start the query |
 
 **Example**  
 ```js

--- a/docs/README.md
+++ b/docs/README.md
@@ -97,6 +97,8 @@ which are obtained from Auth0.</p>
 <dd></dd>
 <dt><a href="./Typedefs.md#AssetMetricValue">AssetMetricValue</a> : <code>Object</code></dt>
 <dd></dd>
+<dt><a href="./Typedefs.md#AssetMetricValuesFromServer">AssetMetricValuesFromServer</a> : <code>Object</code></dt>
+<dd></dd>
 <dt><a href="./Typedefs.md#AssetMetricsFromServer">AssetMetricsFromServer</a> : <code>Object</code></dt>
 <dd></dd>
 <dt><a href="./Typedefs.md#AssetType">AssetType</a> : <code>Object</code></dt>

--- a/docs/Typedefs.md
+++ b/docs/Typedefs.md
@@ -114,6 +114,19 @@
 | updatedAt | <code>string</code> | ISO 8601 Extended Format date/time string |
 | value | <code>string</code> |  |
 
+<a name="AssetMetricValuesFromServer"></a>
+
+## AssetMetricValuesFromServer : <code>Object</code>
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| _metadata | <code>Object</code> | Metadata about the pagination settings |
+| _metadata.offset | <code>number</code> | Offset of records in subsequent queries |
+| _metadata.totalRecords | <code>number</code> | Total number of asset types found |
+| records | [<code>Array.&lt;AssetMetricValue&gt;</code>](#AssetMetricValue) |  |
+
 <a name="AssetMetricsFromServer"></a>
 
 ## AssetMetricsFromServer : <code>Object</code>

--- a/package-lock.json
+++ b/package-lock.json
@@ -6506,9 +6506,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.12.1.tgz",
-      "integrity": "sha1-wa0g6APndJ+vkFpAnSNn4Gu+cyU=",
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.14.3.tgz",
+      "integrity": "sha512-qZDVnCrnpsRJJq5nSsiHCE3BYMED2OtsI+cmzIzF1QIfqm5ALf8tEJcO27zV1gKNKRPdhjO0dNWnrzssDQ1tFg==",
       "dev": true
     },
     "pretty-quick": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "lodash.times": "^4.3.2",
     "mocha": "^4.1.0",
     "nyc": "^13.0.1",
-    "prettier": "^1.12.1",
+    "prettier": "^1.14.3",
     "pretty-quick": "^1.4.1",
     "rollup": "^0.54.1",
     "rollup-plugin-babel": "^3.0.3",

--- a/src/assets/assetMetrics.js
+++ b/src/assets/assetMetrics.js
@@ -451,18 +451,18 @@ class AssetMetrics {
    * Method: GET
    *
    * @param {String} assetId The ID of the asset (formatted as a UUID)
-   * @param {Object} [assetMetricValuesFilters] Specific information that is used to
-   *   filter the list of asset metric values
-   * @param {String} [assetMetricValuesFilters.assetMetricLabel] The label of the
-   *   associated asset metrics
-   * @param {String} [assetMetricValuesFilters.effectiveEndDate] Effective end date
-   *   of the asset metric values
-   * @param {String} [assetMetricValuesFilters.effectiveStartDate] Effective start
-   *   date of the asset metric values
-   * @param {Number} [assetMetricValuesFilters.limit] Maximum number of records to
-   *   return per query
-   * @param {Number} [assetMetricValuesFilters.offset] How many records from the first
-   *   record to start the query
+   * @param {Object} [assetMetricValuesFilters] Specific information that is
+   *   used to filter the list of asset metric values
+   * @param {String} [assetMetricValuesFilters.assetMetricLabel] The label of
+   *   the associated asset metrics
+   * @param {String} [assetMetricValuesFilters.effectiveEndDate] Effective end
+   *   date (ISO 8601 Extended formatted) of the asset metric values
+   * @param {String} [assetMetricValuesFilters.effectiveStartDate] Effective
+   *   start date (ISO 8601 Extended formatted) of the asset metric values
+   * @param {Number} [assetMetricValuesFilters.limit] Maximum number of records
+   *   to return per query
+   * @param {Number} [assetMetricValuesFilters.offset] How many records from the
+   *   first record to start the query
    *
    * @returns {Promise}
    * @fulfill {AssetMetricValuesFromServer}
@@ -508,13 +508,14 @@ class AssetMetrics {
    * Method: GET
    *
    * @param {String} assetId The ID of the asset (formatted as a UUID)
-   * @param {String} assetMetricId The ID of the asset metric (formatted as a UUID)
+   * @param {String} assetMetricId The ID of the asset metric (formatted as a
+   *   UUID)
    * @param {Object} [assetMetricValuesFilters] Specific information that is
    *   used to filter the list of asset metric values
    * @param {String} [assetMetricValuesFilters.effectiveEndDate] Effective end
-   *   date of the asset metric values
+   *   date (ISO 8601 Extended formatted) of the asset metric values
    * @param {String} [assetMetricValuesFilters.effectiveStartDate] Effective
-   *   start date of the asset metric values
+   *   start date (ISO 8601 Extended formatted) of the asset metric values
    * @param {Number} [assetMetricValuesFilters.limit] Maximum number of records
    *   to return per query
    * @param {Number} [assetMetricValuesFilters.offset] How many records from the

--- a/src/assets/assetMetrics.js
+++ b/src/assets/assetMetrics.js
@@ -246,7 +246,14 @@ class AssetMetrics {
    * Method: GET
    *
    * @param {string} assetTypeId The UUID formatted ID of the asset type
-   * @param {PaginationOptions} [paginationOptions]
+   * @param {Object} [assetMetricsFilters] Specific information that is used to
+   *   filter the list of asset metrics
+   * @param {Number} [assetMetricsFilters.limit] Maximum number of records to
+   *   return per query
+   * @param {Number} [assetMetricsFilters.offset] How many records from the first
+   *   record to start the query
+   * @param {String} [assetMetricsFilters.organizationId] The UUID formatted ID
+   *   of the organization to filter asset metrics by
    *
    * @returns {Promise}
    * @fulfill {AssetMetricsFromServer}
@@ -254,11 +261,17 @@ class AssetMetrics {
    *
    * @example
    * contxtSdk.assets.metrics
-   *   .getByAssetTypeId('4f0e51c6-728b-4892-9863-6d002e61204d')
+   *   .getByAssetTypeId(
+   *     '4f0e51c6-728b-4892-9863-6d002e61204d'
+   *      {
+   *        limit: 50,
+   *        offset: 150
+   *      }
+   *    )
    *   .then((assetMetrics) => console.log(assetMetrics))
    *   .catch((err) => console.log(err));
    */
-  getByAssetTypeId(assetTypeId, paginationOptions) {
+  getByAssetTypeId(assetTypeId, assetMetricsFilters) {
     if (!assetTypeId) {
       return Promise.reject(
         new Error(
@@ -269,9 +282,11 @@ class AssetMetrics {
 
     return this._request
       .get(`${this._baseUrl}/assets/types/${assetTypeId}/metrics`, {
-        params: toSnakeCase(paginationOptions)
+        params: toSnakeCase(assetMetricsFilters)
       })
-      .then((assetTypesData) => formatPaginatedDataFromServer(assetTypesData));
+      .then((assetMetricsData) =>
+        formatPaginatedDataFromServer(assetMetricsData)
+      );
   }
 
   /**
@@ -494,17 +509,19 @@ class AssetMetrics {
    *
    * @param {String} assetId The ID of the asset (formatted as a UUID)
    * @param {String} assetMetricId The ID of the asset metric (formatted as a UUID)
-   * @param {Object} [assetMetricFilters] Specific information that is used to
-   *   filter the list of asset attribute values
-   * @param {String} [assetMetricFilters.effectiveEndDate] Effective end date
-   *   of the asset metric values
-   * @param {String} [assetMetricFilters.effectiveStartDate] Effective start date
-   *   of the asset metric values
-   * @param {Number} [assetMetricFilters.limit] Maximum number of records to return per query
-   * @param {Number} [assetMetricFilters.offset] How many records from the first record to start the query
+   * @param {Object} [assetMetricValuesFilters] Specific information that is
+   *   used to filter the list of asset metric values
+   * @param {String} [assetMetricValuesFilters.effectiveEndDate] Effective end
+   *   date of the asset metric values
+   * @param {String} [assetMetricValuesFilters.effectiveStartDate] Effective
+   *   start date of the asset metric values
+   * @param {Number} [assetMetricValuesFilters.limit] Maximum number of records
+   *   to return per query
+   * @param {Number} [assetMetricValuesFilters.offset] How many records from the
+   *   first record to start the query
    *
    * @returns {Promise}
-   * @fulfill {AssetMetricValue[]}
+   * @fulfill {AssetMetricValuesFromServer}
    * @rejects {Error}
    *
    * @example
@@ -522,7 +539,7 @@ class AssetMetrics {
    *   })
    *   .catch((err) => console.log(err));
    */
-  getValuesByMetricId(assetId, assetMetricId, assetMetricFilters) {
+  getValuesByMetricId(assetId, assetMetricId, assetMetricValuesFilters) {
     if (!assetId) {
       return Promise.reject(
         new Error(
@@ -543,7 +560,7 @@ class AssetMetrics {
       .get(
         `${this._baseUrl}/assets/${assetId}/metrics/${assetMetricId}/values`,
         {
-          params: toSnakeCase(assetMetricFilters)
+          params: toSnakeCase(assetMetricValuesFilters)
         }
       )
       .then((assetMetricValueData) =>

--- a/src/assets/assetMetrics.js
+++ b/src/assets/assetMetrics.js
@@ -38,6 +38,14 @@ import { formatPaginatedDataFromServer } from '../utils/pagination';
  */
 
 /**
+ * @typedef {Object} AssetMetricValuesFromServer
+ * @property {Object} _metadata Metadata about the pagination settings
+ * @property {number} _metadata.offset Offset of records in subsequent queries
+ * @property {number} _metadata.totalRecords Total number of asset types found
+ * @property {AssetMetricValue[]} records
+ */
+
+/**
  * Module that provides access to, and the manipulation of, information about different asset metrics
  *
  * @typicalname contxtSdk.assets.metrics
@@ -180,6 +188,55 @@ class AssetMetrics {
     return this._request
       .get(`${this._baseUrl}/assets/metrics/${assetMetricId}`)
       .then((assetMetric) => toCamelCase(assetMetric));
+  }
+
+  /**
+   * Gets a list of all asset metrics that belong to a given asset
+   *
+   * API Endpoint: '/assets/:assetId/metrics
+   * Method: GET
+   *
+   * @param {string} assetId The UUID formatted ID of the asset type
+   * @param {Object} [assetMetricsFilters] Specific information that is used to
+   *   filter the list of asset metrics
+   * @param {String} [assetMetricsFilters.assetMetricLabel] The label of the
+   *   associated asset metrics
+   * @param {Number} [assetMetricsFilters.limit] Maximum number of records to
+   *   return per query
+   * @param {Number} [assetMetricsFilters.offset] How many records from the first
+   *   record to start the query
+   *
+   * @returns {Promise}
+   * @fulfill {AssetMetricsFromServer}
+   * @reject {Error}
+   *
+   * @example
+   * contxtSdk.assets.metrics
+   *   .getByAssetId(
+   *     'f3be81fd-4494-443b-87a3-320b1c9aa495',
+   *      {
+   *        assetMetricLabel: 'Square Footage',
+   *        limit: 50,
+   *        offset: 150
+   *      }
+   *    )
+   *   .then((assetMetricData) => console.log(assetMetricData))
+   *   .catch((err) => console.log(err));
+   */
+  getByAssetId(assetId, assetMetricsFilters) {
+    if (!assetId) {
+      return Promise.reject(
+        new Error('An asset ID is required to get a list of all asset metrics.')
+      );
+    }
+
+    return this._request
+      .get(`${this._baseUrl}/assets/${assetId}/metrics`, {
+        params: toSnakeCase(assetMetricsFilters)
+      })
+      .then((assetMetricsData) =>
+        formatPaginatedDataFromServer(assetMetricsData)
+      );
   }
 
   /**

--- a/src/assets/assetMetrics.js
+++ b/src/assets/assetMetrics.js
@@ -430,6 +430,63 @@ class AssetMetrics {
   }
 
   /**
+   * Gets asset metric values for a particular asset
+   *
+   * API Endpoint: '/assets/:assetId/metrics/values'
+   * Method: GET
+   *
+   * @param {String} assetId The ID of the asset (formatted as a UUID)
+   * @param {Object} [assetMetricValuesFilters] Specific information that is used to
+   *   filter the list of asset metric values
+   * @param {String} [assetMetricValuesFilters.assetMetricLabel] The label of the
+   *   associated asset metrics
+   * @param {String} [assetMetricValuesFilters.effectiveEndDate] Effective end date
+   *   of the asset metric values
+   * @param {String} [assetMetricValuesFilters.effectiveStartDate] Effective start
+   *   date of the asset metric values
+   * @param {Number} [assetMetricValuesFilters.limit] Maximum number of records to
+   *   return per query
+   * @param {Number} [assetMetricValuesFilters.offset] How many records from the first
+   *   record to start the query
+   *
+   * @returns {Promise}
+   * @fulfill {AssetMetricValuesFromServer}
+   * @rejects {Error}
+   *
+   * @example
+   * contxtSdk.assets.metrics
+   *   .getValuesByAssetId(
+   *      'f9c606f3-d270-4623-bf3b-b085424d9a8b',
+   *      {
+   *        assetMetricLabel: 'Square Footage',
+   *        effectiveEndDate: '2018-04-13T15:44:51.943Z'
+   *        effectiveStartDate: '2017-12-13T15:42:01.376Z'
+   *        limit: 10,
+   *        offset: 200
+   *      }
+   *    )
+   *   .then((assetMetricValuesData) => console.log(assetMetricValuesData))
+   *   .catch((err) => console.log(err));
+   */
+  getValuesByAssetId(assetId, assetMetricValuesFilters) {
+    if (!assetId) {
+      return Promise.reject(
+        new Error(
+          'An asset ID is required to get a list of asset metric values.'
+        )
+      );
+    }
+
+    return this._request
+      .get(`${this._baseUrl}/assets/${assetId}/metrics/values`, {
+        params: toSnakeCase(assetMetricValuesFilters)
+      })
+      .then((assetMetricValueData) =>
+        formatPaginatedDataFromServer(assetMetricValueData)
+      );
+  }
+
+  /**
    * Gets asset metric values for a particular asset and metric
    *
    * API Endpoint: '/assets/:assetId/metrics/:assetMetricId/values'

--- a/src/assets/assetMetrics.spec.js
+++ b/src/assets/assetMetrics.spec.js
@@ -381,8 +381,8 @@ describe('Assets/Metrics', function() {
       let assetTypeId;
       let formatPaginatedDataFromServer;
       let numberOfAssetMetrics;
-      let paginationOptionsAfterFormat;
-      let paginationOptionsBeforeFormat;
+      let metricsFiltersAfterFormat;
+      let metricsFiltersBeforeFormat;
       let promise;
       let request;
       let toSnakeCase;
@@ -392,11 +392,11 @@ describe('Assets/Metrics', function() {
       beforeEach(function() {
         numberOfAssetMetrics = faker.random.number({ min: 1, max: 10 });
         assetTypeId = fixture.build('assetType').id;
-        paginationOptionsBeforeFormat = {
+        metricsFiltersBeforeFormat = {
           limit: faker.random.number({ min: 10, max: 1000 }),
           offset: faker.random.number({ max: 1000 })
         };
-        paginationOptionsAfterFormat = {
+        metricsFiltersAfterFormat = {
           limit: faker.random.number({ min: 10, max: 1000 }),
           offset: faker.random.number({ max: 1000 })
         };
@@ -422,23 +422,23 @@ describe('Assets/Metrics', function() {
         };
         toSnakeCase = this.sandbox
           .stub(objectUtils, 'toSnakeCase')
-          .returns(paginationOptionsAfterFormat);
+          .returns(metricsFiltersAfterFormat);
 
         const assetMetrics = new AssetMetrics(baseSdk, request, expectedHost);
         promise = assetMetrics.getByAssetTypeId(
           assetTypeId,
-          paginationOptionsBeforeFormat
+          metricsFiltersBeforeFormat
         );
       });
 
       it('formats the pagination options sent to the server', function() {
-        expect(toSnakeCase).to.be.calledWith(paginationOptionsBeforeFormat);
+        expect(toSnakeCase).to.be.calledWith(metricsFiltersBeforeFormat);
       });
 
       it('gets a list of the asset metrics from the server', function() {
         expect(request.get).to.be.calledWith(
           `${expectedHost}/assets/types/${assetTypeId}/metrics`,
-          { params: paginationOptionsAfterFormat }
+          { params: metricsFiltersAfterFormat }
         );
       });
 
@@ -833,8 +833,8 @@ describe('Assets/Metrics', function() {
       let assetId;
       let metricId;
       let formatPaginatedDataFromServer;
-      let paginationOptionsBeforeFormat;
-      let paginationOptionsAfterFormat;
+      let metricValuesFiltersBeforeFormat;
+      let metricValuesFiltersAfterFormat;
       let promise;
       let request;
       let toSnakeCase;
@@ -844,11 +844,11 @@ describe('Assets/Metrics', function() {
       beforeEach(function() {
         assetId = fixture.build('asset').id;
         metricId = fixture.build('assetMetric').id;
-        paginationOptionsBeforeFormat = {
+        metricValuesFiltersBeforeFormat = {
           limit: faker.random.number({ min: 10, max: 1000 }),
           offset: faker.random.number({ max: 1000 })
         };
-        paginationOptionsAfterFormat = {
+        metricValuesFiltersAfterFormat = {
           limit: faker.random.number({ min: 10, max: 1000 }),
           offset: faker.random.number({ max: 1000 })
         };
@@ -879,24 +879,24 @@ describe('Assets/Metrics', function() {
         };
         toSnakeCase = this.sandbox
           .stub(objectUtils, 'toSnakeCase')
-          .returns(paginationOptionsAfterFormat);
+          .returns(metricValuesFiltersAfterFormat);
 
         const assetMetrics = new AssetMetrics(baseSdk, request, expectedHost);
         promise = assetMetrics.getValuesByMetricId(
           assetId,
           metricId,
-          paginationOptionsBeforeFormat
+          metricValuesFiltersBeforeFormat
         );
       });
 
       it('formats the pagination options sent to the server', function() {
-        expect(toSnakeCase).to.be.calledWith(paginationOptionsBeforeFormat);
+        expect(toSnakeCase).to.be.calledWith(metricValuesFiltersBeforeFormat);
       });
 
       it('gets a list of asset metric values from the server', function() {
         expect(request.get).to.be.calledWith(
           `${expectedHost}/assets/${assetId}/metrics/${metricId}/values`,
-          { params: paginationOptionsAfterFormat }
+          { params: metricValuesFiltersAfterFormat }
         );
       });
 


### PR DESCRIPTION
## Why?
There were a couple new endpoints added to the Facilities service that make getting lists of asset metrics and asset metric values easier.

## What changed?
- `AssetMetrics#getByAssetId` for getting all Asset Metrics for a specific Asset ID
  - Allows filtering by `assetMetricLabel`
- `AssetMetrics#getValuesByAssetId` for getting Asset Metric Values by for a specific Asset ID
  - Allows filtering by `assetMetricLabel`, `effectiveEndDate`, and `effectiveStartDate`
- Upgraded the `prettier` package
  - The newest version of `prettier-atom` required a newer version of prettier than we had installed.
- Ran `prettier` over CHANGELOG.md, which apparently had not happened before
