### PR TITLE
Switch from using `uuid/v4` package to `nanoid` package in `WebSocket` module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
   - `Files#setUploadFailed` for updating a File's upload status to indicate the upload failed
   - `Files#upload` for uploading a File to the external service used for storing files
 
+**Fixed**
+
+- There was an issue with requiring v0.0.41 in a browser related to the `uuid` package we were using in the WebSocket module. It's been switched out with `nanoid`.
+
 ## [v0.0.41](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.41) (2019-03-01)
 
 **Added**

--- a/package-lock.json
+++ b/package-lock.json
@@ -5306,6 +5306,11 @@
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
+    "nanoid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.0.1.tgz",
+      "integrity": "sha512-k1u2uemjIGsn25zmujKnotgniC/gxQ9sdegdezeDiKdkDW56THUMqlz3urndKCXJxA6yPzSZbXx/QCMe/pxqsA=="
+    },
     "nanomatch": {
       "version": "1.2.9",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
@@ -9486,11 +9491,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
-    },
-    "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "validate-npm-package-license": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "change-case": "^3.0.2",
     "lodash.has": "^4.5.2",
     "lodash.isplainobject": "^4.0.6",
-    "url-parse": "^1.4.3",
-    "uuid": "^3.3.2"
+    "nanoid": "^2.0.1",
+    "url-parse": "^1.4.3"
   },
   "devDependencies": {
     "auth0-js": "^9.3.0",

--- a/src/bus/webSocketConnection.js
+++ b/src/bus/webSocketConnection.js
@@ -1,4 +1,4 @@
-import uuid from 'uuid/v4';
+import nanoid from 'nanoid/non-secure';
 
 /**
  * The WebSocket Error Event
@@ -73,7 +73,7 @@ class WebSocketConnection {
         return reject(new Error('WebSocket connection not open'));
       }
 
-      const messageId = uuid();
+      const messageId = nanoid();
 
       this._messageHandlers[messageId] = (message) => {
         const error = message.error;
@@ -198,7 +198,7 @@ class WebSocketConnection {
         return reject(new Error('WebSocket connection not open'));
       }
 
-      const messageId = uuid();
+      const messageId = nanoid();
 
       this._messageHandlers[messageId] = (message) => {
         const error = message.error;


### PR DESCRIPTION
## Why?
1. `uuid` leans on the Node `crypto` built-in package when requiring the regular CommonJS version of the library and the browers's `crypto.getRandomValues` method when requiring the browser version of the library (via their `package.json`'s `browser` attribute).
1. Our build process does not build separate files for a browser/Webpack setup and does not distinguish between the two versions, which led to a file being built that works in Node, but not when built for a browser/Webpack

## What changed?
- Switched out the `uuid/v4` method for the `nanoid/non-secure` ([nanoid](https://github.com/ai/nanoid))
  - `nanoid/non-secure` generates an ID with a similar collision probability to a UUIDv4, but with a slight predictability. The ID is only used as an internal identifier, so it should not be an issue in this case