### PR TITLE
Bug Fix: Update client ID for Message Bus environment to fix log in loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [v0.0.46](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.46) (2019-04-01)
+
+**Fixed**
+
+- Fixed the client ID used for seeking authorization with the message bus in staging environments.
+
 ## [v0.0.45](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.45) (2019-03-25)
 
 **Added**

--- a/src/config/audiences.js
+++ b/src/config/audiences.js
@@ -6,7 +6,7 @@ export default {
       webSocket: 'wss://bus.ndustrial.io'
     },
     staging: {
-      clientId: 'WLlg0VHqGneLuPNMFKCoJDjUlhocDFEF',
+      clientId: '1HD1NG1VTBtkqRt2HRRj3E3hdmqmwzoz',
       host: 'https://bus-staging.ndustrial.io',
       webSocket: 'wss://bus-staging.ndustrial.io'
     }

--- a/src/utils/objects/map.js
+++ b/src/utils/objects/map.js
@@ -6,7 +6,7 @@ import isPlainObject from 'lodash.isplainobject';
  * @param {Object} input The object to map over
  * @param {Function} callback The function invoked per iteration
  * @param {Object} [userOptions]
- * @param {Boolean} [userOptions.deep = true] Boolean indicating if only the first
+ * @param {Boolean} [userOptions.deep = false] Boolean indicating if only the first
  *   level should be mapped or if it should recursively map over nested
  *   objects/arrays
  *


### PR DESCRIPTION
## Why?
We were seeing a log in loop when attempting to use newer versions of the SDK because we had the wrong client ID for the message bus staging environment in our configuration.

## What changed?
- Update client ID for message bus staging environment
- Fix a default value in the object mapping private function documentation
