### PR TITLE
Fix regression with alias in documentation for browser only modules

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -286,3 +286,4 @@ the optional methods are documented below.</p>
 <dd><p>The WebSocket Message Event</p>
 </dd>
 </dl>
+

--- a/src/bus/index.browser.js
+++ b/src/bus/index.browser.js
@@ -9,6 +9,8 @@ import Channels from './channels';
  */
 class Bus {
   /**
+   * @alias BrowserBus
+   *
    * @param {Object} sdk An instance of the SDK so the module can communicate with other modules
    * @param {Object} request An instance of the request module tied to this module's audience.
    */

--- a/src/bus/webSocketConnection.browser.js
+++ b/src/bus/webSocketConnection.browser.js
@@ -7,6 +7,9 @@
  * @alias BrowserWebSocketConnection
  */
 class WebSocketConnection {
+  /**
+   * @alias BrowserWebSocketConnection
+   */
   constructor(webSocket, organizationId) {
     throw new Error(
       'The Message Bus is not currently supported in browser environments'


### PR DESCRIPTION
## Why?
We recently upgraded to `jsdoc-to-markdown@5.0.0` which upgraded us to `jsdoc@3.6.2` which seems to have a regression/change in how it handles the `alias` annotation. This broke our documentation for the `Bus` module, which has separate modules for Node and the browser (it was replacing the Bus documentation with the documentation for BrowserBus and removing the BrowserBus documentation).

## What changed?
- Added a second instance of the alias annotation to the two Browser version modules
  - At least a temporary fix -- continues to build two separate files as expected