### PR TITLE
In beta/v1, auth0-js, axios, and ws are no longer peer dependencies and are regular dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,6 @@ The `contxt-sdk` can be installed with NPM:
 npm install --save @ndustrial/contxt-sdk
 ```
 
-There are three peer dependencies for `contxt-sdk`: `auth0-js`, `axios`, and `ws`. If you don't already have a compatible version installed, run:
-
-```bash
-npm install --save auth0-js@^9.0.0 axios@~0.17.0 ws@~6.1.3
-```
-
 ## Getting Started
 
 Once installed, the minimum configuration you need to get going is to include the `clientId` of your application (from Auth0) and a string with the type of authentication you want to use (`auth0WebAuth` or `machineAuth`).


### PR DESCRIPTION
## Why?

No longer need the peer dependency language in the `README.md` for the `beta/v1` version

## What changed?
- Removed peer dependency language in `README.md`
- Reference: https://github.com/ndustrialio/contxt-sdk-js/commit/df4202d43c72e0208aab8e02e1be14ad95c07b12#diff-b9cfc7f2cdf78a7f4b91a753d10865a2

### NOTE: merging this into the `betas/v1` branch since these packages are still considered peer dependencies in v0.0.x