### PR TITLE
MOB-2540: Feature/add-remove-roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ coordinator.removeUserFromOrganization() -> coordinator.users.remove()
 **Added**
 
 - Added `Permissions#getByOrganizationId` for fetching all user permissions for an entire organization.
+- Added `Users#addRole` for adding a role to a user
+- Added `Users#removeRole` for removing a role from a user
 
 ## [v0.0.50](http://github.com/ndustrialio/contxt-sdk-js/tree/v0.0.50) (2019-05-14)
 

--- a/docs/Permissions.md
+++ b/docs/Permissions.md
@@ -23,7 +23,7 @@ Module that provides access to contxt user permissions
 <a name="Permissions+getByOrganizationId"></a>
 
 ### contxtSdk.coordinator.permissions.getByOrganizationId(organizationId) ⇒ <code>Promise</code>
-Gets a list of user permissions for an entire organization
+Gets a list of user permissions for each user in an organization
 
 API Endpoint: '/organizations/:organizationId/users/permissions'
 Method: GET

--- a/docs/README.md
+++ b/docs/README.md
@@ -183,6 +183,8 @@ More information at <a href="https://github.com/axios/axios#interceptors">axios 
 <dd></dd>
 <dt><a href="./Typedefs.md#ContxtUserPermissions">ContxtUserPermissions</a> : <code>Object</code></dt>
 <dd></dd>
+<dt><a href="./Typedefs.md#ContxtUserRole">ContxtUserRole</a> : <code>Object</code></dt>
+<dd></dd>
 <dt><a href="./Typedefs.md#CostCenter">CostCenter</a> : <code>Object</code></dt>
 <dd></dd>
 <dt><a href="./Typedefs.md#CostCenterFacility">CostCenterFacility</a> : <code>Object</code></dt>

--- a/docs/Typedefs.md
+++ b/docs/Typedefs.md
@@ -351,6 +351,21 @@ More information at [axios Interceptors](https://github.com/axios/axios#intercep
 | stacksImplicit | <code>Array.&lt;number&gt;</code> | Stack ids the user has access to from a role or being the owner |
 | userId | <code>string</code> |  |
 
+<a name="ContxtUserRole"></a>
+
+## ContxtUserRole : <code>Object</code>
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| createdAt | <code>string</code> | ISO 8601 Extended Format date/time string |
+| id | <code>string</code> |  |
+| mappedFromExternalGroup | <code>boolean</code> |  |
+| userId | <code>string</code> |  |
+| roleId | <code>string</code> |  |
+| updatedAt | <code>string</code> | ISO 8601 Extended Format date/time string |
+
 <a name="CostCenter"></a>
 
 ## CostCenter : <code>Object</code>

--- a/docs/Users.md
+++ b/docs/Users.md
@@ -13,6 +13,7 @@ Module that provides access to contxt users
     * [.getByOrganizationId(organizationId)](#Users+getByOrganizationId) ⇒ <code>Promise</code>
     * [.invite(organizationId, user)](#Users+invite) ⇒ <code>Promise</code>
     * [.remove(organizationId, userId)](#Users+remove) ⇒ <code>Promise</code>
+    * [.removeRole(userId, roleId)](#Users+removeRole) ⇒ <code>Promise</code>
 
 <a name="new_Users_new"></a>
 
@@ -184,5 +185,28 @@ Method: DELETE
 ```js
 contxtSdk.coordinator.users
   .remove('ed2e8e24-79ef-4404-bf5f-995ef31b2298', '4a577e87-7437-4342-b183-00c18ec26d52')
+  .catch((err) => console.log(err));
+```
+<a name="Users+removeRole"></a>
+
+### contxtSdk.coordinator.users.removeRole(userId, roleId) ⇒ <code>Promise</code>
+Removes a role from a user
+
+API Endpoint: '/users/:userId/roles/:roleId'
+Method: DELETE
+
+**Kind**: instance method of [<code>Users</code>](#Users)  
+**Fulfill**: <code>undefined</code>  
+**Reject**: <code>Error</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| userId | <code>string</code> | The ID of the user |
+| roleId | <code>string</code> | The ID of the role |
+
+**Example**  
+```js
+contxtSdk.coordinator.users
+  .removeRole('36b8421a-cc4a-4204-b839-1397374fb16b', '007ca9ee-ece7-4931-9d11-9b4fd97d4d58')
   .catch((err) => console.log(err));
 ```

--- a/docs/Users.md
+++ b/docs/Users.md
@@ -8,6 +8,7 @@ Module that provides access to contxt users
 * [Users](#Users)
     * [new Users(sdk, request, baseUrl)](#new_Users_new)
     * [.activate(userId, user)](#Users+activate) ⇒ <code>Promise</code>
+    * [.addRole(userId, roleId)](#Users+addRole) ⇒ <code>Promise</code>
     * [.get(userId)](#Users+get) ⇒ <code>Promise</code>
     * [.getByOrganizationId(organizationId)](#Users+getByOrganizationId) ⇒ <code>Promise</code>
     * [.invite(organizationId, user)](#Users+invite) ⇒ <code>Promise</code>
@@ -54,6 +55,30 @@ contxtSdk.coordinator.users
     userToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c'
   })
   .then(() => console.log("User Activated"))
+  .catch((err) => console.log(err));
+```
+<a name="Users+addRole"></a>
+
+### contxtSdk.coordinator.users.addRole(userId, roleId) ⇒ <code>Promise</code>
+Adds a role to a user
+
+API Endpoint: '/users/:userId/roles/:roleId'
+Method: GET
+
+**Kind**: instance method of [<code>Users</code>](#Users)  
+**Fulfill**: <code>ContxtUserRole[]</code> The newly created user role  
+**Reject**: <code>Error</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| userId | <code>string</code> | The ID of the user |
+| roleId | <code>string</code> | The ID of the role |
+
+**Example**  
+```js
+contxtSdk.coordinator.users
+  .addRole('36b8421a-cc4a-4204-b839-1397374fb16b', '007ca9ee-ece7-4931-9d11-9b4fd97d4d58')
+  .then((userRole) => console.log(userRole))
   .catch((err) => console.log(err));
 ```
 <a name="Users+get"></a>

--- a/docs/Users.md
+++ b/docs/Users.md
@@ -67,7 +67,7 @@ API Endpoint: '/users/:userId/roles/:roleId'
 Method: GET
 
 **Kind**: instance method of [<code>Users</code>](#Users)  
-**Fulfill**: <code>ContxtUserRole[]</code> The newly created user role  
+**Fulfill**: [<code>ContxtUserRole</code>](./Typedefs.md#ContxtUserRole) The newly created user role  
 **Reject**: <code>Error</code>  
 
 | Param | Type | Description |

--- a/src/coordinator/users.js
+++ b/src/coordinator/users.js
@@ -292,6 +292,42 @@ class Users {
       `${this._baseUrl}/organizations/${organizationId}/users/${userId}`
     );
   }
+
+  /**
+   * Removes a role from a user
+   *
+   * API Endpoint: '/users/:userId/roles/:roleId'
+   * Method: DELETE
+   *
+   * @param {string} userId The ID of the user
+   * @param {string} roleId The ID of the role
+   *
+   * @returns {Promise}
+   * @fulfill {undefined}
+   * @reject {Error}
+   *
+   * @example
+   * contxtSdk.coordinator.users
+   *   .removeRole('36b8421a-cc4a-4204-b839-1397374fb16b', '007ca9ee-ece7-4931-9d11-9b4fd97d4d58')
+   *   .catch((err) => console.log(err));
+   */
+  removeRole(userId, roleId) {
+    if (!userId) {
+      return Promise.reject(
+        new Error('A user ID is required for removing a role from a user')
+      );
+    }
+
+    if (!roleId) {
+      return Promise.reject(
+        new Error('A role ID is required for removing a role from a user')
+      );
+    }
+
+    return this._request.delete(
+      `${this._baseUrl}/users/${userId}/roles/${roleId}`
+    );
+  }
 }
 
 export default Users;

--- a/src/coordinator/users.js
+++ b/src/coordinator/users.js
@@ -103,7 +103,7 @@ class Users {
    * @param {string} roleId The ID of the role
    *
    * @returns {Promise}
-   * @fulfill {ContxtUserRole[]} The newly created user role
+   * @fulfill {ContxtUserRole} The newly created user role
    * @reject {Error}
    *
    * @example

--- a/src/coordinator/users.js
+++ b/src/coordinator/users.js
@@ -14,6 +14,16 @@ import { toCamelCase, toSnakeCase } from '../utils/objects';
  */
 
 /**
+ * @typedef {Object} ContxtUserRole
+ * @property {string} createdAt ISO 8601 Extended Format date/time string
+ * @property {string} id
+ * @property {boolean} mappedFromExternalGroup
+ * @property {string} userId
+ * @property {string} roleId
+ * @property {string} updatedAt ISO 8601 Extended Format date/time string
+ */
+
+/**
  * Module that provides access to contxt users
  *
  * @typicalname contxtSdk.coordinator.users
@@ -81,6 +91,43 @@ class Users {
       `${this._baseUrl}/users/${userId}/activate`,
       toSnakeCase(user)
     );
+  }
+
+  /**
+   * Adds a role to a user
+   *
+   * API Endpoint: '/users/:userId/roles/:roleId'
+   * Method: GET
+   *
+   * @param {string} userId The ID of the user
+   * @param {string} roleId The ID of the role
+   *
+   * @returns {Promise}
+   * @fulfill {ContxtUserRole[]} The newly created user role
+   * @reject {Error}
+   *
+   * @example
+   * contxtSdk.coordinator.users
+   *   .addRole('36b8421a-cc4a-4204-b839-1397374fb16b', '007ca9ee-ece7-4931-9d11-9b4fd97d4d58')
+   *   .then((userRole) => console.log(userRole))
+   *   .catch((err) => console.log(err));
+   */
+  addRole(userId, roleId) {
+    if (!userId) {
+      return Promise.reject(
+        new Error('A user ID is required for adding a role to a user')
+      );
+    }
+
+    if (!roleId) {
+      return Promise.reject(
+        new Error('A role ID is required for adding a role to a user')
+      );
+    }
+
+    return this._request
+      .post(`${this._baseUrl}/users/${userId}/roles/${roleId}`)
+      .then((response) => toCamelCase(response));
   }
 
   /**

--- a/src/coordinator/users.spec.js
+++ b/src/coordinator/users.spec.js
@@ -142,6 +142,81 @@ describe('Coordinator/Users', function() {
     });
   });
 
+  describe('addRole', function() {
+    context('when all the required parameters are provided', function() {
+      let expectedUserRole;
+      let promise;
+      let request;
+      let role;
+      let user;
+      let userRoleFromServer;
+      let toCamelCase;
+
+      beforeEach(function() {
+        role = fixture.build('contxtRole');
+        user = fixture.build('contxtUser');
+
+        expectedUserRole = fixture.build('contxtUserRole');
+        userRoleFromServer = fixture.build('contxtUserRole', expectedUserRole, {
+          fromServer: true
+        });
+
+        request = {
+          ...baseRequest,
+          post: this.sandbox.stub().resolves(userRoleFromServer)
+        };
+        toCamelCase = this.sandbox
+          .stub(objectUtils, 'toCamelCase')
+          .callsFake((app) => expectedUserRole);
+
+        const users = new Users(baseSdk, request, expectedHost);
+        promise = users.addRole(user.id, role.id);
+      });
+
+      it('posts the user role to the server', function() {
+        expect(request.post).to.be.calledWith(
+          `${expectedHost}/users/${user.id}/roles/${role.id}`
+        );
+      });
+
+      it('formats the returned user role', function() {
+        return promise.then(() => {
+          expect(toCamelCase).to.be.calledWith(userRoleFromServer);
+        });
+      });
+
+      it('returns a fulfilled promise', function() {
+        return expect(promise).to.be.fulfilled;
+      });
+    });
+
+    context('when the user ID is not provided', function() {
+      it('throws an error', function() {
+        const role = fixture.build('contxtRole');
+
+        const users = new Users(baseSdk, baseRequest, expectedHost);
+        const promise = users.addRole(null, role.id);
+
+        return expect(promise).to.be.rejectedWith(
+          'A user ID is required for adding a role to a user'
+        );
+      });
+    });
+
+    context('when the role ID is not provided', function() {
+      it('throws an error', function() {
+        const user = fixture.build('contxtUser');
+
+        const users = new Users(baseSdk, baseRequest, expectedHost);
+        const promise = users.addRole(user.id, null);
+
+        return expect(promise).to.be.rejectedWith(
+          'A role ID is required for adding a role to a user'
+        );
+      });
+    });
+  });
+
   describe('get', function() {
     context('the user ID is provided', function() {
       let userFromServerAfterFormat;

--- a/src/coordinator/users.spec.js
+++ b/src/coordinator/users.spec.js
@@ -505,4 +505,54 @@ describe('Coordinator/Users', function() {
       });
     });
   });
+
+  describe('removeRole', function() {
+    context('when all required parameters are provided', function() {
+      let role;
+      let user;
+      let promise;
+
+      beforeEach(function() {
+        role = fixture.build('contxtRole');
+        user = fixture.build('contxtUser');
+
+        const users = new Users(baseSdk, baseRequest, expectedHost);
+        promise = users.removeRole(user.id, role.id);
+      });
+
+      it('sends a request to removeRole the user from the organization', function() {
+        expect(baseRequest.delete).to.be.calledWith(
+          `${expectedHost}/users/${user.id}/roles/${role.id}`
+        );
+      });
+
+      it('returns a resolved promise', function() {
+        return expect(promise).to.be.fulfilled;
+      });
+    });
+
+    context('when the user ID is not provided', function() {
+      it('throws an error', function() {
+        const role = fixture.build('contxtRole');
+        const users = new Users(baseSdk, baseRequest, expectedHost);
+        const promise = users.removeRole(null, role.id);
+
+        return expect(promise).to.be.rejectedWith(
+          'A user ID is required for removing a role from a user'
+        );
+      });
+    });
+
+    context('when the role ID is not provided', function() {
+      it('throws an error', function() {
+        const user = fixture.build('contxtUser');
+        const users = new Users(baseSdk, baseRequest, expectedHost);
+        const promise = users.removeRole(user.id, null);
+
+        return expect(promise).to.be.rejectedWith(
+          'A role ID is required for removing a role from a user'
+        );
+      });
+    });
+  });
 });

--- a/support/fixtures/factories/contxtUserRole.js
+++ b/support/fixtures/factories/contxtUserRole.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const factory = require('rosie').Factory;
+const faker = require('faker');
+
+factory
+  .define('contxtUserRole')
+  .option('fromServer', false)
+  .attrs({
+    createdAt: () => faker.date.past().toISOString(),
+    id: () => faker.random.uuid(),
+    mappedFromExternalGroup: () => faker.random.boolean(),
+    roleId: () => factory.build('contxtRole').id,
+    updatedAt: () => faker.date.recent().toISOString(),
+    userId: () => factory.build('contxtUser').id
+  })
+  .after((userRole, options) => {
+    // If building a userRole object that comes from the server, transform it to have camel
+    // case and capital letters in the right spots
+    if (options.fromServer) {
+      userRole.created_at = userRole.createdAt;
+      delete userRole.createdAt;
+
+      userRole.mapped_from_external_group = userRole.mappedFromExternalGroup;
+      delete userRole.mappedFromExternalGroup;
+
+      userRole.role_id = userRole.roleId;
+      delete userRole.roleId;
+
+      userRole.updated_at = userRole.updatedAt;
+      delete userRole.updatedAt;
+
+      userRole.user_id = userRole.userId;
+      delete userRole.userId;
+    }
+  });

--- a/support/fixtures/factories/index.js
+++ b/support/fixtures/factories/index.js
@@ -18,6 +18,7 @@ require('./contxtStack');
 require('./contxtUser');
 require('./contxtUserFavoriteApplication');
 require('./contxtUserPermissions');
+require('./contxtUserRole');
 require('./costCenter');
 require('./costCenterFacility');
 require('./defaultAudiences');


### PR DESCRIPTION
### Why?
Contxt needs the ability to add and remove roles from a user. [MOB-2540](https://lineagelogistics.atlassian.net/browse/MOB-2540)

### What changed?
- Added `Users#addRole` for adding a role to a user: `POST /users/:user_id/roles/:role_id` 
- Added `Users#removeRole` for removing a role from a user: `DELETE /users/:user_id/roles/:role_id` 
