### PR TITLE
Fix bug where some methods did not pass pagination options to the APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,295 +1,295 @@
-## [v0.0.34](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.34) (2018-xx-xx)
+## [v0.0.34](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.34) (2018-10-08)
 
 **Fixed**
 
-- There were some methods that returned paginated data, but did not pass the `limit` and `offset` to the API. This has been fixed and now allows for passing `limit` and `offset` for:
-  - `AssetTypes#getAll`
-  - `AssetTypes#getAllByOrganizationId`
-  - `Assets#getAll`
-  - `Events#getEventTypesByClientId`
+* There were some methods that returned paginated data, but did not pass the `limit` and `offset` to the API. This has been fixed and now allows for passing `limit` and `offset` for:
+  * `AssetTypes#getAll`
+  * `AssetTypes#getAllByOrganizationId`
+  * `Assets#getAll`
+  * `Events#getEventTypesByClientId`
 
 ## [v0.0.33](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.33) (2018-09-27)
 
 **Added**
 
-- Additional methods for Asset Metrics and Asset Metric Values
+* Additional methods for Asset Metrics and Asset Metric Values
 
-  - `AssetMetrics#getByAssetId` for getting all Asset Metrics for a specific Asset ID
-    - Allows filtering by `assetMetricLabel`
-  - `AssetMetrics#getValuesByAssetId` for getting Asset Metric Values for a specific Asset ID
-    - Allows filtering by `assetMetricLabel`, `effectiveEndDate`, and `effectiveStartDate`
+  * `AssetMetrics#getByAssetId` for getting all Asset Metrics for a specific Asset ID
+    * Allows filtering by `assetMetricLabel`
+  * `AssetMetrics#getValuesByAssetId` for getting Asset Metric Values for a specific Asset ID
+    * Allows filtering by `assetMetricLabel`, `effectiveEndDate`, and `effectiveStartDate`
 
-- Additional methods for Events
+* Additional methods for Events
 
-  - `Events#getEventTypesByClientId` for getting all Event Types for a specific Client ID
-  - `Events#getEventsByTypeId` for getting Events for a specific Event Type ID
-    - Allows passing option to add latest `triggered_event` to Events.
+  * `Events#getEventTypesByClientId` for getting all Event Types for a specific Client ID
+  * `Events#getEventsByTypeId` for getting Events for a specific Event Type ID
+    * Allows passing option to add latest `triggered_event` to Events.
 
 ## [v0.0.32](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.32) (2018-09-17)
 
 **Added**
 
-- Methods around Asset Metrics and Asset Metric Values. They are namespaced under `metrics` and include:
-  - `AssetMetrics#create` for creating an Asset Metric
-  - `AssetMetrics#delete` for removing an Asset Metric
-  - `AssetMetrics#get` for getting an Asset Metric by its ID
-  - `AssetMetrics#getByAssetTypeId` for getting all Asset Metrics by Asset Type
-  - `AssetMetrics#update` for updating an Asset Metric
-  - `AssetMetrics#createValue` for creating an Asset Metric Value
-  - `AssetMetrics#deleteValue` for deleting an Asset Metric Value
-  - `AssetMetrics#getValuesByMetricId` for getting Asset Metric Values by Asset Metric ID
-  - `AssetMetrics#updateValue` for updating an Asset Metric Value
+* Methods around Asset Metrics and Asset Metric Values. They are namespaced under `metrics` and include:
+  * `AssetMetrics#create` for creating an Asset Metric
+  * `AssetMetrics#delete` for removing an Asset Metric
+  * `AssetMetrics#get` for getting an Asset Metric by its ID
+  * `AssetMetrics#getByAssetTypeId` for getting all Asset Metrics by Asset Type
+  * `AssetMetrics#update` for updating an Asset Metric
+  * `AssetMetrics#createValue` for creating an Asset Metric Value
+  * `AssetMetrics#deleteValue` for deleting an Asset Metric Value
+  * `AssetMetrics#getValuesByMetricId` for getting Asset Metric Values by Asset Metric ID
+  * `AssetMetrics#updateValue` for updating an Asset Metric Value
 
 ## [v0.0.31](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.31) (2018-09-10)
 
 **Added**
 
-- Added `AssetAttributes#getEffectiveValuesByOrganizationId` to retrieve all effective attribute values for a given organization.
+* Added `AssetAttributes#getEffectiveValuesByOrganizationId` to retrieve all effective attribute values for a given organization.
 
 ## [v0.0.30](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.30) (2018-08-20)
 
 **Changed**
 
-- Started normalizing Silent Authentication errors from Auth0 in the Auth0WebAuth session type to match Axios errors.
-  - Additionally, started logging the user out when one of these errors is encountered.
+* Started normalizing Silent Authentication errors from Auth0 in the Auth0WebAuth session type to match Axios errors.
+  * Additionally, started logging the user out when one of these errors is encountered.
 
 ## [v0.0.29](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.29) (2018-08-16)
 
 **Changed**
 
-- Added generic methods to normalize data moving between the API and the SDK consumer.
-  - Removed most formatters that were "brute forcing" the same task. Only remaining formatters are for specific edge cases.
+* Added generic methods to normalize data moving between the API and the SDK consumer.
+  * Removed most formatters that were "brute forcing" the same task. Only remaining formatters are for specific edge cases.
 
 ## [v0.0.28](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.28) (2018-08-15)
 
 **Added**
 
-- Methods around Edge Nodes. They are namespaced under coordinator (i.e. `coordinator.edgeNodes()`) and include:
-  - `EdgeNodes#get` for getting info about a specific Edge Node
+* Methods around Edge Nodes. They are namespaced under coordinator (i.e. `coordinator.edgeNodes()`) and include:
+  * `EdgeNodes#get` for getting info about a specific Edge Node
 
 ## [v0.0.27](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.27) (2018-08-14)
 
 **Added**
 
-- Added Bus, Channel module with the ability to perform create, read, update and delete on Message Bus Channels
+* Added Bus, Channel module with the ability to perform create, read, update and delete on Message Bus Channels
 
 ## [v0.0.26](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.26) (2018-08-13)
 
 **Changed**
 
-- Set specific engine versions for Node and NPM
-- Audited and updated dependencies
-- Updated `AssetAttributes#createValue` to use an updated API endpoint
+* Set specific engine versions for Node and NPM
+* Audited and updated dependencies
+* Updated `AssetAttributes#createValue` to use an updated API endpoint
 
 **Fixed**
 
-- Fixed documentation building process to support Node 6
+* Fixed documentation building process to support Node 6
 
 ## [v0.0.25](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.25) (2018-08-08)
 
 **Added**
 
-- Added Coordinator module with ability to get info about organizations and users from Contxt Coordinator
+* Added Coordinator module with ability to get info about organizations and users from Contxt Coordinator
 
 ## [v0.0.24](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.24) (2018-08-07)
 
 **Added**
 
-- Added Events module with ability to create, read, update, and delete events
+* Added Events module with ability to create, read, update, and delete events
 
 **Changed**
 
-- Added `assetLabel` and `label` as fields associated with `AssetAttributeValues`
+* Added `assetLabel` and `label` as fields associated with `AssetAttributeValues`
 
 ## [v0.0.23](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.23) (2018-08-01)
 
 **Fixed**
 
-- Fixed how results were returned from `AssetAttributes#getAll`
+* Fixed how results were returned from `AssetAttributes#getAll`
 
 ## [v0.0.22](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.22) (2018-07-30)
 
 **Changed**
 
-- Started to pass a more robust error when there is a problem renewing tokens with the Auth0WebAuth session adapter
-- Updated `AssetAttributes#getAll` to pass pagination information along with the request
+* Started to pass a more robust error when there is a problem renewing tokens with the Auth0WebAuth session adapter
+* Updated `AssetAttributes#getAll` to pass pagination information along with the request
 
 ## [v0.0.21](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.21) (2018-07-23)
 
 **Fixed**
 
-- Updated `AssetTypes#create` to allow for the creation of global asset types
+* Updated `AssetTypes#create` to allow for the creation of global asset types
 
 ## [v0.0.20](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.20) (2018-07-16)
 
 **Added**
 
-- Methods around the display and manipulation of Asset Attributes Values. They are namespaced under assets (i.e. `assets.attributes.methodName()`) and include:
+* Methods around the display and manipulation of Asset Attributes Values. They are namespaced under assets (i.e. `assets.attributes.methodName()`) and include:
 
-  - `AssetAttributes#createValue` to add an asset attribute value
-  - `AssetAttributes#deleteValue` to delete an asset attribute value
-  - `AssetAttributes#getEffectiveValuesByAssetId` to get the effective asset attribute values for a particular asset
-  - `AssetAttributes#getValuesByAttributeId` to get a paginated list of asset attribute values for a particular attribute of a particular asset
-  - `AssetAttributes#updateValue` to update an asset attribute value
+  * `AssetAttributes#createValue` to add an asset attribute value
+  * `AssetAttributes#deleteValue` to delete an asset attribute value
+  * `AssetAttributes#getEffectiveValuesByAssetId` to get the effective asset attribute values for a particular asset
+  * `AssetAttributes#getValuesByAttributeId` to get a paginated list of asset attribute values for a particular attribute of a particular asset
+  * `AssetAttributes#updateValue` to update an asset attribute value
 
 **Changed**
 
-- Now supporting the `data_type` field for `AssetAttributes`
+* Now supporting the `data_type` field for `AssetAttributes`
 
 ## [v0.0.19](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.19) (2018-07-09)
 
 **Added**
 
-- Methods around the display and manipulation of Asset Attributes. They are namespaced under assets (i.e. `assets.attributes.methodName()`) and include:
-  - `AssetAttributes#create` to add an asset attribute
-  - `AssetAttributes#delete` to delete an asset attribute
-  - `AssetAttributes#get` to get an asset attribute
-  - `AssetAttributes#getAll` to get a list of all asset attributes
-  - `AssetAttributes#update` to update an asset attribute
+* Methods around the display and manipulation of Asset Attributes. They are namespaced under assets (i.e. `assets.attributes.methodName()`) and include:
+  * `AssetAttributes#create` to add an asset attribute
+  * `AssetAttributes#delete` to delete an asset attribute
+  * `AssetAttributes#get` to get an asset attribute
+  * `AssetAttributes#getAll` to get a list of all asset attributes
+  * `AssetAttributes#update` to update an asset attribute
 
 ## [v0.0.18](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.18) (2018-07-06)
 
 **Changed**
 
-- External Modules can now have a `clientId` or `host` set to `null` if the values are not needed for the module. (_NOTE:_ Some SessionType adapters, like the MachineAuth adapter, require a `clientId` if the built-in `request` module is used since contxt auth tokens for those adapters are generated on a per-clientId basis).
+* External Modules can now have a `clientId` or `host` set to `null` if the values are not needed for the module. (_NOTE:_ Some SessionType adapters, like the MachineAuth adapter, require a `clientId` if the built-in `request` module is used since contxt auth tokens for those adapters are generated on a per-clientId basis).
 
 ## [v0.0.17](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.17) (2018-07-03)
 
 **Added**
 
-- Methods around the display and manipulation of Assets. They are namespaced under assets (i.e. `assets.methodName()`) and include:
-  - `Assets#create` to add an asset
-  - `Assets#delete` to delete an asset
-  - `Assets#get` to get an asset
-  - `Assets#getAll` to get a list of all assets
-  - `Assets#getAllByOrganizationId` to get a list of all assets for a specific organization
-  - `Assets#update` to update an asset
-- Methods around the display and manipulation of Asset Types. They are namespaced under assets (i.e. `assets.types.methodName()`) and include:
-  - `AssetTypes#create` to add an asset type
-  - `AssetTypes#delete` to delete an asset type
-  - `AssetTypes#get` to get an asset type
-  - `AssetTypes#getAll` to get a list of all asset types
-  - `AssetTypes#getAllByOrganizationId` to get a list of all asset types for a specific organization
-  - `AssetTypes#update` to update an asset type
+* Methods around the display and manipulation of Assets. They are namespaced under assets (i.e. `assets.methodName()`) and include:
+  * `Assets#create` to add an asset
+  * `Assets#delete` to delete an asset
+  * `Assets#get` to get an asset
+  * `Assets#getAll` to get a list of all assets
+  * `Assets#getAllByOrganizationId` to get a list of all assets for a specific organization
+  * `Assets#update` to update an asset
+* Methods around the display and manipulation of Asset Types. They are namespaced under assets (i.e. `assets.types.methodName()`) and include:
+  * `AssetTypes#create` to add an asset type
+  * `AssetTypes#delete` to delete an asset type
+  * `AssetTypes#get` to get an asset type
+  * `AssetTypes#getAll` to get a list of all asset types
+  * `AssetTypes#getAllByOrganizationId` to get a list of all asset types for a specific organization
+  * `AssetTypes#update` to update an asset type
 
 ## [v0.0.16](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.16) (2018-07-02)
 
 **Added**
 
-- Added IOT module, with ability to get field data and field information
+* Added IOT module, with ability to get field data and field information
 
 **Changed**
 
-- `asset_id` added as an optional field when getting facilities
+* `asset_id` added as an optional field when getting facilities
 
 **Fixed**
 
-- Fixed bug where calls would return with a 401 when making simultaneous requests while using the `MachineAuth` session typ.
+* Fixed bug where calls would return with a 401 when making simultaneous requests while using the `MachineAuth` session typ.
 
 ## [v0.0.15](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.15) (2018-06-21)
 
 **Changed**
 
-- Auth0WebAuth now automatically handles refreshing Access and API tokens instead of forcing the user to log in again every two hours.
+* Auth0WebAuth now automatically handles refreshing Access and API tokens instead of forcing the user to log in again every two hours.
 
 ## [v0.0.14](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.14) (2018-06-18)
 
 **Changed**
 
-- `Facilities#getAllByOrganizationId` to accept parameters to include cost centers information
-- `Facilities#get` to include cost centers information for that specific facility
+* `Facilities#getAllByOrganizationId` to accept parameters to include cost centers information
+* `Facilities#get` to include cost centers information for that specific facility
 
 ## [v0.0.13](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.13) (2018-06-16)
 
 **Added**
 
-- The ability to set up custom axios interceptors to be used on each request and response made to an API. (More information available at at {@link https://github.com/axios/axios#interceptors axios Interceptors})
+* The ability to set up custom axios interceptors to be used on each request and response made to an API. (More information available at at {@link https://github.com/axios/axios#interceptors axios Interceptors})
 
 ## [v0.0.12](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.12) (2018-06-14)
 
 **Added**
 
-- Methods around the display and manipulation of Cost Centers. They are namespaced under facilities (i.e. `facilities.costCenters.methodName()`) and include:
-  - `CostCenters#addFacility` to add a facility to a cost center
-  - `CostCenters#create` for creating a new cost center
-  - `CostCenters#getAll` for getting a list of all cost centers
-  - `CostCenters#getAllByOrganizationId` for getting all cost centers for a specific organization
-  - `CostCenters#remove` to remove an existing cost center
-  - `CostCenters#removeFacility` to remove a facility from a cost center
-  - `CostCenters#update` to update an existing cost center
+* Methods around the display and manipulation of Cost Centers. They are namespaced under facilities (i.e. `facilities.costCenters.methodName()`) and include:
+  * `CostCenters#addFacility` to add a facility to a cost center
+  * `CostCenters#create` for creating a new cost center
+  * `CostCenters#getAll` for getting a list of all cost centers
+  * `CostCenters#getAllByOrganizationId` for getting all cost centers for a specific organization
+  * `CostCenters#remove` to remove an existing cost center
+  * `CostCenters#removeFacility` to remove a facility from a cost center
+  * `CostCenters#update` to update an existing cost center
 
 ## [v0.0.11](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.11) (2018-05-16)
 
 **Changed**
 
-- `Facilities#getAllByOrganizationId` to accept parameters to include facility grouping information
+* `Facilities#getAllByOrganizationId` to accept parameters to include facility grouping information
 
 ## [v0.0.10](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.10) (2018-05-01)
 
 **Added**
 
-- `FacilityGroupings#remove` to remove an existing facility grouping
-- `FacilityGroupings#update` to update an existing facility grouping
+* `FacilityGroupings#remove` to remove an existing facility grouping
+* `FacilityGroupings#update` to update an existing facility grouping
 
 ## [v0.0.9](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.9) (2018-04-19)
 
 **Added**
 
-- `FacilityGroupings#getAllByOrganizationId` for getting all facility groupings for a specific organization
+* `FacilityGroupings#getAllByOrganizationId` for getting all facility groupings for a specific organization
 
 ## [v0.0.8](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.8) (2018-04-16)
 
 **Added**
 
-- Added some methods to help out when working with facility groupings. They are namespaced under facilities (i.e. `facilities.groupings.methodName()`) and include:
-  - `FacilityGroupings#addFacility` to add a facility to a facility grouping
-  - `FacilityGroupings#create` for creating new facility groupings
-  - `FacilityGroupings#getAll` for getting a list of all facility groupings
-  - `FacilityGroupings#removeFacility` to remove a facility from a facility grouping
+* Added some methods to help out when working with facility groupings. They are namespaced under facilities (i.e. `facilities.groupings.methodName()`) and include:
+  * `FacilityGroupings#addFacility` to add a facility to a facility grouping
+  * `FacilityGroupings#create` for creating new facility groupings
+  * `FacilityGroupings#getAll` for getting a list of all facility groupings
+  * `FacilityGroupings#removeFacility` to remove a facility from a facility grouping
 
 ## [v0.0.7](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.7) (2018-03-29)
 
 **Renamed**
 
-- `Facilities#updateInfo` to `Facilities#createOrUpdateInfo` so that what the method does is more obvious
+* `Facilities#updateInfo` to `Facilities#createOrUpdateInfo` so that what the method does is more obvious
 
 ## [v0.0.6](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.6) (2018-03-28)
 
 **Added**
 
-- `Facilities#updateInfo` for updating a facility's facilily info
+* `Facilities#updateInfo` for updating a facility's facilily info
 
 ## [v0.0.5](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.5) (2018-03-20)
 
 **Added**
 
-- Facilities#create, Facilities#delete, Facilities#getAllByOrganizationId, and Facilities#update
+* Facilities#create, Facilities#delete, Facilities#getAllByOrganizationId, and Facilities#update
 
 ## [v0.0.4](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.4) (2018-03-08)
 
 **Added**
 
-- MachineAuth SessionType for use on Node.js projects
+* MachineAuth SessionType for use on Node.js projects
 
 **Changed**
 
-- Split API documentation into multiple files for easy reading and navigation
+* Split API documentation into multiple files for easy reading and navigation
 
 **Fixed**
 
-- Updated required version of `auth0-js` to fix [CVS-2018-7307](https://auth0.com/docs/security/bulletins/cve-2018-7307)
+* Updated required version of `auth0-js` to fix [CVS-2018-7307](https://auth0.com/docs/security/bulletins/cve-2018-7307)
 
 ## v0.0.3 (2018-02-26)
 
-- Adds documentation!
-- Fixes bug where placement of customModuleConfigs and the chosen environment in the user config did not match up with what was in documentation
+* Adds documentation!
+* Fixes bug where placement of customModuleConfigs and the chosen environment in the user config did not match up with what was in documentation
 
 ## v0.0.2 (2018-02-26)
 
-- Fixes publication process so that the built files are in the package grabbed from NPM
+* Fixes publication process so that the built files are in the package grabbed from NPM
 
 ## v0.0.1 (2018-02-23)
 
-- Initial release
-- Provides Request, Config and an initial SessionType, Auth0WebAuth
-- Provides `Facilities#get` and Facilities#getAll
+* Initial release
+* Provides Request, Config and an initial SessionType, Auth0WebAuth
+* Provides `Facilities#get` and Facilities#getAll

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [v0.0.34](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.34) (2018-xx-xx)
+
+**Fixed**
+
+- There were some methods that returned paginated data, but did not pass the `limit` and `offset` to the API. This has been fixed and now allows for passing `limit` and `offset` for:
+  - `AssetTypes#getAll`
+  - `AssetTypes#getAllByOrganizationId`
+  - `Assets#getAll`
+  - `Events#getEventTypesByClientId`
+
 ## [v0.0.33](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.33) (2018-09-27)
 
 **Added**

--- a/docs/AssetTypes.md
+++ b/docs/AssetTypes.md
@@ -10,8 +10,8 @@ Module that provides access to, and the manipulation of, information about diffe
     * [.create(assetType)](#AssetTypes+create) ⇒ <code>Promise</code>
     * [.delete(assetTypeId)](#AssetTypes+delete) ⇒ <code>Promise</code>
     * [.get(assetTypeId)](#AssetTypes+get) ⇒ <code>Promise</code>
-    * [.getAll()](#AssetTypes+getAll) ⇒ <code>Promise</code>
-    * [.getAllByOrganizationId(organizationId)](#AssetTypes+getAllByOrganizationId) ⇒ <code>Promise</code>
+    * [.getAll([paginationOptions])](#AssetTypes+getAll) ⇒ <code>Promise</code>
+    * [.getAllByOrganizationId(organizationId, [paginationOptions])](#AssetTypes+getAllByOrganizationId) ⇒ <code>Promise</code>
     * [.update(assetTypeId, update)](#AssetTypes+update) ⇒ <code>Promise</code>
 
 <a name="new_AssetTypes_new"></a>
@@ -99,7 +99,7 @@ contxtSdk.assets.types
 ```
 <a name="AssetTypes+getAll"></a>
 
-### contxtSdk.assets.types.getAll() ⇒ <code>Promise</code>
+### contxtSdk.assets.types.getAll([paginationOptions]) ⇒ <code>Promise</code>
 Gets a list of all asset types
 
 API Endpoint: '/assets/types/
@@ -108,6 +108,11 @@ Method: GET
 **Kind**: instance method of [<code>AssetTypes</code>](#AssetTypes)  
 **Fulfill**: [<code>AssetTypesFromServer</code>](./Typedefs.md#AssetTypesFromServer)  
 **Reject**: <code>Error</code>  
+
+| Param | Type |
+| --- | --- |
+| [paginationOptions] | [<code>PaginationOptions</code>](./Typedefs.md#PaginationOptions) | 
+
 **Example**  
 ```js
 contxtSdk.assets.types
@@ -117,7 +122,7 @@ contxtSdk.assets.types
 ```
 <a name="AssetTypes+getAllByOrganizationId"></a>
 
-### contxtSdk.assets.types.getAllByOrganizationId(organizationId) ⇒ <code>Promise</code>
+### contxtSdk.assets.types.getAllByOrganizationId(organizationId, [paginationOptions]) ⇒ <code>Promise</code>
 Gets a list of all asset types that belong to a particular organization
 
 API Endpoint: '/organizations/:organizationId/assets/types'
@@ -130,6 +135,7 @@ Method: GET
 | Param | Type | Description |
 | --- | --- | --- |
 | organizationId | <code>string</code> | UUID corresponding with an organization |
+| [paginationOptions] | [<code>PaginationOptions</code>](./Typedefs.md#PaginationOptions) |  |
 
 **Example**  
 ```js

--- a/docs/Assets.md
+++ b/docs/Assets.md
@@ -10,7 +10,7 @@ Module that provides access to, and the manipulation of, information about diffe
     * [.create(asset)](#Assets+create) ⇒ <code>Promise</code>
     * [.delete(assetId)](#Assets+delete) ⇒ <code>Promise</code>
     * [.get(assetId)](#Assets+get) ⇒ <code>Promise</code>
-    * [.getAll()](#Assets+getAll) ⇒ <code>Promise</code>
+    * [.getAll([paginationOptions])](#Assets+getAll) ⇒ <code>Promise</code>
     * [.getAllByOrganizationId(organizationId, [options])](#Assets+getAllByOrganizationId) ⇒ <code>Promise</code>
     * [.update(assetId, update)](#Assets+update)
 
@@ -100,7 +100,7 @@ contxtSdk.assets
 ```
 <a name="Assets+getAll"></a>
 
-### contxtSdk.assets.getAll() ⇒ <code>Promise</code>
+### contxtSdk.assets.getAll([paginationOptions]) ⇒ <code>Promise</code>
 Get a list of all assets
 
 API Endpoint: '/assets'
@@ -109,6 +109,11 @@ Method: GET
 **Kind**: instance method of [<code>Assets</code>](#Assets)  
 **Fulfill**: [<code>AssetsFromServer</code>](./Typedefs.md#AssetsFromServer)  
 **Reject**: <code>Error</code>  
+
+| Param | Type |
+| --- | --- |
+| [paginationOptions] | [<code>PaginationOptions</code>](./Typedefs.md#PaginationOptions) | 
+
 **Example**  
 ```js
 contxtSdk.assets
@@ -132,7 +137,9 @@ Method: GET
 | --- | --- | --- |
 | organizationId | <code>string</code> | UUID corresponding with an organization |
 | [options] | <code>Object</code> | Object containing parameters to be called with the request |
-| [options.assetTypeId] | <code>string</code> | ID of the asset type to use for filtering |
+| [options.assetTypeId] | <code>string</code> | UUID of the asset type to use for filtering |
+| [options.limit] | <code>Number</code> | Maximum number of records to return per query |
+| [options.offset] | <code>Number</code> | How many records from the first record to start |
 
 **Example**  
 ```js

--- a/docs/Events.md
+++ b/docs/Events.md
@@ -11,7 +11,7 @@ of, information about different events
     * [.create(event)](#Events+create) ⇒ <code>Promise</code>
     * [.delete(eventId)](#Events+delete) ⇒ <code>Promise</code>
     * [.get(eventId)](#Events+get) ⇒ <code>Promise</code>
-    * [.getEventTypesByClientId(clientId)](#Events+getEventTypesByClientId) ⇒ <code>Promise</code>
+    * [.getEventTypesByClientId(clientId, [paginationOptions])](#Events+getEventTypesByClientId) ⇒ <code>Promise</code>
     * [.getEventsByTypeId(eventTypeId, [latest])](#Events+getEventsByTypeId) ⇒ <code>Promise</code>
     * [.update(eventId, update)](#Events+update) ⇒ <code>Promise</code>
 
@@ -104,7 +104,7 @@ contxtSdk.events
 ```
 <a name="Events+getEventTypesByClientId"></a>
 
-### contxtSdk.events.getEventTypesByClientId(clientId) ⇒ <code>Promise</code>
+### contxtSdk.events.getEventTypesByClientId(clientId, [paginationOptions]) ⇒ <code>Promise</code>
 Gets all event types for a client
 
 API Endpoint: '/clients/:clientId/types'
@@ -117,6 +117,7 @@ Method: GET
 | Param | Type | Description |
 | --- | --- | --- |
 | clientId | <code>string</code> | The ID of the client |
+| [paginationOptions] | [<code>PaginationOptions</code>](./Typedefs.md#PaginationOptions) |  |
 
 **Example**  
 ```js

--- a/src/assets/assetTypes.js
+++ b/src/assets/assetTypes.js
@@ -150,6 +150,8 @@ class AssetTypes {
    * API Endpoint: '/assets/types/
    * Method: GET
    *
+   * @param {PaginationOptions} [paginationOptions]
+   *
    * @returns {Promise}
    * @fulfill {AssetTypesFromServer}
    * @reject {Error}
@@ -160,9 +162,11 @@ class AssetTypes {
    *   .then((assetTypes) => console.log(assetTypes))
    *   .catch((err) => console.log(err));
    */
-  getAll() {
+  getAll(paginationOptions) {
     return this._request
-      .get(`${this._baseUrl}/assets/types`)
+      .get(`${this._baseUrl}/assets/types`, {
+        params: toSnakeCase(paginationOptions)
+      })
       .then((assetTypesData) => formatPaginatedDataFromServer(assetTypesData));
   }
 
@@ -173,6 +177,7 @@ class AssetTypes {
    * Method: GET
    *
    * @param {string} organizationId UUID corresponding with an organization
+   * @param {PaginationOptions} [paginationOptions]
    *
    * @returns {Promise}
    * @fulfill {AssetTypesFromServer}
@@ -184,7 +189,7 @@ class AssetTypes {
    *   .then((assetTypes) => console.log(assetTypes))
    *   .catch((err) => console.log(assetTypes));
    */
-  getAllByOrganizationId(organizationId) {
+  getAllByOrganizationId(organizationId, paginationOptions) {
     if (!organizationId) {
       return Promise.reject(
         new Error(
@@ -194,7 +199,9 @@ class AssetTypes {
     }
 
     return this._request
-      .get(`${this._baseUrl}/organizations/${organizationId}/assets/types`)
+      .get(`${this._baseUrl}/organizations/${organizationId}/assets/types`, {
+        params: toSnakeCase(paginationOptions)
+      })
       .then((assetTypesData) => formatPaginatedDataFromServer(assetTypesData));
   }
 

--- a/src/assets/assetTypes.spec.js
+++ b/src/assets/assetTypes.spec.js
@@ -315,8 +315,11 @@ describe('Assets/Types', function() {
     let assetTypesFromServerBeforeFormat;
     let formatPaginatedDataFromServer;
     let numberOfAssetTypes;
+    let paginationOptionsAfterFormat;
+    let paginationOptionsBeforeFormat;
     let promise;
     let request;
+    let toSnakeCase;
 
     beforeEach(function() {
       numberOfAssetTypes = faker.random.number({ min: 1, max: 10 });
@@ -330,6 +333,13 @@ describe('Assets/Types', function() {
           fixture.build('assetType', asset, { fromServer: true })
         )
       };
+      paginationOptionsBeforeFormat = {
+        limit: faker.random.number({ min: 10, max: 1000 }),
+        offset: faker.random.number({ max: 1000 })
+      };
+      paginationOptionsAfterFormat = {
+        ...paginationOptionsBeforeFormat
+      };
 
       formatPaginatedDataFromServer = this.sandbox
         .stub(paginationUtils, 'formatPaginatedDataFromServer')
@@ -338,14 +348,23 @@ describe('Assets/Types', function() {
         ...baseRequest,
         get: this.sandbox.stub().resolves(assetTypesFromServerBeforeFormat)
       };
+      toSnakeCase = this.sandbox
+        .stub(objectUtils, 'toSnakeCase')
+        .returns(paginationOptionsAfterFormat);
 
       const assetTypes = new AssetTypes(baseSdk, request, expectedHost);
 
-      promise = assetTypes.getAll();
+      promise = assetTypes.getAll(paginationOptionsBeforeFormat);
+    });
+
+    it('formats the pagination options', function() {
+      expect(toSnakeCase).to.be.calledWith(paginationOptionsBeforeFormat);
     });
 
     it('gets a list of the asset types from the server', function() {
-      expect(request.get).to.be.calledWith(`${expectedHost}/assets/types`);
+      expect(request.get).to.be.calledWith(`${expectedHost}/assets/types`, {
+        params: paginationOptionsAfterFormat
+      });
     });
 
     it('formats the asset type object', function() {
@@ -370,8 +389,11 @@ describe('Assets/Types', function() {
       let expectedOrganizationId;
       let formatPaginatedDataFromServer;
       let numberOfAssetTypes;
+      let paginationOptionsAfterFormat;
+      let paginationOptionsBeforeFormat;
       let promise;
       let request;
+      let toSnakeCase;
 
       beforeEach(function() {
         expectedOrganizationId = fixture.build('organization').id;
@@ -386,6 +408,13 @@ describe('Assets/Types', function() {
             fixture.build('assetType', asset, { fromServer: true })
           )
         };
+        paginationOptionsBeforeFormat = {
+          limit: faker.random.number({ min: 10, max: 1000 }),
+          offset: faker.random.number({ max: 1000 })
+        };
+        paginationOptionsAfterFormat = {
+          ...paginationOptionsBeforeFormat
+        };
 
         formatPaginatedDataFromServer = this.sandbox
           .stub(paginationUtils, 'formatPaginatedDataFromServer')
@@ -394,15 +423,26 @@ describe('Assets/Types', function() {
           ...baseRequest,
           get: this.sandbox.stub().resolves(assetTypesFromServerBeforeFormat)
         };
+        toSnakeCase = this.sandbox
+          .stub(objectUtils, 'toSnakeCase')
+          .returns(paginationOptionsAfterFormat);
 
         const assetTypes = new AssetTypes(baseSdk, request, expectedHost);
 
-        promise = assetTypes.getAllByOrganizationId(expectedOrganizationId);
+        promise = assetTypes.getAllByOrganizationId(
+          expectedOrganizationId,
+          paginationOptionsBeforeFormat
+        );
+      });
+
+      it('formats the pagination options', function() {
+        expect(toSnakeCase).to.be.calledWith(paginationOptionsBeforeFormat);
       });
 
       it('gets a list of asset types for an organization from the server', function() {
         expect(request.get).to.be.calledWith(
-          `${expectedHost}/organizations/${expectedOrganizationId}/assets/types`
+          `${expectedHost}/organizations/${expectedOrganizationId}/assets/types`,
+          { params: paginationOptionsAfterFormat }
         );
       });
 

--- a/src/assets/index.js
+++ b/src/assets/index.js
@@ -155,6 +155,8 @@ class Assets {
    * API Endpoint: '/assets'
    * Method: GET
    *
+   * @param {PaginationOptions} [paginationOptions]
+   *
    * @returns {Promise}
    * @fulfill {AssetsFromServer}
    * @reject {Error}
@@ -165,9 +167,11 @@ class Assets {
    *   .then((assets) => console.log(assets))
    *   .catch((err) => console.log(err));
    */
-  getAll() {
+  getAll(paginationOptions) {
     return this._request
-      .get(`${this._baseUrl}/assets`)
+      .get(`${this._baseUrl}/assets`, {
+        params: toSnakeCase(paginationOptions)
+      })
       .then((assetsData) => formatPaginatedDataFromServer(assetsData));
   }
 
@@ -179,7 +183,9 @@ class Assets {
    *
    * @param {string} organizationId UUID corresponding with an organization
    * @param {Object} [options] Object containing parameters to be called with the request
-   * @param {string} [options.assetTypeId] ID of the asset type to use for filtering
+   * @param {string} [options.assetTypeId] UUID of the asset type to use for filtering
+   * @param {Number} [options.limit] Maximum number of records to return per query
+   * @param {Number} [options.offset] How many records from the first record to start
    *
    * @returns {Promise}
    * @fulfill {AssetsFromServer}

--- a/src/events/index.js
+++ b/src/events/index.js
@@ -197,6 +197,7 @@ class Events {
    * Method: GET
    *
    * @param {string} clientId The ID of the client
+   * @param {PaginationOptions} [paginationOptions]
    *
    * @returns {Promise}
    * @fulfill {EventTypesFromServer} Event types from the server
@@ -208,7 +209,7 @@ class Events {
    *   .then((events) => console.log(events))
    *   .catch((err) => console.log(err));
    */
-  getEventTypesByClientId(clientId) {
+  getEventTypesByClientId(clientId, paginationOptions) {
     if (!clientId) {
       return Promise.reject(
         new Error('A client ID is required for getting types')
@@ -216,7 +217,9 @@ class Events {
     }
 
     return this._request
-      .get(`${this._baseUrl}/clients/${clientId}/types`)
+      .get(`${this._baseUrl}/clients/${clientId}/types`, {
+        params: toSnakeCase(paginationOptions)
+      })
       .then((response) => formatPaginatedDataFromServer(response));
   }
 


### PR DESCRIPTION
## Why?
There were a few methods that returned paginated data, but could not pass the limit or offset, which resulted in not being able to get all results.

## What changed?
- This has been fixed and now allows for passing `limit` and `offset` for:
  - `AssetTypes#getAll`
  - `AssetTypes#getAllByOrganizationId`
  - `Assets#getAll`
  - `Events#getEventTypesByClientId`