### PR TITLE
Adds Permissions#getOneByOrganizationId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [v1.2.0](http://github.com/ndustrialio/contxt-sdk-js/tree/v1.2.0) (2019-05-30)
+
+**Added**
+
+- Added `Coordinator.permissions#getOneByOrganizationId` for getting a single user's permissions within an organization
+
+**Changed**
+
+- Renamed `Coordinator.permissions#getByOrganizationId` to `Coordinator.permissions#getAllByOrganizationId` for getting every user's permissions within an organization.
+
 ## [v1.1.0](http://github.com/ndustrialio/contxt-sdk-js/tree/v1.1.0) (2019-05-29)
 
 **Added**

--- a/docs/Permissions.md
+++ b/docs/Permissions.md
@@ -7,7 +7,8 @@ Module that provides access to contxt user permissions
 
 * [Permissions](#Permissions)
     * [new Permissions(sdk, request, baseUrl)](#new_Permissions_new)
-    * [.getByOrganizationId(organizationId)](#Permissions+getByOrganizationId) ⇒ <code>Promise</code>
+    * [.getAllByOrganizationId(organizationId)](#Permissions+getAllByOrganizationId) ⇒ <code>Promise</code>
+    * [.getOneByOrganizationId(organizationId, userId)](#Permissions+getOneByOrganizationId) ⇒ <code>Promise</code>
     * [.getByUserId(userId)](#Permissions+getByUserId) ⇒ <code>Promise</code>
 
 <a name="new_Permissions_new"></a>
@@ -20,9 +21,9 @@ Module that provides access to contxt user permissions
 | request | <code>Object</code> | An instance of the request module tied to this module's audience. |
 | baseUrl | <code>string</code> | The base URL provided by the parent module |
 
-<a name="Permissions+getByOrganizationId"></a>
+<a name="Permissions+getAllByOrganizationId"></a>
 
-### contxtSdk.coordinator.permissions.getByOrganizationId(organizationId) ⇒ <code>Promise</code>
+### contxtSdk.coordinator.permissions.getAllByOrganizationId(organizationId) ⇒ <code>Promise</code>
 Gets a list of user permissions for each user in an organization
 
 API Endpoint: '/organizations/:organizationId/users/permissions'
@@ -39,7 +40,31 @@ Method: GET
 **Example**  
 ```js
 contxtSdk.coordinator.permissions
-  .getByOrganizationId('36b8421a-cc4a-4204-b839-1397374fb16b')
+  .getAllByOrganizationId('36b8421a-cc4a-4204-b839-1397374fb16b')
+  .then((usersPermissions) => console.log(usersPermissions))
+  .catch((err) => console.log(err));
+```
+<a name="Permissions+getOneByOrganizationId"></a>
+
+### contxtSdk.coordinator.permissions.getOneByOrganizationId(organizationId, userId) ⇒ <code>Promise</code>
+Gets a single user's permissions within an organization
+
+API Endpoint: '/organizations/:organizationId/users/:userId/permissions'
+Method: GET
+
+**Kind**: instance method of [<code>Permissions</code>](#Permissions)  
+**Fulfill**: [<code>ContxtUserPermissions</code>](./Typedefs.md#ContxtUserPermissions) A single user's permissions  
+**Reject**: <code>Error</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| organizationId | <code>string</code> | The ID of the organization |
+| userId | <code>string</code> | The ID of the user |
+
+**Example**  
+```js
+contxtSdk.coordinator.permissions
+  .getOneByOrganizationId('36b8421a-cc4a-4204-b839-1397374fb16b', 'auth0|12345')
   .then((usersPermissions) => console.log(usersPermissions))
   .catch((err) => console.log(err));
 ```

--- a/src/coordinator/permissions.js
+++ b/src/coordinator/permissions.js
@@ -41,11 +41,11 @@ class Permissions {
    *
    * @example
    * contxtSdk.coordinator.permissions
-   *   .getByOrganizationId('36b8421a-cc4a-4204-b839-1397374fb16b')
+   *   .getAllByOrganizationId('36b8421a-cc4a-4204-b839-1397374fb16b')
    *   .then((usersPermissions) => console.log(usersPermissions))
    *   .catch((err) => console.log(err));
    */
-  getByOrganizationId(organizationId) {
+  getAllByOrganizationId(organizationId) {
     if (!organizationId) {
       return Promise.reject(
         new Error(
@@ -56,6 +56,51 @@ class Permissions {
 
     return this._request
       .get(`${this._baseUrl}/organizations/${organizationId}/users/permissions`)
+      .then((userPermissions) => toCamelCase(userPermissions));
+  }
+
+  /**
+   * Gets a single user's permissions within an organization
+   *
+   * API Endpoint: '/organizations/:organizationId/users/:userId/permissions'
+   * Method: GET
+   *
+   * @param {string} organizationId The ID of the organization
+   * @param {string} userId The ID of the user
+   *
+   * @returns {Promise}
+   * @fulfill {ContxtUserPermissions} A single user's permissions
+   * @reject {Error}
+   *
+   * @example
+   * contxtSdk.coordinator.permissions
+   *   .getOneByOrganizationId('36b8421a-cc4a-4204-b839-1397374fb16b', 'auth0|12345')
+   *   .then((usersPermissions) => console.log(usersPermissions))
+   *   .catch((err) => console.log(err));
+   */
+  getOneByOrganizationId(organizationId, userId) {
+    if (!organizationId) {
+      return Promise.reject(
+        new Error(
+          "An organization ID is required for getting a user's permissions for an organization"
+        )
+      );
+    }
+
+    if (!userId) {
+      return Promise.reject(
+        new Error(
+          "An user ID is required for getting a user's permissions for an organization"
+        )
+      );
+    }
+
+    return this._request
+      .get(
+        `${
+          this._baseUrl
+        }/organizations/${organizationId}/users/${userId}/permissions`
+      )
       .then((userPermissions) => toCamelCase(userPermissions));
   }
 

--- a/src/coordinator/permissions.js
+++ b/src/coordinator/permissions.js
@@ -90,7 +90,7 @@ class Permissions {
     if (!userId) {
       return Promise.reject(
         new Error(
-          "An user ID is required for getting a user's permissions for an organization"
+          "A user ID is required for getting a user's permissions for an organization"
         )
       );
     }

--- a/src/coordinator/permissions.spec.js
+++ b/src/coordinator/permissions.spec.js
@@ -203,7 +203,7 @@ describe('Coordinator/Permissions', function() {
         );
 
         return expect(promise).to.be.rejectedWith(
-          "An user ID is required for getting a user's permissions for an organization"
+          "A user ID is required for getting a user's permissions for an organization"
         );
       });
     });

--- a/src/coordinator/permissions.spec.js
+++ b/src/coordinator/permissions.spec.js
@@ -49,7 +49,7 @@ describe('Coordinator/Permissions', function() {
     });
   });
 
-  describe('getByOrganizationId', function() {
+  describe('getAllByOrganizationId', function() {
     context('when the organization ID is provided', function() {
       let expectedUsersPermissions;
       let userPermissionFromServer;
@@ -85,7 +85,7 @@ describe('Coordinator/Permissions', function() {
           .returns(expectedUsersPermissions);
 
         const permissions = new Permissions(baseSdk, request, expectedHost);
-        promise = permissions.getByOrganizationId(expectedOrganizationId);
+        promise = permissions.getAllByOrganizationId(expectedOrganizationId);
       });
 
       it('gets the list of users permissions from the server', function() {
@@ -110,10 +110,100 @@ describe('Coordinator/Permissions', function() {
     context('when the organization ID is not provided', function() {
       it('throws an error', function() {
         const permissions = new Permissions(baseSdk, baseRequest, expectedHost);
-        const promise = permissions.getByOrganizationId();
+        const promise = permissions.getAllByOrganizationId();
 
         return expect(promise).to.be.rejectedWith(
           'An organization ID is required for getting users permissions for an organization'
+        );
+      });
+    });
+  });
+
+  describe('getOneByOrganizationId', function() {
+    context('when the organization ID is provided', function() {
+      let expectedUserPermissions;
+      let userPermissionFromServer;
+      let expectedOrganizationId;
+      let expectedUserId;
+      let promise;
+      let request;
+      let toCamelCase;
+
+      beforeEach(function() {
+        expectedOrganizationId = fixture.build('contxtOrganization').id;
+        expectedUserId = fixture.build('contxtUser').id;
+        expectedUserPermissions = fixture.build('contxtUserPermissions', {
+          organizationId: expectedOrganizationId
+        });
+
+        userPermissionFromServer = fixture.build(
+          'contxtUserPermissions',
+          expectedUserPermissions,
+          {
+            fromServer: true
+          }
+        );
+
+        request = {
+          ...baseRequest,
+          get: this.sandbox.stub().resolves(userPermissionFromServer)
+        };
+        toCamelCase = this.sandbox
+          .stub(objectUtils, 'toCamelCase')
+          .returns(expectedUserPermissions);
+
+        const permissions = new Permissions(baseSdk, request, expectedHost);
+        promise = permissions.getOneByOrganizationId(
+          expectedOrganizationId,
+          expectedUserId
+        );
+      });
+
+      it('gets the user permissions from the server', function() {
+        expect(request.get).to.be.calledWith(
+          `${expectedHost}/organizations/${expectedOrganizationId}/users/${expectedUserId}/permissions`
+        );
+      });
+
+      it('formats the of user permissions', function() {
+        return promise.then(() => {
+          expect(toCamelCase).to.be.calledWith(userPermissionFromServer);
+        });
+      });
+
+      it('returns a fulfilled promise with the users permissions', function() {
+        return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
+          expectedUserPermissions
+        );
+      });
+    });
+
+    context('when the organization ID is not provided', function() {
+      it('throws an error', function() {
+        const expectedUserId = fixture.build('contxtUser').id;
+        const permissions = new Permissions(baseSdk, baseRequest, expectedHost);
+        const promise = permissions.getOneByOrganizationId(
+          null,
+          expectedUserId
+        );
+
+        return expect(promise).to.be.rejectedWith(
+          "An organization ID is required for getting a user's permissions for an organization"
+        );
+      });
+    });
+
+    context('when the user ID is not provided', function() {
+      it('throws an error', function() {
+        const expectedOrganizationId = fixture.build('contxtOrganization').id;
+        const permissions = new Permissions(baseSdk, baseRequest, expectedHost);
+        const promise = permissions.getOneByOrganizationId(
+          expectedOrganizationId,
+          null
+        );
+
+        return expect(promise).to.be.rejectedWith(
+          "An user ID is required for getting a user's permissions for an organization"
         );
       });
     });


### PR DESCRIPTION
## Why?
There's a new endpoint `GET /organizations/:organization_id/users/:user_id/permissions` that needs added to the SDK. 

## What changed?
- Added `Permissions#getOneByOrganizationId` (`GET /organizations/:organization_id/users/:user_id/permissions`) for getting a single user's permissions within an organization
- Renamed `Permissions#getByOrganizationId` to `Permissions#getAllByOrganizationId` (`GET /organizations/:organization_id/users/permissions`) for getting every user's permissions within an organization.