### PR TITLE
Fix: Exposes missing permissions module in coordinator

### DIFF
--- a/src/coordinator/index.js
+++ b/src/coordinator/index.js
@@ -1,7 +1,8 @@
 import Applications from './applications';
 import EdgeNodes from './edgeNodes';
-import Roles from './roles';
 import Organizations from './organizations';
+import Permissions from './permissions';
+import Roles from './roles';
 import Users from './users';
 
 /**
@@ -24,6 +25,7 @@ class Coordinator {
     this.applications = new Applications(sdk, request, baseUrl);
     this.edgeNodes = new EdgeNodes(sdk, request, baseUrl);
     this.organizations = new Organizations(sdk, request, baseUrl);
+    this.permissions = new Permissions(sdk, request, baseUrl);
     this.roles = new Roles(sdk, request, baseUrl);
     this.users = new Users(sdk, request, baseUrl);
   }

--- a/src/coordinator/index.spec.js
+++ b/src/coordinator/index.spec.js
@@ -1,8 +1,9 @@
-import Coordinator from './index';
 import Applications from './applications';
+import Coordinator from './index';
 import EdgeNodes from './edgeNodes';
-import Roles from './roles';
 import Organizations from './organizations';
+import Permissions from './permissions';
+import Roles from './roles';
 import Users from './users';
 
 describe('Coordinator', function() {
@@ -60,12 +61,16 @@ describe('Coordinator', function() {
       expect(coordinator.edgeNodes).to.be.an.instanceof(EdgeNodes);
     });
 
-    it('appends an instance of Roles to the class instance', function() {
-      expect(coordinator.roles).to.be.an.instanceof(Roles);
-    });
-
     it('appends an instance of Organizations to the class instance', function() {
       expect(coordinator.organizations).to.be.an.instanceof(Organizations);
+    });
+
+    it('appends an instance of Permissions to the class instance', function() {
+      expect(coordinator.permissions).to.be.an.instanceof(Permissions);
+    });
+
+    it('appends an instance of Roles to the class instance', function() {
+      expect(coordinator.roles).to.be.an.instanceof(Roles);
     });
 
     it('appends an instance of Users to the class instance', function() {


### PR DESCRIPTION
### What changed?
The permissions module wasn't correctly added to the coordinator module. 