### PR TITLE
Refactor onmessage and onerror handling for message bus web socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [v0.0.41](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.41) (2019-02-26)
+## [v0.0.41](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.41) (2019-02-27)
 
 **Added**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [v0.0.41](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.41) (2019-02-27)
+## [v0.0.41](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.41) (2019-03-01)
 
 **Added**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [v0.0.41](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.41) (2019-02-26)
+
+**Added**
+
+- Added `WebSocketConnection#onMessage` for handling all messages recieved by the WebSocket
+- Added `WebSocketConnection#onError` for handling all WebSocket errors
+
+**Changed**
+
+- Updated `onmessage` handling for the `WebSocketConnection`
+  - Multiple messages can be sent to the Message Bus and an `onmessage` handler is created for each message sent
+  - When a response comes back for a sent message, the response is sent back to the user and the `onmessage` handler is torn down
+
 ## [v0.0.40](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.40) (2019-02-18)
 
 **Added**

--- a/docs/README.md
+++ b/docs/README.md
@@ -211,5 +211,11 @@ the optional methods are documented below.</p>
 <dt><a href="./Typedefs.md#WebSocketConnection">WebSocketConnection</a> : <code>Object</code></dt>
 <dd><p>A wrapper around the raw WebSocket to provide a finite set of operations</p>
 </dd>
+<dt><a href="./Typedefs.md#WebSocketError">WebSocketError</a> : <code>Object</code></dt>
+<dd><p>The WebSocket Error Event</p>
+</dd>
+<dt><a href="./Typedefs.md#WebSocketMessage">WebSocketMessage</a> : <code>Object</code></dt>
+<dd><p>The WebSocket Message Event</p>
+</dd>
 </dl>
 

--- a/docs/Typedefs.md
+++ b/docs/Typedefs.md
@@ -831,3 +831,31 @@ contxtSdk.bus.connect('4f0e51c6-728b-4892-9863-6d002e61204d')
     })
 });
 ```
+<a name="WebSocketError"></a>
+
+## WebSocketError : <code>Object</code>
+The WebSocket Error Event
+
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| type | <code>string</code> | The event type |
+
+<a name="WebSocketMessage"></a>
+
+## WebSocketMessage : <code>Object</code>
+The WebSocket Message Event
+
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| data | <code>Object</code> | The data sent by the message emitter |
+| origin | <code>string</code> | A USVString representing the origin of the message emitter |
+| lastEventId | <code>string</code> | A DOMString representing a unique ID for the event |
+| source | <code>Object</code> | A MessageEventSource (which can be a WindowProxy, MessagePort, or ServiceWorker object) representing the message emitter |
+| ports | <code>Array</code> | MessagePort objects representing the ports associated with the channel the message is being sent through (where appropriate, e.g. in channel messaging or when sending a message to a shared worker) |
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -9487,6 +9487,11 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+    },
     "validate-npm-package-license": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "change-case": "^3.0.2",
     "lodash.has": "^4.5.2",
     "lodash.isplainobject": "^4.0.6",
-    "url-parse": "^1.4.3"
+    "url-parse": "^1.4.3",
+    "uuid": "^3.3.2"
   },
   "devDependencies": {
     "auth0-js": "^9.3.0",

--- a/src/bus/webSocketConnection.js
+++ b/src/bus/webSocketConnection.js
@@ -134,7 +134,7 @@ class WebSocketConnection {
   /**
    * Handles messages sent from the Message Bus WebSocket connection.
    *
-   * @param {WebSocketMessge} message The message event recieved over the WebSocket connection
+   * @param {WebSocketMessage} message The message event recieved over the WebSocket connection
    *
    * @private
    */

--- a/src/bus/webSocketConnection.js
+++ b/src/bus/webSocketConnection.js
@@ -104,7 +104,6 @@ class WebSocketConnection {
    * Handles WebSocket errors.
    * The `ws` library also closes the socket when an error occurs.
    * Since the socket connection closes, the jsonRpcId and message handlers are cleared
-   *
    */
   onError = (error) => {
     this._jsonRpcId = null;
@@ -115,7 +114,6 @@ class WebSocketConnection {
 
   /**
    * Handles messages sent from the Message Bus WebSocket connection.
-   *
    */
   onMessage = (message) => {
     let messageData;

--- a/src/bus/webSocketConnection.js
+++ b/src/bus/webSocketConnection.js
@@ -1,6 +1,24 @@
 import uuid from 'uuid/v4';
 
 /**
+ * The WebSocket Error Event
+ *
+ * @typedef {Object} WebSocketError
+ * @property {string} type The event type
+ */
+
+/**
+ * The WebSocket Message Event
+ *
+ * @typedef {Object} WebSocketMessage
+ * @property {Object} data The data sent by the message emitter
+ * @property {string} origin A USVString representing the origin of the message emitter
+ * @property {string} lastEventId A DOMString representing a unique ID for the event
+ * @property {Object} source A MessageEventSource (which can be a WindowProxy, MessagePort, or ServiceWorker object) representing the message emitter
+ * @property {Array} ports  MessagePort objects representing the ports associated with the channel the message is being sent through (where appropriate, e.g. in channel messaging or when sending a message to a shared worker)
+ */
+
+/**
  * Module that wraps the websocket connection to the message bus
  * to provide the developer with a specific set of functionality
  *
@@ -16,8 +34,8 @@ class WebSocketConnection {
     this._webSocket = webSocket;
 
     if (this._webSocket) {
-      this._webSocket.onmessage = this.onMessage;
-      this._webSocket.onerror = this.onError;
+      this._webSocket.onerror = this._onError;
+      this._webSocket.onmessage = this._onMessage;
     }
   }
 
@@ -102,17 +120,25 @@ class WebSocketConnection {
    * Handles WebSocket errors.
    * The `ws` library also closes the socket when an error occurs.
    * Since the socket connection closes, the jsonRpcId and message handlers are cleared
+   *
+   * @param {WebSocketError} error The error event thrown
+   *
+   * @private
    */
-  onError = (error) => {
+  _onError = (error) => {
     this._messageHandlers = {};
 
-    console.log(error);
+    console.log('Message Bus WebSocket Error: ', error);
   };
 
   /**
    * Handles messages sent from the Message Bus WebSocket connection.
+   *
+   * @param {WebSocketMessge} message The message event recieved over the WebSocket connection
+   *
+   * @private
    */
-  onMessage = (message) => {
+  _onMessage = (message) => {
     let messageData;
 
     try {

--- a/src/bus/webSocketConnection.js
+++ b/src/bus/webSocketConnection.js
@@ -11,7 +11,6 @@ class WebSocketConnection {
    * @param {string} organizationId UUID corresponding with an organization
    */
   constructor(webSocket, organizationId) {
-    this._jsonRpcId = null;
     this._messageHandlers = {};
     this._organizationId = organizationId;
     this._webSocket = webSocket;
@@ -56,8 +55,7 @@ class WebSocketConnection {
         return reject(new Error('WebSocket connection not open'));
       }
 
-      this._jsonRpcId = uuid();
-      const messageId = this._jsonRpcId;
+      const messageId = uuid();
 
       this._messageHandlers[messageId] = (message) => {
         const error = message.error;
@@ -106,10 +104,9 @@ class WebSocketConnection {
    * Since the socket connection closes, the jsonRpcId and message handlers are cleared
    */
   onError = (error) => {
-    this._jsonRpcId = null;
     this._messageHandlers = {};
 
-    throw new Error(error);
+    console.log(error);
   };
 
   /**
@@ -175,8 +172,7 @@ class WebSocketConnection {
         return reject(new Error('WebSocket connection not open'));
       }
 
-      this._jsonRpcId = uuid();
-      const messageId = this._jsonRpcId;
+      const messageId = uuid();
 
       this._messageHandlers[messageId] = (message) => {
         const error = message.error;

--- a/src/bus/webSocketConnection.spec.js
+++ b/src/bus/webSocketConnection.spec.js
@@ -65,7 +65,7 @@ describe('Bus/WebSocketConnection', function() {
 
           promise = ws.authorize(token);
 
-          jsonRpcId = ws._jsonRpcId;
+          jsonRpcId = Object.keys(ws._messageHandlers)[0];
 
           expectedJsonRpc = JSON.stringify({
             jsonrpc: '2.0',
@@ -122,7 +122,7 @@ describe('Bus/WebSocketConnection', function() {
 
           promise = ws.authorize(token);
 
-          jsonRpcId = ws._jsonRpcId;
+          jsonRpcId = Object.keys(ws._messageHandlers)[0];
 
           expectedMessage = {
             jsonrpc: '2.0',
@@ -336,24 +336,9 @@ describe('Bus/WebSocketConnection', function() {
 
       ws = new WebSocketConnection(expectedWebSocket, expectedOrganization.id);
 
-      ws._jsonRpcId = faker.random.uuid();
       ws._messageHandlers = {
         [faker.random.uuid()]: this.sandbox.stub()
       };
-    });
-
-    it('throws an error', function() {
-      expect(function() {
-        ws.onError(expectedError);
-      }).to.throw(expectedError);
-    });
-
-    it('resets the jsonRpcId', function() {
-      try {
-        ws.onError(expectedError);
-      } catch (err) {
-        expect(ws._jsonRpcId).to.be.null;
-      }
     });
 
     it('resets the messageHandlers', function() {
@@ -502,7 +487,7 @@ describe('Bus/WebSocketConnection', function() {
 
           promise = ws.publish(serviceId, channel, message);
 
-          jsonRpcId = ws._jsonRpcId;
+          jsonRpcId = Object.keys(ws._messageHandlers)[0];
 
           expectedJsonRpc = JSON.stringify({
             jsonrpc: '2.0',
@@ -563,7 +548,7 @@ describe('Bus/WebSocketConnection', function() {
 
           promise = ws.publish(serviceId, channel, message);
 
-          jsonRpcId = ws._jsonRpcId;
+          jsonRpcId = Object.keys(ws._messageHandlers)[0];
 
           expectedMessage = {
             jsonrpc: '2.0',
@@ -676,7 +661,7 @@ describe('Bus/WebSocketConnection', function() {
 
         promise = ws.publish(serviceId, channel, message);
 
-        jsonRpcId = ws._jsonRpcId;
+        jsonRpcId = Object.keys(ws._messageHandlers)[0];
       });
 
       it('does not send a message to the message bus', function() {
@@ -726,7 +711,7 @@ describe('Bus/WebSocketConnection', function() {
 
         expectedWebSocket.onclose = () => {
           promise = ws.publish(serviceId, channel, message);
-          jsonRpcId = ws._jsonRpcId;
+          jsonRpcId = Object.keys(ws._messageHandlers)[0];
           done();
         };
       });
@@ -776,7 +761,7 @@ describe('Bus/WebSocketConnection', function() {
 
         promise = ws.publish(serviceId, channel, message);
 
-        jsonRpcId = ws._jsonRpcId;
+        jsonRpcId = Object.keys(ws._messageHandlers)[0];
       });
 
       it('does not send a message to the message bus', function() {
@@ -824,7 +809,7 @@ describe('Bus/WebSocketConnection', function() {
 
         promise = ws.publish(serviceId, channel, message);
 
-        jsonRpcId = ws._jsonRpcId;
+        jsonRpcId = Object.keys(ws._messageHandlers)[0];
       });
 
       it('does not send a message to the message bus', function() {
@@ -870,7 +855,7 @@ describe('Bus/WebSocketConnection', function() {
 
         promise = ws.publish(serviceId, channel, message);
 
-        jsonRpcId = ws._jsonRpcId;
+        jsonRpcId = Object.keys(ws._messageHandlers)[0];
       });
 
       it('does not send a message to the message bus', function() {


### PR DESCRIPTION
## Why?
The onmessage and onerror handlers were not robust enough to handle multiple messages coming in at the same time. 

## What changed?
* Each message that the SDK sends to the message bus gets its own onmessage handler. 
* The handler is removed after the message is processed.
* Tests updated.