### PR TITLE
Files#createAndUpload and underlying methods

### DIFF
--- a/docs/Files.md
+++ b/docs/Files.md
@@ -12,6 +12,7 @@ Module that provides access to information about Files
     * [.download(fileId)](#Files+download) ⇒ <code>Promise</code>
     * [.get(fileId)](#Files+get) ⇒ <code>Promise</code>
     * [.getAll([filesFilters])](#Files+getAll) ⇒ <code>Promise</code>
+    * [.upload(fileInfo)](#Files+upload) ⇒ <code>Promise</code>
 
 <a name="new_Files_new"></a>
 
@@ -148,5 +149,42 @@ Method: GET
 contxtSdk.files
   .getAll()
   .then((files) => console.log(files))
+  .catch((err) => console.log(err));
+```
+<a name="Files+upload"></a>
+
+### contxtSdk.files.upload(fileInfo) ⇒ <code>Promise</code>
+Uploads a file to the provided URL. The URL and the headers should be
+sourced from the response when initially creating a File record.
+
+Method: PUT
+
+**Kind**: instance method of [<code>Files</code>](#Files)  
+**Fulfill**: <code>Object</code>  
+**Reject**: <code>Error</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| fileInfo | <code>Object</code> |  |
+| fileInfo.data | <code>ArrayBuffer</code> \| <code>Blob</code> \| <code>Buffer</code> \| [<code>File</code>](./Typedefs.md#File) \| <code>Stream</code> | The data to be   uploaded |
+| [fileInfo.headers] | <code>Object.&lt;string, string&gt;</code> | Headers to be appended   to the request. The key is the header name and the value is the included   value |
+| fileInfo.url | <code>String</code> | The URL to use for the request |
+
+**Example**  
+```js
+contxtSdk.files
+  .upload({
+    data: fs.readFileSync(
+      path.join(
+        __dirname,
+        'hawkins_national_labratory-hawkins_energy-october-2019.pdf'
+      )
+    ),
+    headers: {
+      'Content-Type': 'application/pdf'
+    },
+    url:
+      'https://files.ndustrial.example.org/hawkins_national_labratory-hawkins_energy-october-2019.pdf'
+  })
   .catch((err) => console.log(err));
 ```

--- a/docs/Files.md
+++ b/docs/Files.md
@@ -12,6 +12,8 @@ Module that provides access to information about Files
     * [.download(fileId)](#Files+download) ⇒ <code>Promise</code>
     * [.get(fileId)](#Files+get) ⇒ <code>Promise</code>
     * [.getAll([filesFilters])](#Files+getAll) ⇒ <code>Promise</code>
+    * [.setUploadComplete(fileId)](#Files+setUploadComplete) ⇒ <code>Promise</code>
+    * [.setUploadFailed(fileId)](#Files+setUploadFailed) ⇒ <code>Promise</code>
     * [.upload(fileInfo)](#Files+upload) ⇒ <code>Promise</code>
 
 <a name="new_Files_new"></a>
@@ -149,6 +151,50 @@ Method: GET
 contxtSdk.files
   .getAll()
   .then((files) => console.log(files))
+  .catch((err) => console.log(err));
+```
+<a name="Files+setUploadComplete"></a>
+
+### contxtSdk.files.setUploadComplete(fileId) ⇒ <code>Promise</code>
+Updates the upload status of a file to indicate the upload is complete.
+
+API Endpoint: '/files/:fileId/complete'
+Method: POST
+
+**Kind**: instance method of [<code>Files</code>](#Files)  
+**Fulfill**: <code>undefined</code>  
+**Rejects**: <code>Error</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| fileId | <code>string</code> | The ID of the file to update |
+
+**Example**  
+```js
+contxtSdk.files
+  .setUploadComplete('ecd0439e-d5be-4529-ad6a-4a9cbfa7202f')
+  .catch((err) => console.log(err));
+```
+<a name="Files+setUploadFailed"></a>
+
+### contxtSdk.files.setUploadFailed(fileId) ⇒ <code>Promise</code>
+Updates the upload status of a file to indicate the upload has failed.
+
+API Endpoint: '/files/:fileId/failed'
+Method: POST
+
+**Kind**: instance method of [<code>Files</code>](#Files)  
+**Fulfill**: <code>undefined</code>  
+**Rejects**: <code>Error</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| fileId | <code>string</code> | The ID of the file to update |
+
+**Example**  
+```js
+contxtSdk.files
+  .setUploadFailed('ecd0439e-d5be-4529-ad6a-4a9cbfa7202f')
   .catch((err) => console.log(err));
 ```
 <a name="Files+upload"></a>

--- a/docs/Files.md
+++ b/docs/Files.md
@@ -7,6 +7,7 @@ Module that provides access to information about Files
 
 * [Files](#Files)
     * [new Files(sdk, request)](#new_Files_new)
+    * [.create(fileInfo)](#Files+create) ⇒ <code>Promise</code>
     * [.delete(fileId)](#Files+delete) ⇒ <code>Promise</code>
     * [.download(fileId)](#Files+download) ⇒ <code>Promise</code>
     * [.get(fileId)](#Files+get) ⇒ <code>Promise</code>
@@ -21,6 +22,39 @@ Module that provides access to information about Files
 | sdk | <code>Object</code> | An instance of the SDK so the module can communicate with other modules |
 | request | <code>Object</code> | An instance of the request module tied to this module's audience. |
 
+<a name="Files+create"></a>
+
+### contxtSdk.files.create(fileInfo) ⇒ <code>Promise</code>
+Creates a file record.
+
+API Endpoint: '/files'
+Method: POST
+
+**Kind**: instance method of [<code>Files</code>](#Files)  
+**Fulfill**: [<code>File</code>](./Typedefs.md#File)  
+**Rejects**: <code>Error</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| fileInfo | <code>Object</code> | Metadata about the file |
+| fileInfo.contentType | <code>string</code> | The MIME type |
+| [fileInfo.description] | <code>string</code> | A short description |
+| fileInfo.filename | <code>string</code> | The filename |
+| fileInfo.organizationId | <code>string</code> | The organization ID to which the   file belongs |
+
+**Example**  
+```js
+contxtSdk.files
+  .create({
+    contentType: 'application/pdf',
+    description:
+      'Electric Bill from Hawkins National Labratory (October 2018)',
+    filename: 'hawkins_national_labratory-hawkins_energy-october-2019.pdf',
+    organizationId: '8ba33864-01ff-4388-a4e0-63eebf36fed3'
+  })
+  .then((file) => console.log(file))
+  .catch((err) => console.log(err));
+```
 <a name="Files+delete"></a>
 
 ### contxtSdk.files.delete(fileId) ⇒ <code>Promise</code>

--- a/docs/Files.md
+++ b/docs/Files.md
@@ -8,6 +8,7 @@ Module that provides access to information about Files
 * [Files](#Files)
     * [new Files(sdk, request)](#new_Files_new)
     * [.create(fileInfo)](#Files+create) ⇒ <code>Promise</code>
+    * [.createAndUpload(fileInfo)](#Files+createAndUpload) ⇒ <code>Promise</code>
     * [.delete(fileId)](#Files+delete) ⇒ <code>Promise</code>
     * [.download(fileId)](#Files+download) ⇒ <code>Promise</code>
     * [.get(fileId)](#Files+get) ⇒ <code>Promise</code>
@@ -54,6 +55,54 @@ contxtSdk.files
       'Electric Bill from Hawkins National Labratory (October 2018)',
     filename: 'hawkins_national_labratory-hawkins_energy-october-2019.pdf',
     organizationId: '8ba33864-01ff-4388-a4e0-63eebf36fed3'
+  })
+  .then((file) => console.log(file))
+  .catch((err) => console.log(err));
+```
+<a name="Files+createAndUpload"></a>
+
+### contxtSdk.files.createAndUpload(fileInfo) ⇒ <code>Promise</code>
+A procedural method that takes care of:
+  1. Creating a file record
+  2. Uploading the file from information returned when creating the file
+    record
+  3. Updating the file record's status to indicate if the upload was
+    successful or a failure
+  4. Returning an updated copy of the file record OR an error indicating
+    what failed, when it failed, and potentially, why it failed
+
+**Kind**: instance method of [<code>Files</code>](#Files)  
+**Fulfill**: [<code>File</code>](./Typedefs.md#File)  
+**Rejects**: [<code>FileError</code>](./Typedefs.md#FileError)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| fileInfo | <code>Object</code> |  |
+| fileInfo.data | <code>ArrayBuffer</code> \| <code>Blob</code> \| <code>Buffer</code> \| [<code>File</code>](./Typedefs.md#File) \| <code>Stream</code> | The actual data of the file. |
+| fileInfo.metadata | <code>Object</code> | Metadata about the file to be uploaded |
+| fileInfo.metadata.contentType | <code>string</code> | The MIME type |
+| [fileInfo.metadata.description] | <code>string</code> | A short description |
+| fileInfo.metadata.filename | <code>string</code> | The filename |
+| fileInfo.metadata.organizationId | <code>string</code> | The organization ID to which the file belongs |
+
+**Example**  
+```js
+contxtSdk
+  .createAndUpload({
+    data: fs.readFileSync(
+      path.join(
+        __dirname,
+        'hawkins_national_labratory-hawkins_energy-october-2019.pdf'
+      )
+    ),
+    metadata: {
+      contentType: 'application/pdf',
+      description:
+        'Electric Bill from Hawkins National Labratory (October 2018)',
+      filename:
+        'hawkins_national_labratory-hawkins_energy-october-2019.pdf',
+      organizationId: '8ba33864-01ff-4388-a4e0-63eebf36fed3'
+    }
   })
   .then((file) => console.log(file))
   .catch((err) => console.log(err));

--- a/docs/README.md
+++ b/docs/README.md
@@ -181,6 +181,10 @@ for authenticating and communicating with an individual API and the external mod
 <dd></dd>
 <dt><a href="./Typedefs.md#File">File</a> : <code>Object</code></dt>
 <dd></dd>
+<dt><a href="./Typedefs.md#FileError">FileError</a> : <code>Error</code></dt>
+<dd><p>An error returned while creating and uploading an
+  individual file</p>
+</dd>
 <dt><a href="./Typedefs.md#FileToDownload">FileToDownload</a> : <code>Object</code></dt>
 <dd></dd>
 <dt><a href="./Typedefs.md#FileWithUploadInformation">FileWithUploadInformation</a> : <code>Object</code></dt>

--- a/docs/README.md
+++ b/docs/README.md
@@ -183,6 +183,8 @@ for authenticating and communicating with an individual API and the external mod
 <dd></dd>
 <dt><a href="./Typedefs.md#FileToDownload">FileToDownload</a> : <code>Object</code></dt>
 <dd></dd>
+<dt><a href="./Typedefs.md#FileWithUploadInformation">FileWithUploadInformation</a> : <code>Object</code></dt>
+<dd></dd>
 <dt><a href="./Typedefs.md#FilesFromServer">FilesFromServer</a> : <code>Object</code></dt>
 <dd></dd>
 <dt><a href="./Typedefs.md#MachineAuthSessionInfo">MachineAuthSessionInfo</a> : <code>Object</code></dt>

--- a/docs/Typedefs.md
+++ b/docs/Typedefs.md
@@ -574,6 +574,29 @@ for authenticating and communicating with an individual API and the external mod
 | expiresAt | <code>string</code> | ISO 8601 Extended Format date/time |
 | temporaryUrl | <code>string</code> | A temporary URL that can be used to download the file |
 
+<a name="FileWithUploadInformation"></a>
+
+## FileWithUploadInformation : <code>Object</code>
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| createdAt | <code>string</code> | ISO 8601 Extended Format date/time string |
+| contentType | <code>string</code> | The MIME type of the file |
+| description | <code>string</code> |  |
+| filename | <code>string</code> |  |
+| id | <code>string</code> | UUID of the file |
+| organizationId | <code>string</code> | UUID of the organization to which the file   belongs |
+| ownerId | <code>string</code> | The ID of the user who owns the file |
+| status | <code>string</code> | The status of the File, e.g. "ACTIVE" |
+| updatedAt | <code>string</code> | ISO 8601 Extended Format date/time string |
+| uploadInfo | <code>Object</code> | Information related to the uploading the   underlying file |
+| uploadInfo.expiresAt | <code>string</code> | A ISO 8601 Extended format date/time   string indicating when the validity of the included URL expires |
+| uploadInfo.headers | <code>Object.&lt;string, string&gt;</code> | to be appended to the   request when uploading the file. The key is the header name and the value   is the included value. |
+| uploadInfo.method | <code>string</code> | The HTTP method to be used when   uploading the file. |
+| uploadInfo.url | <code>string</code> | The URL to be used when uploading the file. |
+
 <a name="FilesFromServer"></a>
 
 ## FilesFromServer : <code>Object</code>

--- a/docs/Typedefs.md
+++ b/docs/Typedefs.md
@@ -563,6 +563,22 @@ for authenticating and communicating with an individual API and the external mod
 | status | <code>string</code> | The status of the File, e.g. "ACTIVE" |
 | updatedAt | <code>string</code> | ISO 8601 Extended Format date/time string |
 
+<a name="FileError"></a>
+
+## FileError : <code>Error</code>
+An error returned while creating and uploading an
+  individual file
+
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| artifacts | <code>Object</code> | Records that may have been created while   creating and uploading a file. Can be used to pick up the process manually   or clean up before trying again. |
+| [artifacts.file] | <code>Object</code> | A created File artifact |
+| originalError | <code>Error</code> | The original error object that can be used   for additional debugging purposes |
+| stage | <code>string</code> | A string describing in what stage of the create and   upload process the failure occurred. Possible choices are:     - create (failed while creating the initial file record)     - upload (failed while uploading the actual file for storage)     - statusUpdate (failed while updating the upload status for the file record)     - get (failed at the end while getting an updated file record) |
+
 <a name="FileToDownload"></a>
 
 ## FileToDownload : <code>Object</code>

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "husky": "^0.14.3",
     "jsdoc-to-markdown": "^4.0.1",
     "lodash.omit": "^4.5.0",
+    "lodash.pick": "^4.4.0",
     "lodash.sortby": "^4.7.0",
     "lodash.times": "^4.3.2",
     "mocha": "^4.1.0",

--- a/src/files/index.js
+++ b/src/files/index.js
@@ -242,6 +242,60 @@ class Files {
   }
 
   /**
+   * Updates the upload status of a file to indicate the upload is complete.
+   *
+   * API Endpoint: '/files/:fileId/complete'
+   * Method: POST
+   *
+   * @param {string} fileId The ID of the file to update
+   *
+   * @returns {Promise}
+   * @fulfill {undefined}
+   * @rejects {Error}
+   *
+   * @example
+   * contxtSdk.files
+   *   .setUploadComplete('ecd0439e-d5be-4529-ad6a-4a9cbfa7202f')
+   *   .catch((err) => console.log(err));
+   */
+  setUploadComplete(fileId) {
+    if (!fileId) {
+      return Promise.reject(
+        new Error('A file ID is required to mark a file upload as complete')
+      );
+    }
+
+    return this._request.post(`${this._baseUrl}/files/${fileId}/complete`);
+  }
+
+  /**
+   * Updates the upload status of a file to indicate the upload has failed.
+   *
+   * API Endpoint: '/files/:fileId/failed'
+   * Method: POST
+   *
+   * @param {string} fileId The ID of the file to update
+   *
+   * @returns {Promise}
+   * @fulfill {undefined}
+   * @rejects {Error}
+   *
+   * @example
+   * contxtSdk.files
+   *   .setUploadFailed('ecd0439e-d5be-4529-ad6a-4a9cbfa7202f')
+   *   .catch((err) => console.log(err));
+   */
+  setUploadFailed(fileId) {
+    if (!fileId) {
+      return Promise.reject(
+        new Error('A file ID is required to mark a file upload as failed')
+      );
+    }
+
+    return this._request.post(`${this._baseUrl}/files/${fileId}/failed`);
+  }
+
+  /**
    * Uploads a file to the provided URL. The URL and the headers should be
    * sourced from the response when initially creating a File record.
    *

--- a/src/files/index.js
+++ b/src/files/index.js
@@ -1,3 +1,4 @@
+import axios from 'axios';
 import { toCamelCase, toSnakeCase } from '../utils/objects';
 import { formatPaginatedDataFromServer } from '../utils/pagination';
 
@@ -238,6 +239,57 @@ class Files {
         params: toSnakeCase(filesFilters)
       })
       .then((assetsData) => formatPaginatedDataFromServer(assetsData));
+  }
+
+  /**
+   * Uploads a file to the provided URL. The URL and the headers should be
+   * sourced from the response when initially creating a File record.
+   *
+   * Method: PUT
+   *
+   * @param {Object} fileInfo
+   * @param {ArrayBuffer|Blob|Buffer|File|Stream} fileInfo.data The data to be
+   *   uploaded
+   * @param {Object.<string, string>} [fileInfo.headers] Headers to be appended
+   *   to the request. The key is the header name and the value is the included
+   *   value
+   * @param {String} fileInfo.url The URL to use for the request
+   *
+   * @returns {Promise}
+   * @fulfill {Object}
+   * @reject {Error}
+   *
+   * @example
+   * contxtSdk.files
+   *   .upload({
+   *     data: fs.readFileSync(
+   *       path.join(
+   *         __dirname,
+   *         'hawkins_national_labratory-hawkins_energy-october-2019.pdf'
+   *       )
+   *     ),
+   *     headers: {
+   *       'Content-Type': 'application/pdf'
+   *     },
+   *     url:
+   *       'https://files.ndustrial.example.org/hawkins_national_labratory-hawkins_energy-october-2019.pdf'
+   *   })
+   *   .catch((err) => console.log(err));
+   */
+  upload(fileInfo) {
+    const requiredFields = ['data', 'url'];
+
+    for (let i = 0; i < requiredFields.length; i++) {
+      if (!fileInfo[requiredFields[i]]) {
+        return Promise.reject(
+          new Error(`A ${requiredFields[i]} is required to upload a file`)
+        );
+      }
+    }
+
+    const { data, headers, url } = fileInfo;
+
+    return axios.put(url, data, { headers });
   }
 }
 

--- a/src/files/index.spec.js
+++ b/src/files/index.spec.js
@@ -466,6 +466,159 @@ describe('Files', function() {
     });
   });
 
+  describe('setUploadComplete', function() {
+    context('when successfully marking the upload as complete', function() {
+      let createdFileId;
+      let promise;
+
+      beforeEach(function() {
+        createdFileId = fixture.build('file').id;
+
+        const files = new Files(baseSdk, baseRequest);
+        files._baseUrl = expectedHost;
+
+        promise = files.setUploadComplete(createdFileId);
+      });
+
+      it('sets the upload as complete', function() {
+        return promise.then(() => {
+          expect(baseRequest.post).to.be.calledWith(
+            `${expectedHost}/files/${createdFileId}/complete`
+          );
+        });
+      });
+
+      it('returns a fulfilled promise', function() {
+        return expect(promise).to.be.fulfilled;
+      });
+    });
+
+    context(
+      'when theres is a failure while marking the upload as complete',
+      function() {
+        let expectedError;
+        let promise;
+
+        beforeEach(function() {
+          const createdFileId = fixture.build('file').id;
+          expectedError = new Error();
+
+          const request = {
+            ...baseRequest,
+            post: this.sandbox.stub().rejects(expectedError)
+          };
+
+          const files = new Files(baseSdk, request);
+          files._baseUrl = expectedHost;
+
+          promise = files.setUploadComplete(createdFileId);
+        });
+
+        it('returns a rejected promise', function() {
+          return expect(promise).to.be.rejectedWith(expectedError);
+        });
+      }
+    );
+
+    context('when there is no provided file ID', function() {
+      let promise;
+
+      beforeEach(function() {
+        const files = new Files(baseSdk, baseRequest);
+        files._baseUrl = expectedHost;
+
+        promise = files.setUploadComplete();
+      });
+
+      it('does not set the upload as complete', function() {
+        return promise.then(expect.fail).catch(() => {
+          expect(baseRequest.post).to.not.be.called;
+        });
+      });
+
+      it('returns a rejected promise', function() {
+        return expect(promise).to.be.rejectedWith(
+          'A file ID is required to mark a file upload as complete'
+        );
+      });
+    });
+  });
+
+  describe('setUploadFailed', function() {
+    context('when successfully marking the upload as failed', function() {
+      let expectedFileId;
+      let promise;
+
+      beforeEach(function() {
+        expectedFileId = fixture.build('file').id;
+
+        const files = new Files(baseSdk, baseRequest);
+        files._baseUrl = expectedHost;
+
+        promise = files.setUploadFailed(expectedFileId);
+      });
+
+      it('sets the upload as failed', function() {
+        return promise.then(() => {
+          expect(baseRequest.post).to.be.calledWith(
+            `${expectedHost}/files/${expectedFileId}/failed`
+          );
+        });
+      });
+
+      it('returns a fulfilled promise', function() {
+        return expect(promise).to.be.fulfilled;
+      });
+    });
+
+    context('when there is a failure marking the upload as failed', function() {
+      let expectedError;
+      let promise;
+
+      beforeEach(function() {
+        const createdFileId = fixture.build('file').id;
+        expectedError = new Error();
+
+        const request = {
+          ...baseRequest,
+          post: this.sandbox.stub().rejects(expectedError)
+        };
+
+        const files = new Files(baseSdk, request);
+        files._baseUrl = expectedHost;
+
+        promise = files.setUploadFailed(createdFileId);
+      });
+
+      it('returns a rejected promise', function() {
+        return expect(promise).to.be.rejectedWith(expectedError);
+      });
+    });
+
+    context('when there is no provided file ID', function() {
+      let promise;
+
+      beforeEach(function() {
+        const files = new Files(baseSdk, baseRequest);
+        files._baseUrl = expectedHost;
+
+        promise = files.setUploadFailed();
+      });
+
+      it('does not set the upload as complete', function() {
+        return promise.then(expect.fail).catch(() => {
+          expect(baseRequest.post).to.not.be.called;
+        });
+      });
+
+      it('returns a rejected promise', function() {
+        return expect(promise).to.be.rejectedWith(
+          'A file ID is required to mark a file upload as failed'
+        );
+      });
+    });
+  });
+
   describe('upload', function() {
     context('successfully uploading a file', function() {
       let fileData;

--- a/support/fixtures/factories/file.js
+++ b/support/fixtures/factories/file.js
@@ -16,6 +16,9 @@ factory
     status: () => faker.random.arrayElement(['ACTIVE', 'UPLOADING']),
     updatedAt: () => faker.date.recent().toISOString()
   })
+  .attr('uploadInfo', ['fromServer'], (fromServer, uploadInfo) => {
+    return factory.build('fileUploadInfo', null, { fromServer });
+  })
   .after((file, options) => {
     // If building a file object that comes from the server, transform it to have camel
     // case and capital letters in the right spots
@@ -31,5 +34,8 @@ factory
 
       file.updated_at = file.updatedAt;
       delete file.updatedAt;
+
+      file.upload_info = file.uploadInfo;
+      delete file.uploadInfo;
     }
   });

--- a/support/fixtures/factories/fileUploadInfo.js
+++ b/support/fixtures/factories/fileUploadInfo.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const factory = require('rosie').Factory;
+const faker = require('faker');
+const times = require('lodash.times');
+
+factory
+  .define('fileUploadInfo')
+  .option('fromServer', false)
+  .attrs({
+    headers: () =>
+      times(faker.random.number({ min: 1, max: 5 })).reduce((memo) => {
+        memo[faker.lorem.word()] = faker.hacker.phrase();
+
+        return memo;
+      }, {}),
+    expiresAt: () => faker.date.future().toISOString(),
+    method: 'PUT',
+    url: () => faker.internet.avatar()
+  })
+  .after((uploadInfo, options) => {
+    // If building a file object that comes from the server, transform it to have camel
+    // case and capital letters in the right spots
+    // NOTE: headers are not included here because they are case sensitive.
+    if (options.fromServer) {
+      uploadInfo.expires_at = uploadInfo.expiresAt;
+      delete uploadInfo.expiresAt;
+    }
+  });

--- a/support/fixtures/factories/index.js
+++ b/support/fixtures/factories/index.js
@@ -28,6 +28,7 @@ require('./fieldGrouping');
 require('./fieldGroupingField');
 require('./file');
 require('./fileToDownload');
+require('./fileUploadInfo');
 require('./outputField');
 require('./outputFieldData');
 require('./organization');


### PR DESCRIPTION
## Why?
We already had the ability to delete, download, and get file records, but we needed the ability to create new records -- and to actually upload the files to the external service!

## What changed?
- Added Files#create
  - Creates a File record on our API
- Added Files#upload
  - Takes information (that is provided when creating a File record) and the file data to upload the data to an external service (in this case, S3)
- Added Files#setUploadComplete and Files#setUploadFailed
  - Update the File record's status to indicate the file has been uploaded
- Added Files#createAndUpload
  - This procedural method uses all of the above methods to make things easy for the end user. Pass in the metadata about the file and the actual file data and it will make the right calls to get things created and uploaded
  - This is the recommended way to interact with the Files API when doing these types of interactions

## What's to come?
We need some more documentation around how this all works -- both here and readme.io. A general overview and some recommendations are expected. We currently have the individual methods documented well, but need to include info about what order they should be used in and in what situations to use a particular method.