### PR TITLE
Coordinator.applications#getGroupings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [v1.1.0](http://github.com/ndustrialio/contxt-sdk-js/tree/v1.1.0) (2019-05-29)
+
+**Added**
+
+- Added `Coordinator.applications#getGroupings` for getting all application groupings and modules for an application that a user has access to
+
 ## [v1.0.0](http://github.com/ndustrialio/contxt-sdk-js/tree/v1.0.0) (2019-05-28)
 
 **Changed**

--- a/docs/Applications.md
+++ b/docs/Applications.md
@@ -11,6 +11,7 @@ Module that provides access to contxt applications
     * [.getAll()](#Applications+getAll) ⇒ <code>Promise</code>
     * [.getFavorites()](#Applications+getFavorites) ⇒ <code>Promise</code>
     * [.getFeatured(organizationId)](#Applications+getFeatured) ⇒ <code>Promise</code>
+    * [.getGroupings(applicationId)](#Applications+getGroupings) ⇒ <code>Promise</code>
     * [.removeFavorite(applicationId)](#Applications+removeFavorite) ⇒ <code>Promise</code>
 
 <a name="new_Applications_new"></a>
@@ -109,6 +110,30 @@ Note: Only valid for web users using auth0WebAuth session type
 contxtSdk.coordinator.applications
   .getFeatured('36b8421a-cc4a-4204-b839-1397374fb16b')
   .then((featuredApplications) => console.log(featuredApplications))
+  .catch((err) => console.log(err));
+```
+<a name="Applications+getGroupings"></a>
+
+### contxtSdk.coordinator.applications.getGroupings(applicationId) ⇒ <code>Promise</code>
+Gets the application groupings (and application modules) of an application
+that are available to the currently authenticated user.
+
+API Endpoint: '/applications/:applicationId/groupings'
+Method: GET
+
+**Kind**: instance method of [<code>Applications</code>](#Applications)  
+**Fulfill**: <code>ContxtApplicationGrouping[]</code>  
+**Reject**: <code>Error</code>  
+
+| Param | Type |
+| --- | --- |
+| applicationId | <code>string</code> | 
+
+**Example**  
+```js
+contxtSdk.coordinator.applications
+  .getGroupings('31b52932-e25c-42d6-9c60-2f82d38d1e9c')
+  .then((applicationGroupings) => console.log(applicationGroupings))
   .catch((err) => console.log(err));
 ```
 <a name="Applications+removeFavorite"></a>

--- a/docs/Applications.md
+++ b/docs/Applications.md
@@ -127,12 +127,12 @@ Method: GET
 
 | Param | Type |
 | --- | --- |
-| applicationId | <code>string</code> | 
+| applicationId | <code>number</code> | 
 
 **Example**  
 ```js
 contxtSdk.coordinator.applications
-  .getGroupings('31b52932-e25c-42d6-9c60-2f82d38d1e9c')
+  .getGroupings(31)
   .then((applicationGroupings) => console.log(applicationGroupings))
   .catch((err) => console.log(err));
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -169,6 +169,10 @@ More information at <a href="https://github.com/axios/axios#interceptors">axios 
 </dd>
 <dt><a href="./Typedefs.md#ContxtApplication">ContxtApplication</a> : <code>Object</code></dt>
 <dd></dd>
+<dt><a href="./Typedefs.md#ContxtApplicationGrouping">ContxtApplicationGrouping</a> : <code>Object</code></dt>
+<dd></dd>
+<dt><a href="./Typedefs.md#ContxtApplicationModule">ContxtApplicationModule</a> : <code>Object</code></dt>
+<dd></dd>
 <dt><a href="./Typedefs.md#ContxtOrganization">ContxtOrganization</a> : <code>Object</code></dt>
 <dd></dd>
 <dt><a href="./Typedefs.md#ContxtOrganizationFeaturedApplication">ContxtOrganizationFeaturedApplication</a> : <code>Object</code></dt>
@@ -282,4 +286,3 @@ the optional methods are documented below.</p>
 <dd><p>The WebSocket Message Event</p>
 </dd>
 </dl>
-

--- a/docs/Typedefs.md
+++ b/docs/Typedefs.md
@@ -237,6 +237,36 @@ More information at [axios Interceptors](https://github.com/axios/axios#intercep
 | type | <code>string</code> |  |
 | updatedAt | <code>string</code> | ISO 8601 Extended Format date/time string |
 
+<a name="ContxtApplicationGrouping"></a>
+
+## ContxtApplicationGrouping : <code>Object</code>
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| applicationId | <code>string</code> |  |
+| applicationModules | [<code>Array.&lt;ContxtApplicationModule&gt;</code>](#ContxtApplicationModule) |  |
+| id | <code>string</code> |  |
+| index | <code>number</code> | The position of the grouping within the list of all   groupings of a the parent application |
+| label | <code>string</code> |  |
+
+<a name="ContxtApplicationModule"></a>
+
+## ContxtApplicationModule : <code>Object</code>
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| applicationGroupingId | <code>string</code> |  |
+| [externalLink] | <code>string</code> | A URI pointing to an external application |
+| [iconUrl] | <code>string</code> | A URI pointing to an icon/image representing the   application module |
+| id | <code>string</code> |  |
+| index | <code>number</code> | The position of the module within the list of all   modules of a the parent application grouping |
+| label | <code>string</code> |  |
+| slug | <code>string</code> |  |
+
 <a name="ContxtOrganization"></a>
 
 ## ContxtOrganization : <code>Object</code>

--- a/docs/Typedefs.md
+++ b/docs/Typedefs.md
@@ -245,7 +245,7 @@ More information at [axios Interceptors](https://github.com/axios/axios#intercep
 
 | Name | Type | Description |
 | --- | --- | --- |
-| applicationId | <code>string</code> |  |
+| applicationId | <code>number</code> |  |
 | applicationModules | [<code>Array.&lt;ContxtApplicationModule&gt;</code>](#ContxtApplicationModule) |  |
 | id | <code>string</code> |  |
 | index | <code>number</code> | The position of the grouping within the list of all   groupings of a the parent application |
@@ -265,7 +265,7 @@ More information at [axios Interceptors](https://github.com/axios/axios#intercep
 | id | <code>string</code> |  |
 | index | <code>number</code> | The position of the module within the list of all   modules of a the parent application grouping |
 | label | <code>string</code> |  |
-| slug | <code>string</code> |  |
+| slug | <code>string</code> | String that corresponds with a front-end package   name (e.g. the `@ndustrial/nsight-example` example application) |
 
 <a name="ContxtOrganization"></a>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7877,7 +7877,7 @@
         },
         "convert-source-map": {
           "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+          "resolved": false,
           "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
           "dev": true,
           "requires": {
@@ -7907,7 +7907,7 @@
         },
         "debug": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "resolved": false,
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
@@ -7916,7 +7916,7 @@
         },
         "execa": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
           "dev": true,
           "requires": {
@@ -7931,7 +7931,7 @@
         },
         "find-up": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
@@ -7946,7 +7946,7 @@
         },
         "get-stream": {
           "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "resolved": false,
           "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
           "dev": true,
           "requires": {
@@ -7975,7 +7975,7 @@
         },
         "invert-kv": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
           "dev": true
         },
@@ -8008,7 +8008,7 @@
         },
         "lcid": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
           "dev": true,
           "requires": {
@@ -8017,7 +8017,7 @@
         },
         "load-json-file": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
@@ -8029,7 +8029,7 @@
         },
         "locate-path": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "dev": true,
           "requires": {
@@ -8039,13 +8039,13 @@
         },
         "ms": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "resolved": false,
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
         },
         "os-locale": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+          "resolved": false,
           "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
           "dev": true,
           "requires": {
@@ -8065,7 +8065,7 @@
         },
         "p-locate": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "requires": {
@@ -8080,7 +8080,7 @@
         },
         "parse-json": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
@@ -8090,13 +8090,13 @@
         },
         "path-exists": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         },
         "path-type": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
@@ -8105,13 +8105,13 @@
         },
         "pify": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         },
         "pump": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
           "dev": true,
           "requires": {
@@ -8121,7 +8121,7 @@
         },
         "read-pkg": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
@@ -8132,7 +8132,7 @@
         },
         "read-pkg-up": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
           "dev": true,
           "requires": {
@@ -8148,7 +8148,7 @@
         },
         "resolve-from": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
           "dev": true
         },
@@ -8198,7 +8198,7 @@
         },
         "which-module": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
           "dev": true
         },
@@ -8215,7 +8215,7 @@
         },
         "y18n": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
           "dev": true
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -3905,9 +3905,9 @@
       }
     },
     "extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "extend-shallow": {
       "version": "3.0.2",

--- a/src/coordinator/applications.js
+++ b/src/coordinator/applications.js
@@ -17,7 +17,7 @@ import { toCamelCase } from '../utils/objects';
 
 /**
  * @typedef {Object} ContxtApplicationGrouping
- * @property {string} applicationId
+ * @property {number} applicationId
  * @property {ContxtApplicationModule[]} applicationModules
  * @property {string} id
  * @property {number} index The position of the grouping within the list of all
@@ -35,7 +35,8 @@ import { toCamelCase } from '../utils/objects';
  * @property {number} index The position of the module within the list of all
  *   modules of a the parent application grouping
  * @property {string} label
- * @property {string} slug
+ * @property {string} slug String that corresponds with a front-end package
+ *   name (e.g. the `@ndustrial/nsight-example` example application)
  */
 
 /**
@@ -196,7 +197,7 @@ class Applications {
    * API Endpoint: '/applications/:applicationId/groupings'
    * Method: GET
    *
-   * @param {string} applicationId
+   * @param {number} applicationId
    *
    * @returns {Promise}
    * @fulfill {ContxtApplicationGrouping[]}
@@ -204,7 +205,7 @@ class Applications {
    *
    * @example
    * contxtSdk.coordinator.applications
-   *   .getGroupings('31b52932-e25c-42d6-9c60-2f82d38d1e9c')
+   *   .getGroupings(31)
    *   .then((applicationGroupings) => console.log(applicationGroupings))
    *   .catch((err) => console.log(err));
    */

--- a/src/coordinator/applications.js
+++ b/src/coordinator/applications.js
@@ -16,6 +16,29 @@ import { toCamelCase } from '../utils/objects';
  */
 
 /**
+ * @typedef {Object} ContxtApplicationGrouping
+ * @property {string} applicationId
+ * @property {ContxtApplicationModule[]} applicationModules
+ * @property {string} id
+ * @property {number} index The position of the grouping within the list of all
+ *   groupings of a the parent application
+ * @property {string} label
+ */
+
+/**
+ * @typedef {Object} ContxtApplicationModule
+ * @property {string} applicationGroupingId
+ * @property {string} [externalLink] A URI pointing to an external application
+ * @property {string} [iconUrl] A URI pointing to an icon/image representing the
+ *   application module
+ * @property {string} id
+ * @property {number} index The position of the module within the list of all
+ *   modules of a the parent application grouping
+ * @property {string} label
+ * @property {string} slug
+ */
+
+/**
  * @typedef {Object} ContxtOrganizationFeaturedApplication
  * @property {number} applicationId
  * @property {string} createdAt ISO 8601 Extended Format date/time string
@@ -164,6 +187,31 @@ class Applications {
         `${this._baseUrl}/organizations/${organizationId}/applications/featured`
       )
       .then((featuredApplications) => toCamelCase(featuredApplications));
+  }
+
+  /**
+   * Gets the application groupings (and application modules) of an application
+   * that are available to the currently authenticated user.
+   *
+   * API Endpoint: '/applications/:applicationId/groupings'
+   * Method: GET
+   *
+   * @param {string} applicationId
+   *
+   * @returns {Promise}
+   * @fulfill {ContxtApplicationGrouping[]}
+   * @reject {Error}
+   *
+   * @example
+   * contxtSdk.coordinator.applications
+   *   .getGroupings('31b52932-e25c-42d6-9c60-2f82d38d1e9c')
+   *   .then((applicationGroupings) => console.log(applicationGroupings))
+   *   .catch((err) => console.log(err));
+   */
+  getGroupings(applicationId) {
+    return this._request
+      .get(`${this._baseUrl}/applications/${applicationId}/groupings`)
+      .then((groupings) => toCamelCase(groupings));
   }
 
   /**

--- a/src/coordinator/applications.spec.js
+++ b/src/coordinator/applications.spec.js
@@ -225,6 +225,55 @@ describe('Coordinator/Applications', function() {
     });
   });
 
+  describe('getGroupings', function() {
+    let expectedApplicationId;
+    let expectedGroupings;
+    let groupingsFromServer;
+    let promise;
+    let request;
+    let toCamelCase;
+
+    beforeEach(function() {
+      expectedApplicationId = faker.random.uuid();
+      expectedGroupings = fixture.buildList(
+        'applicationGrouping',
+        faker.random.number({ min: 1, max: 10 })
+      );
+      groupingsFromServer = expectedGroupings.map((grouping) =>
+        fixture.build('applicationGrouping', grouping, { fromServer: true })
+      );
+
+      request = {
+        ...baseRequest,
+        get: this.sandbox.stub().resolves(groupingsFromServer)
+      };
+      toCamelCase = this.sandbox
+        .stub(objectUtils, 'toCamelCase')
+        .returns(expectedGroupings);
+
+      const applications = new Applications(baseSdk, request, expectedHost);
+      promise = applications.getGroupings(expectedApplicationId);
+    });
+
+    it('gets the list of application groupings', function() {
+      expect(request.get).to.be.calledWith(
+        `${expectedHost}/applications/${expectedApplicationId}/groupings`
+      );
+    });
+
+    it('formats the list of application groupings', function() {
+      return promise.then(() => {
+        expect(toCamelCase).to.be.calledWith(groupingsFromServer);
+      });
+    });
+
+    it('returns a fulfilled promise with the application groupings', function() {
+      return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
+        expectedGroupings
+      );
+    });
+  });
+
   describe('getFeatured', function() {
     context('when the organization ID is provided', function() {
       let expectedFeaturedApplications;

--- a/support/fixtures/factories/applicationGrouping.js
+++ b/support/fixtures/factories/applicationGrouping.js
@@ -6,7 +6,7 @@ const faker = require('faker');
 factory
   .define('applicationGrouping')
   .attrs({
-    applicationId: () => faker.random.uuid(),
+    applicationId: () => faker.random.number(),
     id: () => faker.random.uuid(),
     index: () => faker.random.number(),
     label: () => faker.random.words()

--- a/support/fixtures/factories/applicationGrouping.js
+++ b/support/fixtures/factories/applicationGrouping.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const factory = require('rosie').Factory;
+const faker = require('faker');
+
+factory
+  .define('applicationGrouping')
+  .attrs({
+    applicationId: () => faker.random.uuid(),
+    id: () => faker.random.uuid(),
+    index: () => faker.random.number(),
+    label: () => faker.random.words()
+  })
+  .attr('applicationModules', ['id'], (id) => {
+    return factory.buildList(
+      'applicationModule',
+      faker.random.number({ min: 1, max: 10 }),
+      { applicationGroupingId: id }
+    );
+  })
+  .after((grouping, options) => {
+    // If building an application grouping object that comes from the server,
+    // transform it to have snake case and underscores in the right spots
+    if (options.fromServer) {
+      grouping.application_id = grouping.applicationId;
+      delete grouping.applicationId;
+
+      grouping.application_modules = grouping.applicationModules;
+      delete grouping.applicationModules;
+    }
+  });

--- a/support/fixtures/factories/applicationModule.js
+++ b/support/fixtures/factories/applicationModule.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const factory = require('rosie').Factory;
+const faker = require('faker');
+
+factory
+  .define('applicationModule')
+  .attrs({
+    applicationGroupingId: () => factory.build('applicationGrouping').id,
+    externalLink: () => faker.internet.url(),
+    iconUrl: () => faker.internet.url(),
+    id: () => faker.random.uuid(),
+    index: () => faker.random.number(),
+    label: () => faker.commerce.productName(),
+    slug: () => `nsight-${faker.internet.domainWord()}`
+  })
+  .after((module, options) => {
+    // If building an application module object that comes from the server,
+    // transform it to have snake case and underscores in the right spots
+    if (options.fromServer) {
+      module.application_grouping_id = module.applicationGroupingId;
+      delete module.applicationGroupingId;
+
+      module.external_link = module.externalLink;
+      delete module.externalLink;
+
+      module.icon_url = module.iconUrl;
+      delete module.iconUrl;
+    }
+  });

--- a/support/fixtures/factories/index.js
+++ b/support/fixtures/factories/index.js
@@ -1,51 +1,18 @@
 'use strict';
 
+const fs = require('fs');
+const path = require('path');
 const factory = require('rosie').Factory;
 
-require('./applicationGrouping');
-require('./applicationModule');
-require('./asset');
-require('./assetAttribute');
-require('./assetAttributeValue');
-require('./assetMetric');
-require('./assetMetricValue');
-require('./assetType');
-require('./audience');
-require('./channel');
-require('./contxtApplication');
-require('./contxtOrganization');
-require('./contxtOrganizationFeaturedApplication');
-require('./contxtRole');
-require('./contxtStack');
-require('./contxtUser');
-require('./contxtUserApplication');
-require('./contxtUserFavoriteApplication');
-require('./contxtUserPermissions');
-require('./contxtUserRole');
-require('./contxtUserStack');
-require('./costCenter');
-require('./costCenterFacility');
-require('./defaultAudiences');
-require('./edgeNode');
-require('./event');
-require('./eventType');
-require('./facility');
-require('./facilityGrouping');
-require('./facilityGroupingFacility');
-require('./facilityInfo');
-require('./facilityTag');
-require('./fieldCategory');
-require('./fieldGrouping');
-require('./fieldGroupingField');
-require('./file');
-require('./fileToDownload');
-require('./fileUploadInfo');
-require('./outputField');
-require('./outputFieldData');
-require('./organization');
-require('./owner');
-require('./paginationMetadata');
-require('./userPermissionsMap');
-require('./userProfile');
+const basename = path.basename(__filename);
+
+fs.readdirSync(__dirname)
+  .filter(
+    (filename) =>
+      filename.indexOf('.') !== 0 &&
+      filename !== basename &&
+      filename.slice(-3) === '.js'
+  )
+  .forEach((filename) => require(`./${filename}`));
 
 module.exports = factory;

--- a/support/fixtures/factories/index.js
+++ b/support/fixtures/factories/index.js
@@ -2,6 +2,8 @@
 
 const factory = require('rosie').Factory;
 
+require('./applicationGrouping');
+require('./applicationModule');
 require('./asset');
 require('./assetAttribute');
 require('./assetAttributeValue');


### PR DESCRIPTION
## Why?
Since we have created the new concept of application groupings and application modules, we need a way to retrieve them for use on front-ends

## What changed?
- Added Coordinator.applications#getGroupings method
- Updated sub-dependency to fix a vulnerability (https://nvd.nist.gov/vuln/detail/CVE-2018-16492)