### PR TITLE
Files#delete and Files#getAll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@
 
 - Added Files module with several methods
 
+  - `Files#delete` for deleting a single File
   - `Files#download` for getting a temporary URL to a File
   - `Files#get` for getting metadata about a File
+  - `Files#getAll` for getting a paginated list of Files and their metadata
 
 ## [v0.0.38](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.38) (2019-01-29)
 

--- a/docs/Files.md
+++ b/docs/Files.md
@@ -10,6 +10,7 @@ Module that provides access to information about Files
     * [.delete(fileId)](#Files+delete) ⇒ <code>Promise</code>
     * [.download(fileId)](#Files+download) ⇒ <code>Promise</code>
     * [.get(fileId)](#Files+get) ⇒ <code>Promise</code>
+    * [.getAll([filesFilters])](#Files+getAll) ⇒ <code>Promise</code>
 
 <a name="new_Files_new"></a>
 
@@ -84,5 +85,34 @@ Method: GET
 contxtSdk.files
   .get('bbcdd201-58f7-4b69-a24e-752e9490a347')
   .then((file) => console.log(file))
+  .catch((err) => console.log(err));
+```
+<a name="Files+getAll"></a>
+
+### contxtSdk.files.getAll([filesFilters]) ⇒ <code>Promise</code>
+Gets a paginated list of files and their metadata. This does not return
+the actual files.
+
+API Endpoint: '/files'
+Method: GET
+
+**Kind**: instance method of [<code>Files</code>](#Files)  
+**Fulfill**: [<code>FilesFromServer</code>](./Typedefs.md#FilesFromServer) Information about the files  
+**Reject**: <code>Error</code>  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| [filesFilters] | <code>Object</code> |  |  |
+| [filesFilters.limit] | <code>Number</code> | <code>100</code> | Maximum number of records to return per query |
+| [filesFilters.offset] | <code>Number</code> | <code>0</code> | How many records from the first record to start the query |
+| [filesFilters.orderBy] | <code>String</code> | <code>&#x27;createdAt&#x27;</code> | How many records from the first record to start the query |
+| [filesFilters.reverseOrder] | <code>Boolean</code> | <code>false</code> | Determine the results should be sorted in reverse (ascending) order |
+| [filesFilters.status] | <code>String</code> | <code>&#x27;ACTIVE&#x27;</code> | Filter by a file's current status |
+
+**Example**  
+```js
+contxtSdk.files
+  .getAll()
+  .then((files) => console.log(files))
   .catch((err) => console.log(err));
 ```

--- a/docs/Files.md
+++ b/docs/Files.md
@@ -7,6 +7,7 @@ Module that provides access to information about Files
 
 * [Files](#Files)
     * [new Files(sdk, request)](#new_Files_new)
+    * [.delete(fileId)](#Files+delete) ⇒ <code>Promise</code>
     * [.download(fileId)](#Files+download) ⇒ <code>Promise</code>
     * [.get(fileId)](#Files+get) ⇒ <code>Promise</code>
 
@@ -19,6 +20,26 @@ Module that provides access to information about Files
 | sdk | <code>Object</code> | An instance of the SDK so the module can communicate with other modules |
 | request | <code>Object</code> | An instance of the request module tied to this module's audience. |
 
+<a name="Files+delete"></a>
+
+### contxtSdk.files.delete(fileId) ⇒ <code>Promise</code>
+Deletes a file and associated file actions.
+
+API Endpoint: '/files/:fileId'
+Method: DELETE
+
+**Kind**: instance method of [<code>Files</code>](#Files)  
+**Fulfill**: <code>undefined</code>  
+**Reject**: <code>Error</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| fileId | <code>string</code> | The ID of the file |
+
+**Example**  
+```js
+contxtSdk.files.delete('8704f900-28f2-4951-aaf0-1827fcd0b0cb');
+```
 <a name="Files+download"></a>
 
 ### contxtSdk.files.download(fileId) ⇒ <code>Promise</code>

--- a/docs/README.md
+++ b/docs/README.md
@@ -183,6 +183,8 @@ for authenticating and communicating with an individual API and the external mod
 <dd></dd>
 <dt><a href="./Typedefs.md#FileToDownload">FileToDownload</a> : <code>Object</code></dt>
 <dd></dd>
+<dt><a href="./Typedefs.md#FilesFromServer">FilesFromServer</a> : <code>Object</code></dt>
+<dd></dd>
 <dt><a href="./Typedefs.md#MachineAuthSessionInfo">MachineAuthSessionInfo</a> : <code>Object</code></dt>
 <dd></dd>
 <dt><a href="./Typedefs.md#MessageBusChannel">MessageBusChannel</a> : <code>Object</code></dt>

--- a/docs/Typedefs.md
+++ b/docs/Typedefs.md
@@ -574,6 +574,19 @@ for authenticating and communicating with an individual API and the external mod
 | expiresAt | <code>string</code> | ISO 8601 Extended Format date/time |
 | temporaryUrl | <code>string</code> | A temporary URL that can be used to download the file |
 
+<a name="FilesFromServer"></a>
+
+## FilesFromServer : <code>Object</code>
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| _metadata | <code>Object</code> | Metadata about the pagination settings |
+| _metadata.offset | <code>number</code> | Offset of records in subsequent queries |
+| _metadata.totalRecords | <code>number</code> | Total number of files found |
+| records | [<code>Array.&lt;File&gt;</code>](#File) |  |
+
 <a name="MachineAuthSessionInfo"></a>
 
 ## MachineAuthSessionInfo : <code>Object</code>

--- a/src/files/index.js
+++ b/src/files/index.js
@@ -1,4 +1,5 @@
-import { toCamelCase } from '../utils/objects';
+import { toCamelCase, toSnakeCase } from '../utils/objects';
+import { formatPaginatedDataFromServer } from '../utils/pagination';
 
 /**
  * @typedef {Object} File
@@ -11,6 +12,14 @@ import { toCamelCase } from '../utils/objects';
  * @property {string} ownerId The ID of the user who owns the file
  * @property {string} status The status of the File, e.g. "ACTIVE"
  * @property {string} updatedAt ISO 8601 Extended Format date/time string
+ */
+
+/**
+ * @typedef {Object} FilesFromServer
+ * @property {Object} _metadata Metadata about the pagination settings
+ * @property {number} _metadata.offset Offset of records in subsequent queries
+ * @property {number} _metadata.totalRecords Total number of files found
+ * @property {File[]} records
  */
 
 /**
@@ -120,6 +129,38 @@ class Files {
     return this._request
       .get(`${this._baseUrl}/files/${fileId}`)
       .then((file) => toCamelCase(file));
+  }
+
+  /**
+   * Gets a paginated list of files and their metadata. This does not return
+   * the actual files.
+   *
+   * API Endpoint: '/files'
+   * Method: GET
+   *
+   * @param {Object} [filesFilters]
+   * @param {Number} [filesFilters.limit = 100] Maximum number of records to return per query
+   * @param {Number} [filesFilters.offset = 0] How many records from the first record to start the query
+   * @param {String} [filesFilters.orderBy = 'createdAt'] How many records from the first record to start the query
+   * @param {Boolean} [filesFilters.reverseOrder = false] Determine the results should be sorted in reverse (ascending) order
+   * @param {String} [filesFilters.status = 'ACTIVE'] Filter by a file's current status
+   *
+   * @returns {Promise}
+   * @fulfill {FilesFromServer} Information about the files
+   * @reject {Error}
+   *
+   * @example
+   * contxtSdk.files
+   *   .getAll()
+   *   .then((files) => console.log(files))
+   *   .catch((err) => console.log(err));
+   */
+  getAll(filesFilters) {
+    return this._request
+      .get(`${this._baseUrl}/files`, {
+        params: toSnakeCase(filesFilters)
+      })
+      .then((assetsData) => formatPaginatedDataFromServer(assetsData));
   }
 }
 

--- a/src/files/index.js
+++ b/src/files/index.js
@@ -38,6 +38,31 @@ class Files {
   }
 
   /**
+   * Deletes a file and associated file actions.
+   *
+   * API Endpoint: '/files/:fileId'
+   * Method: DELETE
+   *
+   * @param {string} fileId The ID of the file
+   *
+   * @returns {Promise}
+   * @fulfill {undefined}
+   * @reject {Error}
+   *
+   * @example
+   * contxtSdk.files.delete('8704f900-28f2-4951-aaf0-1827fcd0b0cb');
+   */
+  delete(fileId) {
+    if (!fileId) {
+      return Promise.reject(
+        new Error('A file ID is required to delete a file')
+      );
+    }
+
+    return this._request.delete(`${this._baseUrl}/files/${fileId}`);
+  }
+
+  /**
    * Gets a temporary URL for the file.
    *
    * API Endpoint: '/files/:fileId/download'

--- a/src/files/index.spec.js
+++ b/src/files/index.spec.js
@@ -52,6 +52,51 @@ describe('Files', function() {
     });
   });
 
+  describe('delete', function() {
+    context('the file ID is provided', function() {
+      let expectedFile;
+      let promise;
+      let request;
+
+      beforeEach(function() {
+        expectedFile = fixture.build('file');
+
+        request = {
+          ...baseRequest,
+          delete: this.sandbox.stub().resolves()
+        };
+
+        const files = new Files(baseSdk, request);
+        files._baseUrl = expectedHost;
+
+        promise = files.delete(expectedFile.id);
+      });
+
+      it('deletes the file from the server', function() {
+        return promise.then(() => {
+          expect(request.delete).to.be.calledWith(
+            `${expectedHost}/files/${expectedFile.id}`
+          );
+        });
+      });
+
+      it('returns a fulfilled promise', function() {
+        return expect(promise).to.be.fulfilled;
+      });
+    });
+
+    context('the file ID is not provided', function() {
+      it('returns a rejected promise with an error', function() {
+        const files = new Files(baseSdk, baseRequest);
+        const promise = files.delete();
+
+        return expect(promise).to.be.rejectedWith(
+          'A file ID is required to delete a file'
+        );
+      });
+    });
+  });
+
   describe('download', function() {
     context('the file ID is provided', function() {
       let fileFromServerAfterFormat;


### PR DESCRIPTION
## Why?
We need to be able to delete a file and get a list of many files.

## What changed?
- Added Files#delete to delete a file on the Files API
- Added Files#getAll to get a paginated list of files on the Files API