### PR TITLE
Add Coordinator#getAllApplications

### DIFF
--- a/docs/Coordinator.md
+++ b/docs/Coordinator.md
@@ -11,6 +11,7 @@ Module that provides access to information about Contxt
     * [.getOrganizationById(organizationId)](#Coordinator+getOrganizationById) ⇒ <code>Promise</code>
     * [.getUser(userId)](#Coordinator+getUser) ⇒ <code>Promise</code>
     * [.getUserPermissionsMap(userId)](#Coordinator+getUserPermissionsMap) ⇒ <code>Promise</code>
+    * [.getAllApplications()](#Coordinator+getAllApplications) ⇒ <code>Promise</code>
 
 <a name="new_Coordinator_new"></a>
 
@@ -109,5 +110,23 @@ Method: GET
 contxtSdk.coordinator
   .getUserPermissionsMap('auth0|12345')
   .then((permissionsMap) => console.log(permissionsMap))
+  .catch((err) => console.log(err));
+```
+<a name="Coordinator+getAllApplications"></a>
+
+### contxtSdk.coordinator.getAllApplications() ⇒ <code>Promise</code>
+Gets information about all contxt applications
+
+API Endpoint: '/applications'
+Method: GET
+
+**Kind**: instance method of [<code>Coordinator</code>](#Coordinator)  
+**Fulfill**: <code>ContxtApplication[]</code> Information about all contxt applications  
+**Reject**: <code>Error</code>  
+**Example**  
+```js
+contxtSdk.coordinator
+  .getAllApplications()
+  .then((apps) => console.log(apps))
   .catch((err) => console.log(err));
 ```

--- a/docs/Coordinator.md
+++ b/docs/Coordinator.md
@@ -7,11 +7,11 @@ Module that provides access to information about Contxt
 
 * [Coordinator](#Coordinator)
     * [new Coordinator(sdk, request)](#new_Coordinator_new)
+    * [.getAllApplications()](#Coordinator+getAllApplications) ⇒ <code>Promise</code>
     * [.getAllOrganizations()](#Coordinator+getAllOrganizations) ⇒ <code>Promise</code>
     * [.getOrganizationById(organizationId)](#Coordinator+getOrganizationById) ⇒ <code>Promise</code>
     * [.getUser(userId)](#Coordinator+getUser) ⇒ <code>Promise</code>
     * [.getUserPermissionsMap(userId)](#Coordinator+getUserPermissionsMap) ⇒ <code>Promise</code>
-    * [.getAllApplications()](#Coordinator+getAllApplications) ⇒ <code>Promise</code>
 
 <a name="new_Coordinator_new"></a>
 
@@ -22,6 +22,24 @@ Module that provides access to information about Contxt
 | sdk | <code>Object</code> | An instance of the SDK so the module can communicate with other modules |
 | request | <code>Object</code> | An instance of the request module tied to this module's audience. |
 
+<a name="Coordinator+getAllApplications"></a>
+
+### contxtSdk.coordinator.getAllApplications() ⇒ <code>Promise</code>
+Gets information about all contxt applications
+
+API Endpoint: '/applications'
+Method: GET
+
+**Kind**: instance method of [<code>Coordinator</code>](#Coordinator)  
+**Fulfill**: <code>ContxtApplication[]</code> Information about all contxt applications  
+**Reject**: <code>Error</code>  
+**Example**  
+```js
+contxtSdk.coordinator
+  .getAllApplications()
+  .then((apps) => console.log(apps))
+  .catch((err) => console.log(err));
+```
 <a name="Coordinator+getAllOrganizations"></a>
 
 ### contxtSdk.coordinator.getAllOrganizations() ⇒ <code>Promise</code>
@@ -110,23 +128,5 @@ Method: GET
 contxtSdk.coordinator
   .getUserPermissionsMap('auth0|12345')
   .then((permissionsMap) => console.log(permissionsMap))
-  .catch((err) => console.log(err));
-```
-<a name="Coordinator+getAllApplications"></a>
-
-### contxtSdk.coordinator.getAllApplications() ⇒ <code>Promise</code>
-Gets information about all contxt applications
-
-API Endpoint: '/applications'
-Method: GET
-
-**Kind**: instance method of [<code>Coordinator</code>](#Coordinator)  
-**Fulfill**: <code>ContxtApplication[]</code> Information about all contxt applications  
-**Reject**: <code>Error</code>  
-**Example**  
-```js
-contxtSdk.coordinator
-  .getAllApplications()
-  .then((apps) => console.log(apps))
   .catch((err) => console.log(err));
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -138,6 +138,8 @@ to provide the developer with a specific set of functionality</p>
 <dd><p>An object of interceptors that get called on every request or response.
 More information at <a href="https://github.com/axios/axios#interceptors">axios Interceptors</a></p>
 </dd>
+<dt><a href="./Typedefs.md#ContxtApplication">ContxtApplication</a> : <code>Object</code></dt>
+<dd></dd>
 <dt><a href="./Typedefs.md#ContxtOrganization">ContxtOrganization</a> : <code>Object</code></dt>
 <dd></dd>
 <dt><a href="./Typedefs.md#ContxtUser">ContxtUser</a> : <code>Object</code></dt>

--- a/docs/Typedefs.md
+++ b/docs/Typedefs.md
@@ -218,6 +218,26 @@ More information at [axios Interceptors](https://github.com/axios/axios#intercep
 | interceptor.fulfilled | <code>function</code> | A function that is run on every successful request or   response |
 | interceptor.rejected | <code>function</code> | A function that is run on every failed request or response |
 
+<a name="ContxtApplication"></a>
+
+## ContxtApplication : <code>Object</code>
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| clientId | <code>string</code> |  |
+| clientSecret | <code>string</code> |  |
+| createdAt | <code>string</code> | ISO 8601 Extended Format date/time string |
+| currentVersionId | <code>string</code> |  |
+| description | <code>string</code> |  |
+| iconUrl | <code>string</code> |  |
+| id | <code>number</code> |  |
+| name | <code>string</code> |  |
+| serviceId | <code>number</code> |  |
+| type | <code>string</code> |  |
+| updatedAt | <code>string</code> | ISO 8601 Extended Format date/time string |
+
 <a name="ContxtOrganization"></a>
 
 ## ContxtOrganization : <code>Object</code>

--- a/src/coordinator/index.js
+++ b/src/coordinator/index.js
@@ -24,6 +24,21 @@ import { toCamelCase } from '../utils/objects';
  */
 
 /**
+ * @typedef {Object} ContxtApplication
+ * @property {string} clientId
+ * @property {string} clientSecret
+ * @property {string} createdAt ISO 8601 Extended Format date/time string
+ * @property {string} currentVersionId
+ * @property {string} description
+ * @property {string} iconUrl
+ * @property {number} id
+ * @property {string} name
+ * @property {number} serviceId
+ * @property {string} type
+ * @property {string} updatedAt ISO 8601 Extended Format date/time string
+ */
+
+/**
  * Module that provides access to information about Contxt
  *
  * @typicalname contxtSdk.coordinator
@@ -160,6 +175,28 @@ class Coordinator {
     // NOTE: This response is not run through the `toCamelCase` method because
     // it could errantly remove underscores from service IDs.
     return this._request.get(`${this._baseUrl}/users/${userId}/permissions`);
+  }
+
+  /**
+   * Gets information about all contxt applications
+   *
+   * API Endpoint: '/applications'
+   * Method: GET
+   *
+   * @returns {Promise}
+   * @fulfill {ContxtApplication[]} Information about all contxt applications
+   * @reject {Error}
+   *
+   * @example
+   * contxtSdk.coordinator
+   *   .getAllApplications()
+   *   .then((apps) => console.log(apps))
+   *   .catch((err) => console.log(err));
+   */
+  getAllApplications() {
+    return this._request
+      .get(`${this._baseUrl}/applications`)
+      .then((apps) => apps.map((app) => toCamelCase(app)));
   }
 }
 

--- a/src/coordinator/index.js
+++ b/src/coordinator/index.js
@@ -59,6 +59,28 @@ class Coordinator {
   }
 
   /**
+   * Gets information about all contxt applications
+   *
+   * API Endpoint: '/applications'
+   * Method: GET
+   *
+   * @returns {Promise}
+   * @fulfill {ContxtApplication[]} Information about all contxt applications
+   * @reject {Error}
+   *
+   * @example
+   * contxtSdk.coordinator
+   *   .getAllApplications()
+   *   .then((apps) => console.log(apps))
+   *   .catch((err) => console.log(err));
+   */
+  getAllApplications() {
+    return this._request
+      .get(`${this._baseUrl}/applications`)
+      .then((apps) => apps.map((app) => toCamelCase(app)));
+  }
+
+  /**
    * Gets information about all contxt organizations
    *
    * API Endpoint: '/organizations'
@@ -175,28 +197,6 @@ class Coordinator {
     // NOTE: This response is not run through the `toCamelCase` method because
     // it could errantly remove underscores from service IDs.
     return this._request.get(`${this._baseUrl}/users/${userId}/permissions`);
-  }
-
-  /**
-   * Gets information about all contxt applications
-   *
-   * API Endpoint: '/applications'
-   * Method: GET
-   *
-   * @returns {Promise}
-   * @fulfill {ContxtApplication[]} Information about all contxt applications
-   * @reject {Error}
-   *
-   * @example
-   * contxtSdk.coordinator
-   *   .getAllApplications()
-   *   .then((apps) => console.log(apps))
-   *   .catch((err) => console.log(err));
-   */
-  getAllApplications() {
-    return this._request
-      .get(`${this._baseUrl}/applications`)
-      .then((apps) => apps.map((app) => toCamelCase(app)));
   }
 }
 

--- a/src/coordinator/index.spec.js
+++ b/src/coordinator/index.spec.js
@@ -295,4 +295,59 @@ describe('Coordinator', function() {
       });
     });
   });
+
+  describe('getAllApplications', function() {
+    let expectedApplications;
+    let applicationsFromServer;
+    let promise;
+    let request;
+    let toCamelCase;
+
+    beforeEach(function() {
+      const numberOfApplications = faker.random.number({
+        min: 1,
+        max: 10
+      });
+      expectedApplications = fixture.buildList(
+        'contxtApplication',
+        numberOfApplications
+      );
+      applicationsFromServer = expectedApplications.map((app) =>
+        fixture.build('contxtApplication', app, { fromServer: true })
+      );
+
+      request = {
+        ...baseRequest,
+        get: this.sandbox.stub().resolves(applicationsFromServer)
+      };
+      toCamelCase = this.sandbox
+        .stub(objectUtils, 'toCamelCase')
+        .callsFake((app) =>
+          expectedApplications.find(({ id }) => id === app.id)
+        );
+
+      const coordinator = new Coordinator(baseSdk, request);
+      coordinator._baseUrl = expectedHost;
+      promise = coordinator.getAllApplications();
+    });
+
+    it('gets the list of applications from the server', function() {
+      expect(request.get).to.be.calledWith(`${expectedHost}/applications`);
+    });
+
+    it('formats the list of applications', function() {
+      return promise.then(() => {
+        expect(toCamelCase).to.have.callCount(applicationsFromServer.length);
+        applicationsFromServer.forEach((app) => {
+          expect(toCamelCase).to.be.calledWith(app);
+        });
+      });
+    });
+
+    it('returns a fulfilled promise with the applications', function() {
+      return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
+        expectedApplications
+      );
+    });
+  });
 });

--- a/support/fixtures/factories/contxtApplication.js
+++ b/support/fixtures/factories/contxtApplication.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const factory = require('rosie').Factory;
+const faker = require('faker');
+
+factory
+  .define('contxtApplication')
+  .option('fromServer', false)
+  .attrs({
+    clientId: () => faker.random.uuid(),
+    clientSecret: () => faker.random.uuid(),
+    createdAt: () => faker.date.past().toISOString(),
+    currentVersionId: () => faker.random.uuid(),
+    description: () => faker.random.words(),
+    iconUrl: () => faker.image.imageUrl(),
+    id: () => faker.random.number(),
+    name: () => faker.name.title(),
+    serviceId: () => faker.random.number(),
+    type: () => faker.random.word(),
+    updatedAt: () => faker.date.recent().toISOString()
+  })
+  .after((org, options) => {
+    // If building an application object that comes from the server, transform it to have camel
+    // case and capital letters in the right spots
+    if (options.fromServer) {
+      org.client_id = org.clientId;
+      delete org.clientId;
+
+      org.client_secret = org.clientSecret;
+      delete org.clientSecret;
+
+      org.created_at = org.createdAt;
+      delete org.createdAt;
+
+      org.current_version_id = org.currentVersionId;
+      delete org.currentVersionId;
+
+      org.icon_url = org.iconUrl;
+      delete org.iconUrl;
+
+      org.service_id = org.serviceId;
+      delete org.serviceId;
+
+      org.updated_at = org.updatedAt;
+      delete org.updatedAt;
+    }
+  });

--- a/support/fixtures/factories/index.js
+++ b/support/fixtures/factories/index.js
@@ -10,6 +10,7 @@ require('./assetMetricValue');
 require('./assetType');
 require('./audience');
 require('./channel');
+require('./contxtApplication');
 require('./contxtOrganization');
 require('./contxtUser');
 require('./costCenter');


### PR DESCRIPTION
## Why?
To add the applications endpoint to the Contxt SDK to be used in contxt dashboard.

## What changed?
- Added Coordinator.getAllApplications()
- Added ContxtApplication test fixture
- Updated docs and tests