### PR TITLE
Feature/build docs on commit

### DIFF
--- a/.huskyrc
+++ b/.huskyrc
@@ -1,0 +1,5 @@
+{
+  "hooks": {
+    "pre-commit": "pretty-quick --staged"
+  }
+}

--- a/.huskyrc
+++ b/.huskyrc
@@ -1,5 +1,5 @@
 {
   "hooks": {
-    "pre-commit": "pretty-quick --staged"
+    "pre-commit": "pretty-quick --staged && npm run build:docs"
   }
 }

--- a/.huskyrc
+++ b/.huskyrc
@@ -1,5 +1,0 @@
-{
-  "hooks": {
-    "pre-commit": "pretty-quick --staged && npm run build:docs"
-  }
-}

--- a/.huskyrc.js
+++ b/.huskyrc.js
@@ -1,0 +1,11 @@
+const tasks = (arr) => arr.join(' && ');
+
+module.exports = {
+  hooks: {
+    'pre-commit': tasks([
+      'pretty-quick --staged',
+      'npm run build:docs',
+      'npm run add:docs'
+    ])
+  }
+};

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ There are certain steps that should be taken when contributing and publishing a 
 
 ### Contributing
 
-We use [jsdoc-to-markdown](https://github.com/jsdoc2md/jsdoc-to-markdown) for documentation which should be committed to source control. The docs are set up to build on a pre-commit hook using [husky](https://github.com/typicode/husky) so you shouldn't need to run an additional command to build the docs before submitting a pull request.
+We use [jsdoc-to-markdown](https://github.com/jsdoc2md/jsdoc-to-markdown) for documentation which should be committed to source control. The docs are set up to build and be added to git on a pre-commit hook using [husky](https://github.com/typicode/husky) so you shouldn't need to run an additional command to build the docs before submitting a pull request.
 
 ### Publishing
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Some tools used for testing and ensuring code quality include:
 - [eslint-config-ndustrial](https://github.com/ndustrialio/eslint-config-ndustrial)
 - [faker.js](https://github.com/marak/Faker.js/)
 - [Mocha](https://mochajs.org/)
+- [Prettier](https://prettier.io/)
 - [Sinon.JS](http://sinonjs.org/)
 - [sinon-chai](http://chaijs.com/plugins/sinon-chai/)
 
@@ -134,9 +135,7 @@ There are certain steps that should be taken when contributing and publishing a 
 
 ### Contributing
 
-Before submitting a pull request for code review, be sure to run `npm run build:docs`. This command will autogenerate
-the documentation, utilizing [jsdoc-to-markdown](https://github.com/jsdoc2md/jsdoc-to-markdown), which should be
-committed to source control.
+We use [jsdoc-to-markdown](https://github.com/jsdoc2md/jsdoc-to-markdown) for documentation which should be committed to source control. The docs are set up to build on a pre-commit hook using [husky](https://github.com/typicode/husky) so you shouldn't need to run an additional command to build the docs before submitting a pull request.
 
 ### Publishing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-sW77BFwJ48YvQp3Gzz5xtAUiXuYOL2aMJKDwiaY3OcvdqBFurtYfOpSa4QrNyDxmOGRFSYzUpabU2m9QrlWE7w==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.0",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.0"
+        "chalk": "2.3.0",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -21,7 +21,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -30,9 +30,9 @@
           "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.1.0",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^4.0.0"
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
           }
         },
         "supports-color": {
@@ -41,7 +41,7 @@
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "^2.0.0"
+            "has-flag": "2.0.0"
           }
         }
       }
@@ -52,11 +52,11 @@
       "integrity": "sha512-aEADYwRRZjJyMnKN7llGIlircxTCofm3dtV5pmY6ob18MSIuipHpA2yZWkPlycwu5HJcx/pADS3zssd8eY7/6A==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.3.3",
-        "jsesc": "^2.5.1",
-        "lodash": "^4.17.11",
-        "source-map": "^0.5.0",
-        "trim-right": "^1.0.1"
+        "@babel/types": "7.3.3",
+        "jsesc": "2.5.2",
+        "lodash": "4.17.11",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
       },
       "dependencies": {
         "@babel/types": {
@@ -65,9 +65,9 @@
           "integrity": "sha512-2tACZ80Wg09UnPg5uGAOUvvInaqLk3l/IAhQzlxLQOIXacr6bMsra5SH6AWw/hIDRCSbCdHP2KzSOD+cT7TzMQ==",
           "dev": true,
           "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.11",
-            "to-fast-properties": "^2.0.0"
+            "esutils": "2.0.2",
+            "lodash": "4.17.11",
+            "to-fast-properties": "2.0.0"
           }
         },
         "jsesc": {
@@ -110,7 +110,7 @@
       "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "7.3.3"
       },
       "dependencies": {
         "@babel/types": {
@@ -119,9 +119,9 @@
           "integrity": "sha512-2tACZ80Wg09UnPg5uGAOUvvInaqLk3l/IAhQzlxLQOIXacr6bMsra5SH6AWw/hIDRCSbCdHP2KzSOD+cT7TzMQ==",
           "dev": true,
           "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.11",
-            "to-fast-properties": "^2.0.0"
+            "esutils": "2.0.2",
+            "lodash": "4.17.11",
+            "to-fast-properties": "2.0.0"
           }
         },
         "to-fast-properties": {
@@ -138,9 +138,9 @@
       "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.0",
-        "esutils": "^2.0.2",
-        "js-tokens": "^4.0.0"
+        "chalk": "2.4.2",
+        "esutils": "2.0.2",
+        "js-tokens": "4.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -149,7 +149,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -158,9 +158,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           }
         },
         "has-flag": {
@@ -181,7 +181,7 @@
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -201,7 +201,7 @@
         "@babel/code-frame": "7.0.0-beta.36",
         "@babel/types": "7.0.0-beta.36",
         "babylon": "7.0.0-beta.36",
-        "lodash": "^4.2.0"
+        "lodash": "4.17.11"
       },
       "dependencies": {
         "babylon": {
@@ -222,10 +222,10 @@
         "@babel/helper-function-name": "7.0.0-beta.36",
         "@babel/types": "7.0.0-beta.36",
         "babylon": "7.0.0-beta.36",
-        "debug": "^3.0.1",
-        "globals": "^11.1.0",
-        "invariant": "^2.2.0",
-        "lodash": "^4.2.0"
+        "debug": "3.1.0",
+        "globals": "11.1.0",
+        "invariant": "2.2.2",
+        "lodash": "4.17.11"
       },
       "dependencies": {
         "babylon": {
@@ -248,9 +248,9 @@
       "integrity": "sha512-PyAORDO9um9tfnrddXgmWN9e6Sq9qxraQIt5ynqBOSXKA5qvK1kUr+Q3nSzKFdzorsiK+oqcUnAFvEoKxv9D+Q==",
       "dev": true,
       "requires": {
-        "esutils": "^2.0.2",
-        "lodash": "^4.2.0",
-        "to-fast-properties": "^2.0.0"
+        "esutils": "2.0.2",
+        "lodash": "4.17.11",
+        "to-fast-properties": "2.0.0"
       },
       "dependencies": {
         "to-fast-properties": {
@@ -267,11 +267,11 @@
       "integrity": "sha512-ciiioYMLdo16ShmfHBXJBOFm3xPC4AuwO4xeRpFeHz7WK9PYsWCmigagG2XyzZpubK4a3qNKoUBDhbzHfa50LQ==",
       "dev": true,
       "requires": {
-        "acorn": "^5.0.3",
-        "css": "^2.2.1",
-        "normalize-path": "^2.1.1",
-        "source-map": "^0.6.0",
-        "through2": "^2.0.3"
+        "acorn": "5.7.3",
+        "css": "2.2.4",
+        "normalize-path": "2.1.1",
+        "source-map": "0.6.1",
+        "through2": "2.0.5"
       },
       "dependencies": {
         "source-map": {
@@ -288,8 +288,8 @@
       "integrity": "sha1-iQrnxdjId/bThIYCFazp1+yUW9o=",
       "dev": true,
       "requires": {
-        "normalize-path": "^2.0.1",
-        "through2": "^2.0.3"
+        "normalize-path": "2.1.1",
+        "through2": "2.0.5"
       }
     },
     "@mrmlnc/readdir-enhanced": {
@@ -298,8 +298,8 @@
       "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
       "dev": true,
       "requires": {
-        "call-me-maybe": "^1.0.1",
-        "glob-to-regexp": "^0.3.0"
+        "call-me-maybe": "1.0.1",
+        "glob-to-regexp": "0.3.0"
       }
     },
     "@sinonjs/commons": {
@@ -325,7 +325,7 @@
       "integrity": "sha512-ZAR2bPHOl4Xg6eklUGpsdiIJ4+J1SNag1DHHrG/73Uz/nVwXqjgUtRPLoS+aVyieN9cSbc0E4LsU984tWcDyNg==",
       "dev": true,
       "requires": {
-        "@sinonjs/samsam": "^2 || ^3"
+        "@sinonjs/samsam": "3.1.1"
       }
     },
     "@sinonjs/samsam": {
@@ -334,15 +334,21 @@
       "integrity": "sha512-ILlwvQUwAiaVBzr3qz8oT1moM7AIUHqUc2UmEjQcH9lLe+E+BZPwUMuc9FFojMswRK4r96x5zDTTrowMLw/vuA==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "^1.0.2",
-        "array-from": "^2.1.1",
-        "lodash": "^4.17.11"
+        "@sinonjs/commons": "1.3.0",
+        "array-from": "2.1.1",
+        "lodash": "4.17.11"
       }
     },
     "@sinonjs/text-encoding": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
+    "@types/normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
       "dev": true
     },
     "acorn": {
@@ -357,7 +363,7 @@
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
-        "acorn": "^3.0.4"
+        "acorn": "3.3.0"
       },
       "dependencies": {
         "acorn": {
@@ -374,10 +380,10 @@
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "dev": true,
       "requires": {
-        "co": "^4.6.0",
-        "fast-deep-equal": "^1.0.0",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0"
+        "co": "4.6.0",
+        "fast-deep-equal": "1.1.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
       }
     },
     "ajv-keywords": {
@@ -392,7 +398,7 @@
       "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
       "dev": true,
       "requires": {
-        "ansi-wrap": "^0.1.0"
+        "ansi-wrap": "0.1.0"
       }
     },
     "ansi-escape-sequences": {
@@ -401,7 +407,7 @@
       "integrity": "sha512-dzW9kHxH011uBsidTXd14JXgzye/YLb2LzeKZ4bsgl/Knwx8AtbSFkkGxagdNOoh0DlqHCmfiEjWKBaqjOanVw==",
       "dev": true,
       "requires": {
-        "array-back": "^3.0.1"
+        "array-back": "3.1.0"
       }
     },
     "ansi-escapes": {
@@ -443,8 +449,8 @@
       "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
       "dev": true,
       "requires": {
-        "micromatch": "^3.1.4",
-        "normalize-path": "^2.1.1"
+        "micromatch": "3.1.10",
+        "normalize-path": "2.1.1"
       },
       "dependencies": {
         "arr-diff": {
@@ -465,16 +471,16 @@
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.1",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "extend-shallow": {
@@ -483,7 +489,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -503,13 +509,13 @@
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.1",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -518,7 +524,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -527,7 +533,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-descriptor": {
@@ -536,9 +542,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
               }
             },
             "kind-of": {
@@ -555,14 +561,14 @@
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.1",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -571,7 +577,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -580,7 +586,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -591,10 +597,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -603,7 +609,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -614,7 +620,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -623,7 +629,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -634,7 +640,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -643,7 +649,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -654,7 +660,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -663,7 +669,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -686,19 +692,19 @@
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.9",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.1",
+            "to-regex": "3.0.2"
           }
         }
       }
@@ -709,7 +715,7 @@
       "integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
       "dev": true,
       "requires": {
-        "buffer-equal": "^1.0.0"
+        "buffer-equal": "1.0.0"
       }
     },
     "append-transform": {
@@ -718,7 +724,7 @@
       "integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
       "dev": true,
       "requires": {
-        "default-require-extensions": "^2.0.0"
+        "default-require-extensions": "2.0.0"
       }
     },
     "archy": {
@@ -733,7 +739,7 @@
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
       "dev": true,
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
     "arr-filter": {
@@ -742,7 +748,7 @@
       "integrity": "sha1-Q/3d0JHo7xGqTEXZzcGOLf8XEe4=",
       "dev": true,
       "requires": {
-        "make-iterator": "^1.0.0"
+        "make-iterator": "1.0.1"
       }
     },
     "arr-flatten": {
@@ -757,7 +763,7 @@
       "integrity": "sha1-Onc0X/wc814qkYJWAfnljy4kysQ=",
       "dev": true,
       "requires": {
-        "make-iterator": "^1.0.0"
+        "make-iterator": "1.0.1"
       }
     },
     "arr-union": {
@@ -790,8 +796,8 @@
       "integrity": "sha1-L6dLJnOTccOUe9enrcc74zSz15U=",
       "dev": true,
       "requires": {
-        "array-slice": "^1.0.0",
-        "is-number": "^4.0.0"
+        "array-slice": "1.1.0",
+        "is-number": "4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -808,7 +814,7 @@
       "integrity": "sha512-eOCut5rXlI6aCOS7Z7kCplKRKyiFQ6dHFBem4PwlwKeNFk2/XxTrhRh5T9PyaEWGy/NHTZWbY+nsZlNFJu9rYg==",
       "dev": true,
       "requires": {
-        "is-number": "^4.0.0"
+        "is-number": "4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -831,9 +837,9 @@
       "integrity": "sha512-ihLeJkonmdiAsD7vpgN3CRcx2J2S0TiYW+IS/5zHBI7mKUq3ySvBdzzBfD236ubDBQFiiyG3SWCPc+msQ9KoYg==",
       "dev": true,
       "requires": {
-        "default-compare": "^1.0.0",
-        "get-value": "^2.0.6",
-        "kind-of": "^5.0.2"
+        "default-compare": "1.0.0",
+        "get-value": "2.0.6",
+        "kind-of": "5.1.0"
       },
       "dependencies": {
         "kind-of": {
@@ -850,7 +856,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "^1.0.1"
+        "array-uniq": "1.0.3"
       }
     },
     "array-uniq": {
@@ -889,10 +895,10 @@
       "integrity": "sha512-R1BaUeJ4PMoLNJuk+0tLJgjmEqVsdN118+Z8O+alhnQDQgy0kmD5Mqi0DNEmMx2LM0Ed5yekKu+ZXYvIHceicg==",
       "dev": true,
       "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.2",
-        "process-nextick-args": "^1.0.7",
-        "stream-exhaust": "^1.0.1"
+        "end-of-stream": "1.4.1",
+        "once": "1.4.0",
+        "process-nextick-args": "1.0.7",
+        "stream-exhaust": "1.0.2"
       }
     },
     "async-each": {
@@ -912,7 +918,7 @@
       "integrity": "sha1-HQqRS7Aldb7IqPOnTlCA9yssDGs=",
       "dev": true,
       "requires": {
-        "async-done": "^1.2.2"
+        "async-done": "1.3.1"
       }
     },
     "asynckit": {
@@ -931,12 +937,12 @@
       "resolved": "https://registry.npmjs.org/auth0-js/-/auth0-js-9.3.2.tgz",
       "integrity": "sha1-5sang4A+WXYpZGbTFPhmtz5ZfA8=",
       "requires": {
-        "base64-js": "^1.2.0",
-        "idtoken-verifier": "^1.1.1",
-        "qs": "^6.4.0",
-        "superagent": "^3.8.2",
-        "url-join": "^1.1.0",
-        "winchan": "^0.2.0"
+        "base64-js": "1.3.0",
+        "idtoken-verifier": "1.2.0",
+        "qs": "6.6.0",
+        "superagent": "3.8.3",
+        "url-join": "1.1.0",
+        "winchan": "0.2.1"
       }
     },
     "axios": {
@@ -944,8 +950,8 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
       "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
       "requires": {
-        "follow-redirects": "^1.2.5",
-        "is-buffer": "^1.1.5"
+        "follow-redirects": "1.7.0",
+        "is-buffer": "1.1.6"
       }
     },
     "babel-code-frame": {
@@ -954,9 +960,9 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
       }
     },
     "babel-core": {
@@ -965,25 +971,25 @@
       "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-generator": "^6.26.0",
-        "babel-helpers": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-register": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "convert-source-map": "^1.5.1",
-        "debug": "^2.6.9",
-        "json5": "^0.5.1",
-        "lodash": "^4.17.4",
-        "minimatch": "^3.0.4",
-        "path-is-absolute": "^1.0.1",
-        "private": "^0.1.8",
-        "slash": "^1.0.0",
-        "source-map": "^0.5.7"
+        "babel-code-frame": "6.26.0",
+        "babel-generator": "6.26.0",
+        "babel-helpers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-register": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "convert-source-map": "1.5.1",
+        "debug": "2.6.9",
+        "json5": "0.5.1",
+        "lodash": "4.17.11",
+        "minimatch": "3.0.4",
+        "path-is-absolute": "1.0.1",
+        "private": "0.1.8",
+        "slash": "1.0.0",
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "debug": {
@@ -1013,8 +1019,8 @@
         "@babel/traverse": "7.0.0-beta.36",
         "@babel/types": "7.0.0-beta.36",
         "babylon": "7.0.0-beta.36",
-        "eslint-scope": "~3.7.1",
-        "eslint-visitor-keys": "^1.0.0"
+        "eslint-scope": "3.7.1",
+        "eslint-visitor-keys": "1.0.0"
       },
       "dependencies": {
         "babylon": {
@@ -1031,14 +1037,14 @@
       "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
       "dev": true,
       "requires": {
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "detect-indent": "^4.0.0",
-        "jsesc": "^1.3.0",
-        "lodash": "^4.17.4",
-        "source-map": "^0.5.6",
-        "trim-right": "^1.0.1"
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "detect-indent": "4.0.0",
+        "jsesc": "1.3.0",
+        "lodash": "4.17.11",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
       },
       "dependencies": {
         "jsesc": {
@@ -1055,9 +1061,9 @@
       "integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-builder-binary-assignment-operator-visitor": {
@@ -1066,9 +1072,9 @@
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
       "dev": true,
       "requires": {
-        "babel-helper-explode-assignable-expression": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-helper-explode-assignable-expression": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-call-delegate": {
@@ -1077,10 +1083,10 @@
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
       "dev": true,
       "requires": {
-        "babel-helper-hoist-variables": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-define-map": {
@@ -1089,10 +1095,10 @@
       "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.11"
       }
     },
     "babel-helper-explode-assignable-expression": {
@@ -1101,9 +1107,9 @@
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-explode-class": {
@@ -1112,10 +1118,10 @@
       "integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
       "dev": true,
       "requires": {
-        "babel-helper-bindify-decorators": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-bindify-decorators": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-function-name": {
@@ -1124,11 +1130,11 @@
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
       "dev": true,
       "requires": {
-        "babel-helper-get-function-arity": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-get-function-arity": {
@@ -1137,8 +1143,8 @@
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-hoist-variables": {
@@ -1147,8 +1153,8 @@
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-optimise-call-expression": {
@@ -1157,8 +1163,8 @@
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-regex": {
@@ -1167,9 +1173,9 @@
       "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.11"
       }
     },
     "babel-helper-remap-async-to-generator": {
@@ -1178,11 +1184,11 @@
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-replace-supers": {
@@ -1191,12 +1197,12 @@
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
       "dev": true,
       "requires": {
-        "babel-helper-optimise-call-expression": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-optimise-call-expression": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helpers": {
@@ -1205,8 +1211,8 @@
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-messages": {
@@ -1215,7 +1221,7 @@
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-check-es2015-constants": {
@@ -1224,7 +1230,7 @@
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-external-helpers": {
@@ -1233,7 +1239,7 @@
       "integrity": "sha1-IoX0iwK9Xe3oUXXK+MYuhq3M76E=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-istanbul": {
@@ -1242,9 +1248,9 @@
       "integrity": "sha512-RNNVv2lsHAXJQsEJ5jonQwrJVWK8AcZpG1oxhnjCUaAjL7xahYLANhPUZbzEQHjKy1NMYUwn+0NPKQc8iSY4xQ==",
       "dev": true,
       "requires": {
-        "find-up": "^3.0.0",
-        "istanbul-lib-instrument": "^3.0.0",
-        "test-exclude": "^5.0.0"
+        "find-up": "3.0.0",
+        "istanbul-lib-instrument": "3.1.0",
+        "test-exclude": "5.1.0"
       },
       "dependencies": {
         "find-up": {
@@ -1253,7 +1259,7 @@
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
-            "locate-path": "^3.0.0"
+            "locate-path": "3.0.0"
           }
         },
         "locate-path": {
@@ -1262,8 +1268,8 @@
           "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "dev": true,
           "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
+            "p-locate": "3.0.0",
+            "path-exists": "3.0.0"
           }
         },
         "p-limit": {
@@ -1272,7 +1278,7 @@
           "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
           "dev": true,
           "requires": {
-            "p-try": "^2.0.0"
+            "p-try": "2.0.0"
           }
         },
         "p-locate": {
@@ -1281,7 +1287,7 @@
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "requires": {
-            "p-limit": "^2.0.0"
+            "p-limit": "2.2.0"
           }
         },
         "p-try": {
@@ -1352,9 +1358,9 @@
       "integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
       "dev": true,
       "requires": {
-        "babel-helper-remap-async-to-generator": "^6.24.1",
-        "babel-plugin-syntax-async-generators": "^6.5.0",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-remap-async-to-generator": "6.24.1",
+        "babel-plugin-syntax-async-generators": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-async-to-generator": {
@@ -1363,9 +1369,9 @@
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
       "dev": true,
       "requires": {
-        "babel-helper-remap-async-to-generator": "^6.24.1",
-        "babel-plugin-syntax-async-functions": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-remap-async-to-generator": "6.24.1",
+        "babel-plugin-syntax-async-functions": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-class-properties": {
@@ -1374,10 +1380,10 @@
       "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-plugin-syntax-class-properties": "^6.8.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-helper-function-name": "6.24.1",
+        "babel-plugin-syntax-class-properties": "6.13.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-decorators": {
@@ -1386,11 +1392,11 @@
       "integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
       "dev": true,
       "requires": {
-        "babel-helper-explode-class": "^6.24.1",
-        "babel-plugin-syntax-decorators": "^6.13.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-explode-class": "6.24.1",
+        "babel-plugin-syntax-decorators": "6.13.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
@@ -1399,7 +1405,7 @@
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
@@ -1408,7 +1414,7 @@
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoping": {
@@ -1417,11 +1423,11 @@
       "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.11"
       }
     },
     "babel-plugin-transform-es2015-classes": {
@@ -1430,15 +1436,15 @@
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
       "dev": true,
       "requires": {
-        "babel-helper-define-map": "^6.24.1",
-        "babel-helper-function-name": "^6.24.1",
-        "babel-helper-optimise-call-expression": "^6.24.1",
-        "babel-helper-replace-supers": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-define-map": "6.26.0",
+        "babel-helper-function-name": "6.24.1",
+        "babel-helper-optimise-call-expression": "6.24.1",
+        "babel-helper-replace-supers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-computed-properties": {
@@ -1447,8 +1453,8 @@
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-destructuring": {
@@ -1457,7 +1463,7 @@
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
@@ -1466,8 +1472,8 @@
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-for-of": {
@@ -1476,7 +1482,7 @@
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-function-name": {
@@ -1485,9 +1491,9 @@
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-literals": {
@@ -1496,7 +1502,7 @@
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-amd": {
@@ -1505,9 +1511,9 @@
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
@@ -1516,10 +1522,10 @@
       "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-strict-mode": "^6.24.1",
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-types": "^6.26.0"
+        "babel-plugin-transform-strict-mode": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
@@ -1528,9 +1534,9 @@
       "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
       "dev": true,
       "requires": {
-        "babel-helper-hoist-variables": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-umd": {
@@ -1539,9 +1545,9 @@
       "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-object-super": {
@@ -1550,8 +1556,8 @@
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
       "dev": true,
       "requires": {
-        "babel-helper-replace-supers": "^6.24.1",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-replace-supers": "6.24.1",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-parameters": {
@@ -1560,12 +1566,12 @@
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
       "dev": true,
       "requires": {
-        "babel-helper-call-delegate": "^6.24.1",
-        "babel-helper-get-function-arity": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-call-delegate": "6.24.1",
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
@@ -1574,8 +1580,8 @@
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-spread": {
@@ -1584,7 +1590,7 @@
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-sticky-regex": {
@@ -1593,9 +1599,9 @@
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-helper-regex": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-template-literals": {
@@ -1604,7 +1610,7 @@
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
@@ -1613,7 +1619,7 @@
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-unicode-regex": {
@@ -1622,9 +1628,9 @@
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "regexpu-core": "^2.0.0"
+        "babel-helper-regex": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "regexpu-core": "2.0.0"
       }
     },
     "babel-plugin-transform-exponentiation-operator": {
@@ -1633,9 +1639,9 @@
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
       "dev": true,
       "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
-        "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-object-rest-spread": {
@@ -1644,8 +1650,8 @@
       "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-object-rest-spread": "^6.8.0",
-        "babel-runtime": "^6.26.0"
+        "babel-plugin-syntax-object-rest-spread": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-regenerator": {
@@ -1654,7 +1660,7 @@
       "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
       "dev": true,
       "requires": {
-        "regenerator-transform": "^0.10.0"
+        "regenerator-transform": "0.10.1"
       }
     },
     "babel-plugin-transform-strict-mode": {
@@ -1663,8 +1669,8 @@
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-preset-env": {
@@ -1673,36 +1679,36 @@
       "integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
       "dev": true,
       "requires": {
-        "babel-plugin-check-es2015-constants": "^6.22.0",
-        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
-        "babel-plugin-transform-async-to-generator": "^6.22.0",
-        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
-        "babel-plugin-transform-es2015-classes": "^6.23.0",
-        "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
-        "babel-plugin-transform-es2015-destructuring": "^6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
-        "babel-plugin-transform-es2015-for-of": "^6.23.0",
-        "babel-plugin-transform-es2015-function-name": "^6.22.0",
-        "babel-plugin-transform-es2015-literals": "^6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
-        "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
-        "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
-        "babel-plugin-transform-es2015-object-super": "^6.22.0",
-        "babel-plugin-transform-es2015-parameters": "^6.23.0",
-        "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
-        "babel-plugin-transform-es2015-spread": "^6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
-        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
-        "babel-plugin-transform-exponentiation-operator": "^6.22.0",
-        "babel-plugin-transform-regenerator": "^6.22.0",
-        "browserslist": "^3.2.6",
-        "invariant": "^2.2.2",
-        "semver": "^5.3.0"
+        "babel-plugin-check-es2015-constants": "6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+        "babel-plugin-transform-async-to-generator": "6.24.1",
+        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+        "babel-plugin-transform-es2015-classes": "6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+        "babel-plugin-transform-es2015-for-of": "6.23.0",
+        "babel-plugin-transform-es2015-function-name": "6.24.1",
+        "babel-plugin-transform-es2015-literals": "6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
+        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+        "babel-plugin-transform-es2015-object-super": "6.24.1",
+        "babel-plugin-transform-es2015-parameters": "6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+        "babel-plugin-transform-es2015-spread": "6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+        "babel-plugin-transform-exponentiation-operator": "6.24.1",
+        "babel-plugin-transform-regenerator": "6.26.0",
+        "browserslist": "3.2.8",
+        "invariant": "2.2.2",
+        "semver": "5.5.0"
       }
     },
     "babel-preset-stage-2": {
@@ -1711,10 +1717,10 @@
       "integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-dynamic-import": "^6.18.0",
-        "babel-plugin-transform-class-properties": "^6.24.1",
-        "babel-plugin-transform-decorators": "^6.24.1",
-        "babel-preset-stage-3": "^6.24.1"
+        "babel-plugin-syntax-dynamic-import": "6.18.0",
+        "babel-plugin-transform-class-properties": "6.24.1",
+        "babel-plugin-transform-decorators": "6.24.1",
+        "babel-preset-stage-3": "6.24.1"
       }
     },
     "babel-preset-stage-3": {
@@ -1723,11 +1729,11 @@
       "integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
-        "babel-plugin-transform-async-generator-functions": "^6.24.1",
-        "babel-plugin-transform-async-to-generator": "^6.24.1",
-        "babel-plugin-transform-exponentiation-operator": "^6.24.1",
-        "babel-plugin-transform-object-rest-spread": "^6.22.0"
+        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+        "babel-plugin-transform-async-generator-functions": "6.24.1",
+        "babel-plugin-transform-async-to-generator": "6.24.1",
+        "babel-plugin-transform-exponentiation-operator": "6.24.1",
+        "babel-plugin-transform-object-rest-spread": "6.26.0"
       }
     },
     "babel-register": {
@@ -1736,13 +1742,13 @@
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "dev": true,
       "requires": {
-        "babel-core": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "core-js": "^2.5.0",
-        "home-or-tmp": "^2.0.0",
-        "lodash": "^4.17.4",
-        "mkdirp": "^0.5.1",
-        "source-map-support": "^0.4.15"
+        "babel-core": "6.26.3",
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.3",
+        "home-or-tmp": "2.0.0",
+        "lodash": "4.17.11",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.4.18"
       }
     },
     "babel-runtime": {
@@ -1751,8 +1757,8 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
+        "core-js": "2.5.3",
+        "regenerator-runtime": "0.11.1"
       }
     },
     "babel-template": {
@@ -1761,11 +1767,11 @@
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "lodash": "^4.17.4"
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "lodash": "4.17.11"
       }
     },
     "babel-traverse": {
@@ -1774,15 +1780,15 @@
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "debug": "^2.6.8",
-        "globals": "^9.18.0",
-        "invariant": "^2.2.2",
-        "lodash": "^4.17.4"
+        "babel-code-frame": "6.26.0",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "debug": "2.6.9",
+        "globals": "9.18.0",
+        "invariant": "2.2.2",
+        "lodash": "4.17.11"
       },
       "dependencies": {
         "debug": {
@@ -1802,10 +1808,10 @@
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.4",
-        "to-fast-properties": "^1.0.3"
+        "babel-runtime": "6.26.0",
+        "esutils": "2.0.2",
+        "lodash": "4.17.11",
+        "to-fast-properties": "1.0.3"
       }
     },
     "babylon": {
@@ -1820,15 +1826,15 @@
       "integrity": "sha1-Szzpa/JxNPeaG0FKUcFONMO9mIA=",
       "dev": true,
       "requires": {
-        "arr-filter": "^1.1.1",
-        "arr-flatten": "^1.0.1",
-        "arr-map": "^2.0.0",
-        "array-each": "^1.0.0",
-        "array-initial": "^1.0.0",
-        "array-last": "^1.1.1",
-        "async-done": "^1.2.2",
-        "async-settle": "^1.0.0",
-        "now-and-later": "^2.0.0"
+        "arr-filter": "1.1.2",
+        "arr-flatten": "1.1.0",
+        "arr-map": "2.0.2",
+        "array-each": "1.0.1",
+        "array-initial": "1.1.0",
+        "array-last": "1.3.0",
+        "async-done": "1.3.1",
+        "async-settle": "1.0.0",
+        "now-and-later": "2.0.0"
       }
     },
     "balanced-match": {
@@ -1843,13 +1849,13 @@
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "dev": true,
       "requires": {
-        "cache-base": "^1.0.1",
-        "class-utils": "^0.3.5",
-        "component-emitter": "^1.2.1",
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.1",
-        "mixin-deep": "^1.2.0",
-        "pascalcase": "^0.1.1"
+        "cache-base": "1.0.1",
+        "class-utils": "0.3.6",
+        "component-emitter": "1.2.1",
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "mixin-deep": "1.3.1",
+        "pascalcase": "0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -1858,7 +1864,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "isobject": {
@@ -1892,7 +1898,7 @@
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true,
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -1908,8 +1914,8 @@
       "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30000844",
-        "electron-to-chromium": "^1.3.47"
+        "caniuse-lite": "1.0.30000945",
+        "electron-to-chromium": "1.3.115"
       }
     },
     "buffer-equal": {
@@ -1936,15 +1942,15 @@
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "dev": true,
       "requires": {
-        "collection-visit": "^1.0.0",
-        "component-emitter": "^1.2.1",
-        "get-value": "^2.0.6",
-        "has-value": "^1.0.0",
-        "isobject": "^3.0.1",
-        "set-value": "^2.0.0",
-        "to-object-path": "^0.3.0",
-        "union-value": "^1.0.0",
-        "unset-value": "^1.0.0"
+        "collection-visit": "1.0.0",
+        "component-emitter": "1.2.1",
+        "get-value": "2.0.6",
+        "has-value": "1.0.0",
+        "isobject": "3.0.1",
+        "set-value": "2.0.0",
+        "to-object-path": "0.3.0",
+        "union-value": "1.0.0",
+        "unset-value": "1.0.0"
       },
       "dependencies": {
         "isobject": {
@@ -1961,9 +1967,9 @@
       "integrity": "sha512-4TgWfe9SF+bUy5cCql8gWHqKNrviufNwSYxLjf2utB0pY4+bdcuFwMmY1hDB+67Gz/L1vmhFNhePAjJTFBtV+Q==",
       "dev": true,
       "requires": {
-        "array-back": "^2.0.0",
-        "fs-then-native": "^2.0.0",
-        "mkdirp2": "^1.0.3"
+        "array-back": "2.0.0",
+        "fs-then-native": "2.0.0",
+        "mkdirp2": "1.0.4"
       },
       "dependencies": {
         "array-back": {
@@ -1972,7 +1978,7 @@
           "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
           "dev": true,
           "requires": {
-            "typical": "^2.6.1"
+            "typical": "2.6.1"
           }
         }
       }
@@ -1983,10 +1989,10 @@
       "integrity": "sha512-Mtgcv3lh3U0zRii/6qVgQODdPA4G3zhG+jtbCWj39RXuUFTMzH0vcdMtaJS1jPowd+It2Pqr6y3NJMQqOqCE2w==",
       "dev": true,
       "requires": {
-        "hasha": "^3.0.0",
-        "make-dir": "^2.0.0",
-        "package-hash": "^3.0.0",
-        "write-file-atomic": "^2.4.2"
+        "hasha": "3.0.0",
+        "make-dir": "2.1.0",
+        "package-hash": "3.0.0",
+        "write-file-atomic": "2.4.3"
       }
     },
     "call-me-maybe": {
@@ -1995,13 +2001,30 @@
       "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
       "dev": true
     },
+    "caller-callsite": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
+      "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
+      "dev": true,
+      "requires": {
+        "callsites": "2.0.0"
+      },
+      "dependencies": {
+        "callsites": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+          "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+          "dev": true
+        }
+      }
+    },
     "caller-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
-        "callsites": "^0.2.0"
+        "callsites": "0.2.0"
       }
     },
     "callsites": {
@@ -2015,8 +2038,8 @@
       "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
       "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
       "requires": {
-        "no-case": "^2.2.0",
-        "upper-case": "^1.1.1"
+        "no-case": "2.3.2",
+        "upper-case": "1.1.3"
       }
     },
     "camelcase": {
@@ -2037,7 +2060,7 @@
       "integrity": "sha512-l2OUaz/3PU3MZylspVFJvwHCVfWyvcduPq4lv3AzZ2pJzZCo7kNKFNyatwujD7XgvGkNAE/Jhhbh2uARNwNkfw==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.11"
+        "lodash": "4.17.11"
       }
     },
     "chai": {
@@ -2046,12 +2069,12 @@
       "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
       "dev": true,
       "requires": {
-        "assertion-error": "^1.0.1",
-        "check-error": "^1.0.1",
-        "deep-eql": "^3.0.0",
-        "get-func-name": "^2.0.0",
-        "pathval": "^1.0.0",
-        "type-detect": "^4.0.0"
+        "assertion-error": "1.1.0",
+        "check-error": "1.0.2",
+        "deep-eql": "3.0.1",
+        "get-func-name": "2.0.0",
+        "pathval": "1.1.0",
+        "type-detect": "4.0.6"
       }
     },
     "chai-as-promised": {
@@ -2060,7 +2083,7 @@
       "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
       "dev": true,
       "requires": {
-        "check-error": "^1.0.2"
+        "check-error": "1.0.2"
       }
     },
     "chalk": {
@@ -2069,11 +2092,11 @@
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
       }
     },
     "change-case": {
@@ -2081,24 +2104,24 @@
       "resolved": "https://registry.npmjs.org/change-case/-/change-case-3.0.2.tgz",
       "integrity": "sha512-Mww+SLF6MZ0U6kdg11algyKd5BARbyM4TbFBepwowYSR5ClfQGCGtxNXgykpN0uF/bstWeaGDT4JWaDh8zWAHA==",
       "requires": {
-        "camel-case": "^3.0.0",
-        "constant-case": "^2.0.0",
-        "dot-case": "^2.1.0",
-        "header-case": "^1.0.0",
-        "is-lower-case": "^1.1.0",
-        "is-upper-case": "^1.1.0",
-        "lower-case": "^1.1.1",
-        "lower-case-first": "^1.0.0",
-        "no-case": "^2.3.2",
-        "param-case": "^2.1.0",
-        "pascal-case": "^2.0.0",
-        "path-case": "^2.1.0",
-        "sentence-case": "^2.1.0",
-        "snake-case": "^2.1.0",
-        "swap-case": "^1.1.0",
-        "title-case": "^2.1.0",
-        "upper-case": "^1.1.1",
-        "upper-case-first": "^1.1.0"
+        "camel-case": "3.0.0",
+        "constant-case": "2.0.0",
+        "dot-case": "2.1.1",
+        "header-case": "1.0.1",
+        "is-lower-case": "1.1.3",
+        "is-upper-case": "1.1.2",
+        "lower-case": "1.1.4",
+        "lower-case-first": "1.0.2",
+        "no-case": "2.3.2",
+        "param-case": "2.1.1",
+        "pascal-case": "2.0.1",
+        "path-case": "2.1.1",
+        "sentence-case": "2.1.1",
+        "snake-case": "2.1.0",
+        "swap-case": "1.1.2",
+        "title-case": "2.1.1",
+        "upper-case": "1.1.3",
+        "upper-case-first": "1.1.2"
       }
     },
     "chardet": {
@@ -2119,18 +2142,18 @@
       "integrity": "sha512-IwXUx0FXc5ibYmPC2XeEj5mpXoV66sR+t3jqu2NS2GYwCktt3KF1/Qqjws/NkegajBA4RbZ5+DDwlOiJsxDHEg==",
       "dev": true,
       "requires": {
-        "anymatch": "^2.0.0",
-        "async-each": "^1.0.1",
-        "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
-        "glob-parent": "^3.1.0",
-        "inherits": "^2.0.3",
-        "is-binary-path": "^1.0.0",
-        "is-glob": "^4.0.0",
-        "normalize-path": "^3.0.0",
-        "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.2.1",
-        "upath": "^1.1.0"
+        "anymatch": "2.0.0",
+        "async-each": "1.0.1",
+        "braces": "2.3.2",
+        "fsevents": "1.2.7",
+        "glob-parent": "3.1.0",
+        "inherits": "2.0.3",
+        "is-binary-path": "1.0.1",
+        "is-glob": "4.0.0",
+        "normalize-path": "3.0.0",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.2.1",
+        "upath": "1.1.2"
       },
       "dependencies": {
         "array-unique": {
@@ -2145,16 +2168,16 @@
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.1",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           }
         },
         "extend-shallow": {
@@ -2163,7 +2186,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "fill-range": {
@@ -2172,10 +2195,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           }
         },
         "glob-parent": {
@@ -2184,8 +2207,8 @@
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
+            "is-glob": "3.1.0",
+            "path-dirname": "1.0.2"
           },
           "dependencies": {
             "is-glob": {
@@ -2194,7 +2217,7 @@
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
               "dev": true,
               "requires": {
-                "is-extglob": "^2.1.0"
+                "is-extglob": "2.1.1"
               }
             }
           }
@@ -2211,7 +2234,7 @@
           "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
           "dev": true,
           "requires": {
-            "is-extglob": "^2.1.1"
+            "is-extglob": "2.1.1"
           }
         },
         "is-number": {
@@ -2220,7 +2243,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         },
         "isobject": {
@@ -2238,9 +2261,9 @@
       }
     },
     "ci-info": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
-      "integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "dev": true
     },
     "circular-json": {
@@ -2255,10 +2278,10 @@
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "dev": true,
       "requires": {
-        "arr-union": "^3.1.0",
-        "define-property": "^0.2.5",
-        "isobject": "^3.0.0",
-        "static-extend": "^0.1.1"
+        "arr-union": "3.1.0",
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "static-extend": "0.1.2"
       },
       "dependencies": {
         "define-property": {
@@ -2267,7 +2290,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "is-accessor-descriptor": {
@@ -2276,7 +2299,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -2285,7 +2308,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -2296,7 +2319,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -2305,7 +2328,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -2316,9 +2339,9 @@
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
           }
         },
         "isobject": {
@@ -2341,7 +2364,7 @@
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
-        "restore-cursor": "^2.0.0"
+        "restore-cursor": "2.0.0"
       }
     },
     "cli-width": {
@@ -2356,9 +2379,9 @@
       "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wrap-ansi": "^2.0.0"
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wrap-ansi": "2.1.0"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -2367,7 +2390,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "string-width": {
@@ -2376,9 +2399,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         }
       }
@@ -2407,9 +2430,9 @@
       "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "process-nextick-args": "^2.0.0",
-        "readable-stream": "^2.3.5"
+        "inherits": "2.0.3",
+        "process-nextick-args": "2.0.0",
+        "readable-stream": "2.3.6"
       },
       "dependencies": {
         "process-nextick-args": {
@@ -2424,13 +2447,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -2439,7 +2462,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -2468,8 +2491,8 @@
       "integrity": "sha512-0y0rBgoX8IzIjBAUnO73SEtSb4Mhk3IoceWJq5zZSxb9mWORhWH8xLYo4EDSOE1jRBk1LhmfjqWFFt10h/+MEA==",
       "dev": true,
       "requires": {
-        "stream-connect": "^1.0.2",
-        "stream-via": "^1.0.4"
+        "stream-connect": "1.0.2",
+        "stream-via": "1.0.4"
       }
     },
     "collection-map": {
@@ -2478,9 +2501,9 @@
       "integrity": "sha1-rqDwb40mx4DCt1SUOFVEsiVa8Yw=",
       "dev": true,
       "requires": {
-        "arr-map": "^2.0.2",
-        "for-own": "^1.0.0",
-        "make-iterator": "^1.0.0"
+        "arr-map": "2.0.2",
+        "for-own": "1.0.0",
+        "make-iterator": "1.0.1"
       },
       "dependencies": {
         "for-own": {
@@ -2489,7 +2512,7 @@
           "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
           "dev": true,
           "requires": {
-            "for-in": "^1.0.1"
+            "for-in": "1.0.2"
           }
         }
       }
@@ -2500,8 +2523,8 @@
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
-        "map-visit": "^1.0.0",
-        "object-visit": "^1.0.0"
+        "map-visit": "1.0.0",
+        "object-visit": "1.0.1"
       }
     },
     "color-convert": {
@@ -2510,7 +2533,7 @@
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "dev": true,
       "requires": {
-        "color-name": "^1.1.1"
+        "color-name": "1.1.3"
       }
     },
     "color-name": {
@@ -2530,7 +2553,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
       "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
       "requires": {
-        "delayed-stream": "~1.0.0"
+        "delayed-stream": "1.0.0"
       }
     },
     "command-line-args": {
@@ -2539,10 +2562,10 @@
       "integrity": "sha512-hL/eG8lrll1Qy1ezvkant+trihbGnaKaeEjj6Scyr3DN+RC7iQ5Rz84IeLERfAWDGo0HBSNAakczwgCilDXnWg==",
       "dev": true,
       "requires": {
-        "array-back": "^3.0.1",
-        "find-replace": "^3.0.0",
-        "lodash.camelcase": "^4.3.0",
-        "typical": "^4.0.0"
+        "array-back": "3.1.0",
+        "find-replace": "3.0.0",
+        "lodash.camelcase": "4.3.0",
+        "typical": "4.0.0"
       },
       "dependencies": {
         "typical": {
@@ -2559,11 +2582,11 @@
       "integrity": "sha512-Xw18HVx/QzQV3Sc5k1vy3kgtOeGmsKIqwtFFoyjI4bbcpSgnw2CWVULvtakyw4s6fhyAdI6soQQhXc2OzJy62g==",
       "dev": true,
       "requires": {
-        "ansi-escape-sequences": "^4.0.0",
-        "array-back": "^2.0.0",
-        "command-line-args": "^5.0.0",
-        "command-line-usage": "^4.1.0",
-        "typical": "^2.6.1"
+        "ansi-escape-sequences": "4.1.0",
+        "array-back": "2.0.0",
+        "command-line-args": "5.1.1",
+        "command-line-usage": "4.1.0",
+        "typical": "2.6.1"
       },
       "dependencies": {
         "array-back": {
@@ -2572,7 +2595,7 @@
           "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
           "dev": true,
           "requires": {
-            "typical": "^2.6.1"
+            "typical": "2.6.1"
           }
         }
       }
@@ -2583,10 +2606,10 @@
       "integrity": "sha512-MxS8Ad995KpdAC0Jopo/ovGIroV/m0KHwzKfXxKag6FHOkGsH8/lv5yjgablcRxCJJC0oJeUMuO/gmaq+Wq46g==",
       "dev": true,
       "requires": {
-        "ansi-escape-sequences": "^4.0.0",
-        "array-back": "^2.0.0",
-        "table-layout": "^0.4.2",
-        "typical": "^2.6.1"
+        "ansi-escape-sequences": "4.1.0",
+        "array-back": "2.0.0",
+        "table-layout": "0.4.4",
+        "typical": "2.6.1"
       },
       "dependencies": {
         "array-back": {
@@ -2595,7 +2618,7 @@
           "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
           "dev": true,
           "requires": {
-            "typical": "^2.6.1"
+            "typical": "2.6.1"
           }
         }
       }
@@ -2635,10 +2658,10 @@
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
+        "buffer-from": "1.1.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "typedarray": "0.0.6"
       }
     },
     "config-master": {
@@ -2647,7 +2670,7 @@
       "integrity": "sha1-ZnZjWQUFooO/JqSE1oSJ10xUhdo=",
       "dev": true,
       "requires": {
-        "walk-back": "^2.0.1"
+        "walk-back": "2.0.1"
       },
       "dependencies": {
         "walk-back": {
@@ -2663,8 +2686,8 @@
       "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-2.0.0.tgz",
       "integrity": "sha1-QXV2TTidP6nI7NKRhu1gBSQ7akY=",
       "requires": {
-        "snake-case": "^2.1.0",
-        "upper-case": "^1.1.1"
+        "snake-case": "2.1.0",
+        "upper-case": "1.1.3"
       }
     },
     "contains-path": {
@@ -2696,8 +2719,8 @@
       "integrity": "sha512-7cjuUME+p+S3HZlbllgsn2CDwS+5eCCX16qBgNC4jgSTf49qR1VKy/Zhl400m0IQXl/bPGEVqncgUUMjrr4s8A==",
       "dev": true,
       "requires": {
-        "each-props": "^1.3.0",
-        "is-plain-object": "^2.0.1"
+        "each-props": "1.3.2",
+        "is-plain-object": "2.0.4"
       }
     },
     "core-js": {
@@ -2711,17 +2734,66 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "cosmiconfig": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+      "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
+      "dev": true,
+      "requires": {
+        "import-fresh": "2.0.0",
+        "is-directory": "0.3.1",
+        "js-yaml": "3.13.1",
+        "parse-json": "4.0.0"
+      },
+      "dependencies": {
+        "caller-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
+          "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
+          "dev": true,
+          "requires": {
+            "caller-callsite": "2.0.0"
+          }
+        },
+        "import-fresh": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+          "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+          "dev": true,
+          "requires": {
+            "caller-path": "2.0.0",
+            "resolve-from": "3.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.1",
+            "json-parse-better-errors": "1.0.2"
+          }
+        },
+        "resolve-from": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+          "dev": true
+        }
+      }
+    },
     "cp-file": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/cp-file/-/cp-file-6.2.0.tgz",
       "integrity": "sha512-fmvV4caBnofhPe8kOcitBwSn2f39QLjnAnGq3gO9dfd75mUytzKNZB1hde6QHunW2Rt+OwuBOMc3i1tNElbszA==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^2.0.0",
-        "nested-error-stacks": "^2.0.0",
-        "pify": "^4.0.1",
-        "safe-buffer": "^5.0.1"
+        "graceful-fs": "4.1.11",
+        "make-dir": "2.1.0",
+        "nested-error-stacks": "2.1.0",
+        "pify": "4.0.1",
+        "safe-buffer": "5.1.1"
       },
       "dependencies": {
         "pify": {
@@ -2738,9 +2810,9 @@
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "lru-cache": "^4.0.1",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+        "lru-cache": "4.1.1",
+        "shebang-command": "1.2.0",
+        "which": "1.3.0"
       }
     },
     "crypto-js": {
@@ -2754,10 +2826,10 @@
       "integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.3",
-        "source-map": "^0.6.1",
-        "source-map-resolve": "^0.5.2",
-        "urix": "^0.1.0"
+        "inherits": "2.0.3",
+        "source-map": "0.6.1",
+        "source-map-resolve": "0.5.2",
+        "urix": "0.1.0"
       },
       "dependencies": {
         "source-map": {
@@ -2772,11 +2844,11 @@
           "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
           "dev": true,
           "requires": {
-            "atob": "^2.1.1",
-            "decode-uri-component": "^0.2.0",
-            "resolve-url": "^0.2.1",
-            "source-map-url": "^0.4.0",
-            "urix": "^0.1.0"
+            "atob": "2.1.1",
+            "decode-uri-component": "0.2.0",
+            "resolve-url": "0.2.1",
+            "source-map-url": "0.4.0",
+            "urix": "0.1.0"
           }
         }
       }
@@ -2787,7 +2859,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "^0.10.9"
+        "es5-ext": "0.10.49"
       }
     },
     "debug": {
@@ -2804,9 +2876,9 @@
       "integrity": "sha512-GZqvGIgKNlUnHUPQhepnUZFIMoi3dgZKQBzKDeL2g7oJF9SNAji/AAu36dusFUas0O+pae74lNeoIPHqXWDkLg==",
       "dev": true,
       "requires": {
-        "debug": "3.X",
-        "memoizee": "0.4.X",
-        "object-assign": "4.X"
+        "debug": "3.1.0",
+        "memoizee": "0.4.14",
+        "object-assign": "4.1.1"
       }
     },
     "decamelize": {
@@ -2827,7 +2899,7 @@
       "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
-        "type-detect": "^4.0.0"
+        "type-detect": "4.0.6"
       }
     },
     "deep-extend": {
@@ -2848,7 +2920,7 @@
       "integrity": "sha512-QWfXlM0EkAbqOCbD/6HjdwT19j7WCkMyiRhWilc4H9/5h/RzTF9gv5LYh1+CmDV5d1rki6KAWLtQale0xt20eQ==",
       "dev": true,
       "requires": {
-        "kind-of": "^5.0.2"
+        "kind-of": "5.1.0"
       },
       "dependencies": {
         "kind-of": {
@@ -2865,7 +2937,7 @@
       "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
       "dev": true,
       "requires": {
-        "strip-bom": "^3.0.0"
+        "strip-bom": "3.0.0"
       }
     },
     "default-resolution": {
@@ -2880,7 +2952,7 @@
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "dev": true,
       "requires": {
-        "object-keys": "^1.0.12"
+        "object-keys": "1.1.0"
       }
     },
     "define-property": {
@@ -2889,8 +2961,8 @@
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "dev": true,
       "requires": {
-        "is-descriptor": "^1.0.2",
-        "isobject": "^3.0.1"
+        "is-descriptor": "1.0.2",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -2907,12 +2979,12 @@
       "integrity": "sha512-/BnSJ+SuZyLu7xMn48kZY0nMXDi+5KNmR4g8n21Wivsl8+B9njV6/5kcTNE9juSprp0zRWBU28JuHUq0FqK1Nw==",
       "dev": true,
       "requires": {
-        "globby": "^6.1.0",
-        "is-path-cwd": "^2.0.0",
-        "is-path-in-cwd": "^2.0.0",
-        "p-map": "^2.0.0",
-        "pify": "^4.0.1",
-        "rimraf": "^2.6.2"
+        "globby": "6.1.0",
+        "is-path-cwd": "2.0.0",
+        "is-path-in-cwd": "2.0.0",
+        "p-map": "2.0.0",
+        "pify": "4.0.1",
+        "rimraf": "2.6.3"
       },
       "dependencies": {
         "pify": {
@@ -2940,7 +3012,7 @@
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "dev": true,
       "requires": {
-        "repeating": "^2.0.0"
+        "repeating": "2.0.1"
       }
     },
     "detect-newline": {
@@ -2961,18 +3033,18 @@
       "integrity": "sha512-J+4CgbQiMuJHiU9dvTVN8iOOZGeR3bef1wBqz6eVvvX17jkpkKVd8TeeutA/FJAeFbLQfXnyQ3o4qY7W+c5cxQ==",
       "dev": true,
       "requires": {
-        "array-back": "^3.1.0",
-        "cache-point": "^0.4.1",
-        "common-sequence": "^1.0.2",
-        "file-set": "^2.0.0",
-        "handlebars": "^4.1.2",
-        "marked": "^0.6.2",
-        "object-get": "^2.1.0",
-        "reduce-flatten": "^2.0.0",
-        "reduce-unique": "^2.0.1",
-        "reduce-without": "^1.0.1",
-        "test-value": "^3.0.0",
-        "walk-back": "^3.0.1"
+        "array-back": "3.1.0",
+        "cache-point": "0.4.1",
+        "common-sequence": "1.0.2",
+        "file-set": "2.0.1",
+        "handlebars": "4.1.2",
+        "marked": "0.6.2",
+        "object-get": "2.1.0",
+        "reduce-flatten": "2.0.0",
+        "reduce-unique": "2.0.1",
+        "reduce-without": "1.0.1",
+        "test-value": "3.0.0",
+        "walk-back": "3.0.1"
       },
       "dependencies": {
         "reduce-flatten": {
@@ -2989,7 +3061,7 @@
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "requires": {
-        "esutils": "^2.0.2"
+        "esutils": "2.0.2"
       }
     },
     "dot-case": {
@@ -2997,7 +3069,7 @@
       "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-2.1.1.tgz",
       "integrity": "sha1-NNzzf1Co6TwrO8qLt/uRVcfaO+4=",
       "requires": {
-        "no-case": "^2.2.0"
+        "no-case": "2.3.2"
       }
     },
     "duplexify": {
@@ -3006,10 +3078,10 @@
       "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
       "dev": true,
       "requires": {
-        "end-of-stream": "^1.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0",
-        "stream-shift": "^1.0.0"
+        "end-of-stream": "1.4.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "stream-shift": "1.0.0"
       }
     },
     "each-props": {
@@ -3018,8 +3090,8 @@
       "integrity": "sha512-vV0Hem3zAGkJAyU7JSjixeU66rwdynTAa1vofCrSA5fEln+m67Az9CcnkVD776/fsN/UjIWmBDoNRS6t6G9RfA==",
       "dev": true,
       "requires": {
-        "is-plain-object": "^2.0.1",
-        "object.defaults": "^1.1.0"
+        "is-plain-object": "2.0.4",
+        "object.defaults": "1.1.0"
       }
     },
     "electron-to-chromium": {
@@ -3040,7 +3112,7 @@
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "dev": true,
       "requires": {
-        "once": "^1.4.0"
+        "once": "1.4.0"
       }
     },
     "entities": {
@@ -3055,7 +3127,7 @@
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "dev": true,
       "requires": {
-        "is-arrayish": "^0.2.1"
+        "is-arrayish": "0.2.1"
       }
     },
     "es5-ext": {
@@ -3064,9 +3136,9 @@
       "integrity": "sha512-3NMEhi57E31qdzmYp2jwRArIUsj1HI/RxbQ4bgnSB+AIKIxsAmTiK83bYMifIcpWvEc3P1X30DhUKOqEtF/kvg==",
       "dev": true,
       "requires": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.1",
-        "next-tick": "^1.0.0"
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1",
+        "next-tick": "1.0.0"
       }
     },
     "es6-error": {
@@ -3081,9 +3153,9 @@
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
+        "d": "1.0.0",
+        "es5-ext": "0.10.49",
+        "es6-symbol": "3.1.1"
       }
     },
     "es6-symbol": {
@@ -3092,8 +3164,8 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
+        "d": "1.0.0",
+        "es5-ext": "0.10.49"
       }
     },
     "es6-weak-map": {
@@ -3102,10 +3174,10 @@
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.14",
-        "es6-iterator": "^2.0.1",
-        "es6-symbol": "^3.1.1"
+        "d": "1.0.0",
+        "es5-ext": "0.10.49",
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1"
       }
     },
     "escape-string-regexp": {
@@ -3120,44 +3192,44 @@
       "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
       "dev": true,
       "requires": {
-        "ajv": "^5.3.0",
-        "babel-code-frame": "^6.22.0",
-        "chalk": "^2.1.0",
-        "concat-stream": "^1.6.0",
-        "cross-spawn": "^5.1.0",
-        "debug": "^3.1.0",
-        "doctrine": "^2.1.0",
-        "eslint-scope": "^3.7.1",
-        "eslint-visitor-keys": "^1.0.0",
-        "espree": "^3.5.4",
-        "esquery": "^1.0.0",
-        "esutils": "^2.0.2",
-        "file-entry-cache": "^2.0.0",
-        "functional-red-black-tree": "^1.0.1",
-        "glob": "^7.1.2",
-        "globals": "^11.0.1",
-        "ignore": "^3.3.3",
-        "imurmurhash": "^0.1.4",
-        "inquirer": "^3.0.6",
-        "is-resolvable": "^1.0.0",
-        "js-yaml": "^3.9.1",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.3.0",
-        "lodash": "^4.17.4",
-        "minimatch": "^3.0.2",
-        "mkdirp": "^0.5.1",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.8.2",
-        "path-is-inside": "^1.0.2",
-        "pluralize": "^7.0.0",
-        "progress": "^2.0.0",
-        "regexpp": "^1.0.1",
-        "require-uncached": "^1.0.3",
-        "semver": "^5.3.0",
-        "strip-ansi": "^4.0.0",
-        "strip-json-comments": "~2.0.1",
+        "ajv": "5.5.2",
+        "babel-code-frame": "6.26.0",
+        "chalk": "2.4.2",
+        "concat-stream": "1.6.2",
+        "cross-spawn": "5.1.0",
+        "debug": "3.1.0",
+        "doctrine": "2.1.0",
+        "eslint-scope": "3.7.1",
+        "eslint-visitor-keys": "1.0.0",
+        "espree": "3.5.4",
+        "esquery": "1.0.1",
+        "esutils": "2.0.2",
+        "file-entry-cache": "2.0.0",
+        "functional-red-black-tree": "1.0.1",
+        "glob": "7.1.2",
+        "globals": "11.11.0",
+        "ignore": "3.3.7",
+        "imurmurhash": "0.1.4",
+        "inquirer": "3.3.0",
+        "is-resolvable": "1.1.0",
+        "js-yaml": "3.13.1",
+        "json-stable-stringify-without-jsonify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.11",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "optionator": "0.8.2",
+        "path-is-inside": "1.0.2",
+        "pluralize": "7.0.0",
+        "progress": "2.0.0",
+        "regexpp": "1.1.0",
+        "require-uncached": "1.0.3",
+        "semver": "5.5.0",
+        "strip-ansi": "4.0.0",
+        "strip-json-comments": "2.0.1",
         "table": "4.0.2",
-        "text-table": "~0.2.0"
+        "text-table": "0.2.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -3172,7 +3244,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -3181,9 +3253,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           }
         },
         "globals": {
@@ -3210,7 +3282,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         },
         "supports-color": {
@@ -3219,7 +3291,7 @@
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -3230,11 +3302,11 @@
       "integrity": "sha1-nYhu2oxlxnVo5g6UJdmfYXitCNE=",
       "dev": true,
       "requires": {
-        "eslint": ">= 3",
-        "eslint-config-standard": ">=7.0.0",
-        "eslint-plugin-import": ">=2.2.0",
-        "eslint-plugin-promise": ">=3.5.0",
-        "eslint-plugin-standard": ">=2.1.1"
+        "eslint": "5.14.1",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.8.0",
+        "eslint-plugin-promise": "3.6.0",
+        "eslint-plugin-standard": "3.0.1"
       },
       "dependencies": {
         "@babel/code-frame": {
@@ -3243,7 +3315,7 @@
           "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
           "dev": true,
           "requires": {
-            "@babel/highlight": "^7.0.0"
+            "@babel/highlight": "7.0.0"
           }
         },
         "acorn": {
@@ -3264,10 +3336,10 @@
           "integrity": "sha512-XDN92U311aINL77ieWHmqCcNlwjoP5cHXDxIxbf2MaPYuCXOHS7gHH8jktxeK5omgd52XbSTX6a4Piwd1pQmzA==",
           "dev": true,
           "requires": {
-            "fast-deep-equal": "^2.0.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
+            "fast-deep-equal": "2.0.1",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.4.1",
+            "uri-js": "4.2.2"
           }
         },
         "ansi-escapes": {
@@ -3288,7 +3360,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -3297,9 +3369,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           }
         },
         "chardet": {
@@ -3314,11 +3386,11 @@
           "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
           "dev": true,
           "requires": {
-            "nice-try": "^1.0.4",
-            "path-key": "^2.0.1",
-            "semver": "^5.5.0",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
+            "nice-try": "1.0.5",
+            "path-key": "2.0.1",
+            "semver": "5.6.0",
+            "shebang-command": "1.2.0",
+            "which": "1.3.0"
           }
         },
         "debug": {
@@ -3327,7 +3399,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.1"
           }
         },
         "doctrine": {
@@ -3336,7 +3408,7 @@
           "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
           "dev": true,
           "requires": {
-            "esutils": "^2.0.2"
+            "esutils": "2.0.2"
           }
         },
         "eslint": {
@@ -3345,42 +3417,42 @@
           "integrity": "sha512-CyUMbmsjxedx8B0mr79mNOqetvkbij/zrXnFeK2zc3pGRn3/tibjiNAv/3UxFEyfMDjh+ZqTrJrEGBFiGfD5Og==",
           "dev": true,
           "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "ajv": "^6.9.1",
-            "chalk": "^2.1.0",
-            "cross-spawn": "^6.0.5",
-            "debug": "^4.0.1",
-            "doctrine": "^3.0.0",
-            "eslint-scope": "^4.0.0",
-            "eslint-utils": "^1.3.1",
-            "eslint-visitor-keys": "^1.0.0",
-            "espree": "^5.0.1",
-            "esquery": "^1.0.1",
-            "esutils": "^2.0.2",
-            "file-entry-cache": "^5.0.1",
-            "functional-red-black-tree": "^1.0.1",
-            "glob": "^7.1.2",
-            "globals": "^11.7.0",
-            "ignore": "^4.0.6",
-            "import-fresh": "^3.0.0",
-            "imurmurhash": "^0.1.4",
-            "inquirer": "^6.2.2",
-            "js-yaml": "^3.12.0",
-            "json-stable-stringify-without-jsonify": "^1.0.1",
-            "levn": "^0.3.0",
-            "lodash": "^4.17.11",
-            "minimatch": "^3.0.4",
-            "mkdirp": "^0.5.1",
-            "natural-compare": "^1.4.0",
-            "optionator": "^0.8.2",
-            "path-is-inside": "^1.0.2",
-            "progress": "^2.0.0",
-            "regexpp": "^2.0.1",
-            "semver": "^5.5.1",
-            "strip-ansi": "^4.0.0",
-            "strip-json-comments": "^2.0.1",
-            "table": "^5.2.3",
-            "text-table": "^0.2.0"
+            "@babel/code-frame": "7.0.0",
+            "ajv": "6.9.1",
+            "chalk": "2.4.2",
+            "cross-spawn": "6.0.5",
+            "debug": "4.1.1",
+            "doctrine": "3.0.0",
+            "eslint-scope": "4.0.0",
+            "eslint-utils": "1.3.1",
+            "eslint-visitor-keys": "1.0.0",
+            "espree": "5.0.1",
+            "esquery": "1.0.1",
+            "esutils": "2.0.2",
+            "file-entry-cache": "5.0.1",
+            "functional-red-black-tree": "1.0.1",
+            "glob": "7.1.2",
+            "globals": "11.11.0",
+            "ignore": "4.0.6",
+            "import-fresh": "3.0.0",
+            "imurmurhash": "0.1.4",
+            "inquirer": "6.2.2",
+            "js-yaml": "3.13.1",
+            "json-stable-stringify-without-jsonify": "1.0.1",
+            "levn": "0.3.0",
+            "lodash": "4.17.11",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "natural-compare": "1.4.0",
+            "optionator": "0.8.2",
+            "path-is-inside": "1.0.2",
+            "progress": "2.0.0",
+            "regexpp": "2.0.1",
+            "semver": "5.6.0",
+            "strip-ansi": "4.0.0",
+            "strip-json-comments": "2.0.1",
+            "table": "5.2.3",
+            "text-table": "0.2.0"
           }
         },
         "eslint-scope": {
@@ -3389,8 +3461,8 @@
           "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
           "dev": true,
           "requires": {
-            "esrecurse": "^4.1.0",
-            "estraverse": "^4.1.1"
+            "esrecurse": "4.2.0",
+            "estraverse": "4.2.0"
           }
         },
         "espree": {
@@ -3399,9 +3471,9 @@
           "integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
           "dev": true,
           "requires": {
-            "acorn": "^6.0.7",
-            "acorn-jsx": "^5.0.0",
-            "eslint-visitor-keys": "^1.0.0"
+            "acorn": "6.1.0",
+            "acorn-jsx": "5.0.1",
+            "eslint-visitor-keys": "1.0.0"
           }
         },
         "esquery": {
@@ -3410,7 +3482,7 @@
           "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
           "dev": true,
           "requires": {
-            "estraverse": "^4.0.0"
+            "estraverse": "4.2.0"
           }
         },
         "external-editor": {
@@ -3419,9 +3491,9 @@
           "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
           "dev": true,
           "requires": {
-            "chardet": "^0.7.0",
-            "iconv-lite": "^0.4.24",
-            "tmp": "^0.0.33"
+            "chardet": "0.7.0",
+            "iconv-lite": "0.4.24",
+            "tmp": "0.0.33"
           }
         },
         "fast-deep-equal": {
@@ -3436,7 +3508,7 @@
           "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
           "dev": true,
           "requires": {
-            "flat-cache": "^2.0.1"
+            "flat-cache": "2.0.1"
           }
         },
         "flat-cache": {
@@ -3445,7 +3517,7 @@
           "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
           "dev": true,
           "requires": {
-            "flatted": "^2.0.0",
+            "flatted": "2.0.0",
             "rimraf": "2.6.3",
             "write": "1.0.3"
           }
@@ -3468,7 +3540,7 @@
           "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "dev": true,
           "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
+            "safer-buffer": "2.1.2"
           }
         },
         "ignore": {
@@ -3483,19 +3555,19 @@
           "integrity": "sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==",
           "dev": true,
           "requires": {
-            "ansi-escapes": "^3.2.0",
-            "chalk": "^2.4.2",
-            "cli-cursor": "^2.1.0",
-            "cli-width": "^2.0.0",
-            "external-editor": "^3.0.3",
-            "figures": "^2.0.0",
-            "lodash": "^4.17.11",
+            "ansi-escapes": "3.2.0",
+            "chalk": "2.4.2",
+            "cli-cursor": "2.1.0",
+            "cli-width": "2.2.0",
+            "external-editor": "3.0.3",
+            "figures": "2.0.0",
+            "lodash": "4.17.11",
             "mute-stream": "0.0.7",
-            "run-async": "^2.2.0",
-            "rxjs": "^6.4.0",
-            "string-width": "^2.1.0",
-            "strip-ansi": "^5.0.0",
-            "through": "^2.3.6"
+            "run-async": "2.3.0",
+            "rxjs": "6.4.0",
+            "string-width": "2.1.1",
+            "strip-ansi": "5.0.0",
+            "through": "2.3.8"
           },
           "dependencies": {
             "strip-ansi": {
@@ -3504,7 +3576,7 @@
               "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
               "dev": true,
               "requires": {
-                "ansi-regex": "^4.0.0"
+                "ansi-regex": "4.0.0"
               }
             }
           }
@@ -3515,8 +3587,8 @@
           "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
           "dev": true,
           "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
+            "argparse": "1.0.9",
+            "esprima": "4.0.0"
           }
         },
         "json-schema-traverse": {
@@ -3537,7 +3609,7 @@
           "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "requires": {
-            "glob": "^7.1.3"
+            "glob": "7.1.3"
           },
           "dependencies": {
             "glob": {
@@ -3546,12 +3618,12 @@
               "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
               "dev": true,
               "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
               }
             }
           }
@@ -3568,9 +3640,9 @@
           "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.0",
-            "astral-regex": "^1.0.0",
-            "is-fullwidth-code-point": "^2.0.0"
+            "ansi-styles": "3.2.1",
+            "astral-regex": "1.0.0",
+            "is-fullwidth-code-point": "2.0.0"
           }
         },
         "strip-ansi": {
@@ -3579,7 +3651,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -3596,7 +3668,7 @@
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         },
         "table": {
@@ -3605,10 +3677,10 @@
           "integrity": "sha512-N2RsDAMvDLvYwFcwbPyF3VmVSSkuF+G1e+8inhBLtHpvwXGw4QRPEZhihQNeEN0i1up6/f6ObCJXNdlRG3YVyQ==",
           "dev": true,
           "requires": {
-            "ajv": "^6.9.1",
-            "lodash": "^4.17.11",
-            "slice-ansi": "^2.1.0",
-            "string-width": "^3.0.0"
+            "ajv": "6.9.1",
+            "lodash": "4.17.11",
+            "slice-ansi": "2.1.0",
+            "string-width": "3.0.0"
           },
           "dependencies": {
             "string-width": {
@@ -3617,9 +3689,9 @@
               "integrity": "sha512-rr8CUxBbvOZDUvc5lNIJ+OC1nPVpz+Siw9VBtUjB9b6jZehZLFt0JMCZzShFHIsI8cbhm0EsNIfWJMFV3cu3Ew==",
               "dev": true,
               "requires": {
-                "emoji-regex": "^7.0.1",
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^5.0.0"
+                "emoji-regex": "7.0.3",
+                "is-fullwidth-code-point": "2.0.0",
+                "strip-ansi": "5.0.0"
               }
             },
             "strip-ansi": {
@@ -3628,7 +3700,7 @@
               "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
               "dev": true,
               "requires": {
-                "ansi-regex": "^4.0.0"
+                "ansi-regex": "4.0.0"
               }
             }
           }
@@ -3639,7 +3711,7 @@
           "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
           "dev": true,
           "requires": {
-            "mkdirp": "^0.5.1"
+            "mkdirp": "0.5.1"
           }
         }
       }
@@ -3650,7 +3722,7 @@
       "integrity": "sha512-ag8YEyBXsm3nmOv1Hz991VtNNDMRa+MNy8cY47Pl4bw6iuzqKbJajXdqUpiw13STdLLrznxgm1hj9NhxeOYq0A==",
       "dev": true,
       "requires": {
-        "get-stdin": "^5.0.1"
+        "get-stdin": "5.0.1"
       }
     },
     "eslint-config-standard": {
@@ -3665,11 +3737,11 @@
       "integrity": "sha1-J4h0Q1psRuwdlPoLH/SU4w7wQpA=",
       "dev": true,
       "requires": {
-        "chalk": "^1.0.0",
+        "chalk": "1.1.3",
         "coalescy": "1.0.0",
-        "extend": "^3.0.0",
-        "minimist": "^1.2.0",
-        "text-table": "^0.2.0"
+        "extend": "3.0.2",
+        "minimist": "1.2.0",
+        "text-table": "0.2.0"
       },
       "dependencies": {
         "minimist": {
@@ -3686,8 +3758,8 @@
       "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
       "dev": true,
       "requires": {
-        "debug": "^2.6.9",
-        "resolve": "^1.5.0"
+        "debug": "2.6.9",
+        "resolve": "1.5.0"
       },
       "dependencies": {
         "debug": {
@@ -3707,8 +3779,8 @@
       "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
       "dev": true,
       "requires": {
-        "debug": "^2.6.8",
-        "pkg-dir": "^1.0.0"
+        "debug": "2.6.9",
+        "pkg-dir": "1.0.0"
       },
       "dependencies": {
         "debug": {
@@ -3728,16 +3800,16 @@
       "integrity": "sha512-Rf7dfKJxZ16QuTgVv1OYNxkZcsu/hULFnC+e+w0Gzi6jMC3guQoWQgxYxc54IDRinlb6/0v5z/PxxIKmVctN+g==",
       "dev": true,
       "requires": {
-        "builtin-modules": "^1.1.1",
-        "contains-path": "^0.1.0",
-        "debug": "^2.6.8",
+        "builtin-modules": "1.1.1",
+        "contains-path": "0.1.0",
+        "debug": "2.6.9",
         "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "^0.3.1",
-        "eslint-module-utils": "^2.1.1",
-        "has": "^1.0.1",
-        "lodash.cond": "^4.3.0",
-        "minimatch": "^3.0.3",
-        "read-pkg-up": "^2.0.0"
+        "eslint-import-resolver-node": "0.3.2",
+        "eslint-module-utils": "2.1.1",
+        "has": "1.0.1",
+        "lodash.cond": "4.5.2",
+        "minimatch": "3.0.4",
+        "read-pkg-up": "2.0.0"
       },
       "dependencies": {
         "debug": {
@@ -3755,8 +3827,8 @@
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
-            "esutils": "^2.0.2",
-            "isarray": "^1.0.0"
+            "esutils": "2.0.2",
+            "isarray": "1.0.0"
           }
         }
       }
@@ -3767,9 +3839,9 @@
       "integrity": "sha512-xhPXrh0Vl/b7870uEbaumb2Q+LxaEcOQ3kS1jtIXanBAwpMre1l5q/l2l/hESYJGEFKuI78bp6Uw50hlpr7B+g==",
       "dev": true,
       "requires": {
-        "ignore": "^3.3.6",
-        "minimatch": "^3.0.4",
-        "resolve": "^1.3.3",
+        "ignore": "3.3.7",
+        "minimatch": "3.0.4",
+        "resolve": "1.5.0",
         "semver": "5.3.0"
       },
       "dependencies": {
@@ -3799,8 +3871,8 @@
       "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
       "dev": true,
       "requires": {
-        "esrecurse": "^4.1.0",
-        "estraverse": "^4.1.1"
+        "esrecurse": "4.2.0",
+        "estraverse": "4.2.0"
       }
     },
     "eslint-utils": {
@@ -3821,8 +3893,8 @@
       "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
       "dev": true,
       "requires": {
-        "acorn": "^5.5.0",
-        "acorn-jsx": "^3.0.0"
+        "acorn": "5.7.3",
+        "acorn-jsx": "3.0.1"
       },
       "dependencies": {
         "acorn": {
@@ -3845,7 +3917,7 @@
       "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.0.0"
+        "estraverse": "4.2.0"
       }
     },
     "esrecurse": {
@@ -3854,8 +3926,8 @@
       "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
       "dev": true,
       "requires": {
-        "estraverse": "^4.1.0",
-        "object-assign": "^4.0.1"
+        "estraverse": "4.2.0",
+        "object-assign": "4.1.1"
       }
     },
     "estraverse": {
@@ -3876,8 +3948,8 @@
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
+        "d": "1.0.0",
+        "es5-ext": "0.10.49"
       }
     },
     "execa": {
@@ -3886,13 +3958,13 @@
       "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
       "dev": true,
       "requires": {
-        "cross-spawn": "^5.0.1",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
+        "cross-spawn": "5.1.0",
+        "get-stream": "3.0.0",
+        "is-stream": "1.1.0",
+        "npm-run-path": "2.0.2",
+        "p-finally": "1.0.0",
+        "signal-exit": "3.0.2",
+        "strip-eof": "1.0.0"
       }
     },
     "expand-tilde": {
@@ -3901,7 +3973,7 @@
       "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
       "dev": true,
       "requires": {
-        "homedir-polyfill": "^1.0.1"
+        "homedir-polyfill": "1.0.3"
       }
     },
     "extend": {
@@ -3915,8 +3987,8 @@
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "requires": {
-        "assign-symbols": "^1.0.0",
-        "is-extendable": "^1.0.1"
+        "assign-symbols": "1.0.0",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -3925,7 +3997,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -3936,9 +4008,9 @@
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "dev": true,
       "requires": {
-        "chardet": "^0.4.0",
-        "iconv-lite": "^0.4.17",
-        "tmp": "^0.0.33"
+        "chardet": "0.4.2",
+        "iconv-lite": "0.4.24",
+        "tmp": "0.0.33"
       }
     },
     "faker": {
@@ -3953,10 +4025,10 @@
       "integrity": "sha512-k9oEhlyc0FrVh25qYuSELjr8oxsCoc4/LEZfg2iJJrfEk/tZL9bCoJE47gqAvI2m/AUjluCS4+3I0eTx8n3AEw==",
       "dev": true,
       "requires": {
-        "ansi-gray": "^0.1.1",
-        "color-support": "^1.1.3",
-        "parse-node-version": "^1.0.0",
-        "time-stamp": "^1.0.0"
+        "ansi-gray": "0.1.1",
+        "color-support": "1.1.3",
+        "parse-node-version": "1.0.1",
+        "time-stamp": "1.1.0"
       }
     },
     "fast-deep-equal": {
@@ -3971,11 +4043,11 @@
       "integrity": "sha512-QSSKZwDHLznUXdVtWvsfdbojmYI5igtVwfVbKW/LwNsy0JdM1cZ5yyP1kl5npg2ddugdnOk66QlNhbJ1c1hErg==",
       "dev": true,
       "requires": {
-        "@mrmlnc/readdir-enhanced": "^2.2.1",
-        "glob-parent": "^3.1.0",
-        "is-glob": "^4.0.0",
-        "merge2": "^1.2.1",
-        "micromatch": "^3.1.8"
+        "@mrmlnc/readdir-enhanced": "2.2.1",
+        "glob-parent": "3.1.0",
+        "is-glob": "4.0.0",
+        "merge2": "1.2.1",
+        "micromatch": "3.1.10"
       },
       "dependencies": {
         "arr-diff": {
@@ -3996,16 +4068,16 @@
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.1",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "extend-shallow": {
@@ -4014,7 +4086,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -4034,13 +4106,13 @@
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.1",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -4049,7 +4121,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -4058,7 +4130,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-descriptor": {
@@ -4067,9 +4139,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
               }
             },
             "kind-of": {
@@ -4086,14 +4158,14 @@
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.1",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -4102,7 +4174,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -4111,7 +4183,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -4122,10 +4194,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -4134,7 +4206,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -4145,8 +4217,8 @@
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
+            "is-glob": "3.1.0",
+            "path-dirname": "1.0.2"
           },
           "dependencies": {
             "is-glob": {
@@ -4155,7 +4227,7 @@
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
               "dev": true,
               "requires": {
-                "is-extglob": "^2.1.0"
+                "is-extglob": "2.1.1"
               }
             }
           }
@@ -4166,7 +4238,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -4175,7 +4247,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -4186,7 +4258,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -4195,7 +4267,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -4212,7 +4284,7 @@
           "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
           "dev": true,
           "requires": {
-            "is-extglob": "^2.1.1"
+            "is-extglob": "2.1.1"
           }
         },
         "is-number": {
@@ -4221,7 +4293,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -4230,7 +4302,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -4253,19 +4325,19 @@
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.9",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.1",
+            "to-regex": "3.0.2"
           }
         }
       }
@@ -4288,7 +4360,7 @@
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.5"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "file-entry-cache": {
@@ -4297,8 +4369,8 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "^1.2.1",
-        "object-assign": "^4.0.1"
+        "flat-cache": "1.3.4",
+        "object-assign": "4.1.1"
       }
     },
     "file-set": {
@@ -4307,8 +4379,8 @@
       "integrity": "sha512-XgOUUpgR6FbbfYcniLw0qm1Am7PnNYIAkd+eXxRt42LiYhjaso0WiuQ+VmrNdtwotyM+cLCfZ56AZrySP3QnKA==",
       "dev": true,
       "requires": {
-        "array-back": "^2.0.0",
-        "glob": "^7.1.3"
+        "array-back": "2.0.0",
+        "glob": "7.1.4"
       },
       "dependencies": {
         "array-back": {
@@ -4317,7 +4389,7 @@
           "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
           "dev": true,
           "requires": {
-            "typical": "^2.6.1"
+            "typical": "2.6.1"
           }
         },
         "glob": {
@@ -4326,12 +4398,12 @@
           "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         }
       }
@@ -4342,8 +4414,8 @@
       "integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
       "dev": true,
       "requires": {
-        "is-object": "~1.0.1",
-        "merge-descriptors": "~1.0.0"
+        "is-object": "1.0.1",
+        "merge-descriptors": "1.0.1"
       }
     },
     "find-cache-dir": {
@@ -4352,9 +4424,9 @@
       "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
       "dev": true,
       "requires": {
-        "commondir": "^1.0.1",
-        "make-dir": "^2.0.0",
-        "pkg-dir": "^3.0.0"
+        "commondir": "1.0.1",
+        "make-dir": "2.1.0",
+        "pkg-dir": "3.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -4363,7 +4435,7 @@
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
-            "locate-path": "^3.0.0"
+            "locate-path": "3.0.0"
           }
         },
         "locate-path": {
@@ -4372,8 +4444,8 @@
           "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "dev": true,
           "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
+            "p-locate": "3.0.0",
+            "path-exists": "3.0.0"
           }
         },
         "p-limit": {
@@ -4382,7 +4454,7 @@
           "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
           "dev": true,
           "requires": {
-            "p-try": "^2.0.0"
+            "p-try": "2.2.0"
           }
         },
         "p-locate": {
@@ -4391,7 +4463,7 @@
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "requires": {
-            "p-limit": "^2.0.0"
+            "p-limit": "2.2.0"
           }
         },
         "p-try": {
@@ -4412,7 +4484,7 @@
           "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
           "dev": true,
           "requires": {
-            "find-up": "^3.0.0"
+            "find-up": "3.0.0"
           }
         }
       }
@@ -4423,7 +4495,7 @@
       "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
       "dev": true,
       "requires": {
-        "array-back": "^3.0.1"
+        "array-back": "3.1.0"
       }
     },
     "find-up": {
@@ -4432,8 +4504,8 @@
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
-        "path-exists": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "findup-sync": {
@@ -4442,10 +4514,10 @@
       "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
       "dev": true,
       "requires": {
-        "detect-file": "^1.0.0",
-        "is-glob": "^3.1.0",
-        "micromatch": "^3.0.4",
-        "resolve-dir": "^1.0.1"
+        "detect-file": "1.0.0",
+        "is-glob": "3.1.0",
+        "micromatch": "3.1.10",
+        "resolve-dir": "1.0.1"
       },
       "dependencies": {
         "arr-diff": {
@@ -4466,16 +4538,16 @@
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.1",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "extend-shallow": {
@@ -4484,7 +4556,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -4504,13 +4576,13 @@
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.1",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -4519,7 +4591,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -4528,7 +4600,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-descriptor": {
@@ -4537,9 +4609,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
               }
             },
             "kind-of": {
@@ -4556,14 +4628,14 @@
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.1",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -4572,7 +4644,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -4581,7 +4653,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -4592,10 +4664,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -4604,7 +4676,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -4615,7 +4687,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -4624,7 +4696,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -4635,7 +4707,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -4644,7 +4716,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -4661,7 +4733,7 @@
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
-            "is-extglob": "^2.1.0"
+            "is-extglob": "2.1.1"
           }
         },
         "is-number": {
@@ -4670,7 +4742,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -4679,7 +4751,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -4702,19 +4774,19 @@
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.9",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.1",
+            "to-regex": "3.0.2"
           }
         }
       }
@@ -4725,11 +4797,11 @@
       "integrity": "sha512-jQp949ZmEbiYHk3gkbdtpJ0G1+kgtLQBNdP5edFP7Fh+WAYceLQz6yO1SBj72Xkg8GVyTB3bBzAYrHJVh5Xd5g==",
       "dev": true,
       "requires": {
-        "expand-tilde": "^2.0.2",
-        "is-plain-object": "^2.0.3",
-        "object.defaults": "^1.1.0",
-        "object.pick": "^1.2.0",
-        "parse-filepath": "^1.0.1"
+        "expand-tilde": "2.0.2",
+        "is-plain-object": "2.0.4",
+        "object.defaults": "1.1.0",
+        "object.pick": "1.3.0",
+        "parse-filepath": "1.0.2"
       }
     },
     "flagged-respawn": {
@@ -4744,10 +4816,10 @@
       "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
       "dev": true,
       "requires": {
-        "circular-json": "^0.3.1",
-        "graceful-fs": "^4.1.2",
-        "rimraf": "~2.6.2",
-        "write": "^0.2.1"
+        "circular-json": "0.3.3",
+        "graceful-fs": "4.1.11",
+        "rimraf": "2.6.3",
+        "write": "0.2.1"
       }
     },
     "flatted": {
@@ -4762,8 +4834,8 @@
       "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.3.6"
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6"
       },
       "dependencies": {
         "process-nextick-args": {
@@ -4778,13 +4850,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -4793,7 +4865,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -4803,7 +4875,7 @@
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz",
       "integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
       "requires": {
-        "debug": "^3.2.6"
+        "debug": "3.2.6"
       },
       "dependencies": {
         "debug": {
@@ -4811,7 +4883,7 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.1"
           }
         },
         "ms": {
@@ -4833,8 +4905,8 @@
       "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
       "dev": true,
       "requires": {
-        "cross-spawn": "^4",
-        "signal-exit": "^3.0.0"
+        "cross-spawn": "4.0.2",
+        "signal-exit": "3.0.2"
       },
       "dependencies": {
         "cross-spawn": {
@@ -4843,8 +4915,8 @@
           "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
           "dev": true,
           "requires": {
-            "lru-cache": "^4.0.1",
-            "which": "^1.2.9"
+            "lru-cache": "4.1.1",
+            "which": "1.3.0"
           }
         }
       }
@@ -4854,9 +4926,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.7",
+        "mime-types": "2.1.22"
       }
     },
     "formatio": {
@@ -4865,7 +4937,7 @@
       "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
       "dev": true,
       "requires": {
-        "samsam": "1.x"
+        "samsam": "1.3.0"
       }
     },
     "formidable": {
@@ -4879,7 +4951,7 @@
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
-        "map-cache": "^0.2.2"
+        "map-cache": "0.2.2"
       }
     },
     "fs-mkdirp-stream": {
@@ -4888,8 +4960,8 @@
       "integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "through2": "^2.0.3"
+        "graceful-fs": "4.1.11",
+        "through2": "2.0.5"
       }
     },
     "fs-then-native": {
@@ -4911,8 +4983,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "^2.9.2",
-        "node-pre-gyp": "^0.10.0"
+        "nan": "2.12.1",
+        "node-pre-gyp": "0.10.3"
       },
       "dependencies": {
         "abbrev": {
@@ -4938,8 +5010,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.6"
           }
         },
         "balanced-match": {
@@ -4952,7 +5024,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "balanced-match": "^1.0.0",
+            "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -5016,7 +5088,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.3.5"
           }
         },
         "fs.realpath": {
@@ -5031,14 +5103,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.3"
           }
         },
         "glob": {
@@ -5047,12 +5119,12 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "has-unicode": {
@@ -5067,7 +5139,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
+            "safer-buffer": "2.1.2"
           }
         },
         "ignore-walk": {
@@ -5076,7 +5148,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minimatch": "^3.0.4"
+            "minimatch": "3.0.4"
           }
         },
         "inflight": {
@@ -5085,8 +5157,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
@@ -5105,7 +5177,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "isarray": {
@@ -5119,7 +5191,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "minimist": {
@@ -5132,8 +5204,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.0"
+            "safe-buffer": "5.1.2",
+            "yallist": "3.0.3"
           }
         },
         "minizlib": {
@@ -5142,7 +5214,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.3.5"
           }
         },
         "mkdirp": {
@@ -5165,9 +5237,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "^2.1.2",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
+            "debug": "2.6.9",
+            "iconv-lite": "0.4.24",
+            "sax": "1.2.4"
           }
         },
         "node-pre-gyp": {
@@ -5176,16 +5248,16 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.1",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.2.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
+            "detect-libc": "1.0.3",
+            "mkdirp": "0.5.1",
+            "needle": "2.2.4",
+            "nopt": "4.0.1",
+            "npm-packlist": "1.2.0",
+            "npmlog": "4.1.2",
+            "rc": "1.2.8",
+            "rimraf": "2.6.3",
+            "semver": "5.6.0",
+            "tar": "4.4.8"
           }
         },
         "nopt": {
@@ -5194,8 +5266,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
           }
         },
         "npm-bundled": {
@@ -5210,8 +5282,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.5"
           }
         },
         "npmlog": {
@@ -5220,10 +5292,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "1.1.5",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           }
         },
         "number-is-nan": {
@@ -5242,7 +5314,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "os-homedir": {
@@ -5263,8 +5335,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
           }
         },
         "path-is-absolute": {
@@ -5285,10 +5357,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "^0.6.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
+            "deep-extend": "0.6.0",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -5305,13 +5377,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "rimraf": {
@@ -5320,7 +5392,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "glob": "^7.1.3"
+            "glob": "7.1.3"
           }
         },
         "safe-buffer": {
@@ -5363,9 +5435,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "string_decoder": {
@@ -5374,7 +5446,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.2"
           }
         },
         "strip-ansi": {
@@ -5382,7 +5454,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "strip-json-comments": {
@@ -5397,13 +5469,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "chownr": "^1.1.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.4",
-            "minizlib": "^1.1.1",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
+            "chownr": "1.1.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.3.5",
+            "minizlib": "1.2.1",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.2",
+            "yallist": "3.0.3"
           }
         },
         "util-deprecate": {
@@ -5418,7 +5490,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "^1.0.2 || 2"
+            "string-width": "1.0.2"
           }
         },
         "wrappy": {
@@ -5481,12 +5553,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "glob-stream": {
@@ -5495,16 +5567,16 @@
       "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
       "dev": true,
       "requires": {
-        "extend": "^3.0.0",
-        "glob": "^7.1.1",
-        "glob-parent": "^3.1.0",
-        "is-negated-glob": "^1.0.0",
-        "ordered-read-streams": "^1.0.0",
-        "pumpify": "^1.3.5",
-        "readable-stream": "^2.1.5",
-        "remove-trailing-separator": "^1.0.1",
-        "to-absolute-glob": "^2.0.0",
-        "unique-stream": "^2.0.2"
+        "extend": "3.0.2",
+        "glob": "7.1.2",
+        "glob-parent": "3.1.0",
+        "is-negated-glob": "1.0.0",
+        "ordered-read-streams": "1.0.1",
+        "pumpify": "1.5.1",
+        "readable-stream": "2.3.3",
+        "remove-trailing-separator": "1.1.0",
+        "to-absolute-glob": "2.0.2",
+        "unique-stream": "2.3.1"
       },
       "dependencies": {
         "glob-parent": {
@@ -5513,8 +5585,8 @@
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
+            "is-glob": "3.1.0",
+            "path-dirname": "1.0.2"
           }
         },
         "is-extglob": {
@@ -5529,7 +5601,7 @@
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
-            "is-extglob": "^2.1.0"
+            "is-extglob": "2.1.1"
           }
         }
       }
@@ -5546,12 +5618,12 @@
       "integrity": "sha512-8tWsULNEPHKQ2MR4zXuzSmqbdyV5PtwwCaWSGQ1WwHsJ07ilNeN1JB8ntxhckbnpSHaf9dXFUHzIWvm1I13dsg==",
       "dev": true,
       "requires": {
-        "anymatch": "^2.0.0",
-        "async-done": "^1.2.0",
-        "chokidar": "^2.0.0",
-        "is-negated-glob": "^1.0.0",
-        "just-debounce": "^1.0.0",
-        "object.defaults": "^1.1.0"
+        "anymatch": "2.0.0",
+        "async-done": "1.3.1",
+        "chokidar": "2.1.2",
+        "is-negated-glob": "1.0.0",
+        "just-debounce": "1.0.0",
+        "object.defaults": "1.1.0"
       }
     },
     "global-modules": {
@@ -5560,9 +5632,9 @@
       "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
       "dev": true,
       "requires": {
-        "global-prefix": "^1.0.1",
-        "is-windows": "^1.0.1",
-        "resolve-dir": "^1.0.0"
+        "global-prefix": "1.0.2",
+        "is-windows": "1.0.2",
+        "resolve-dir": "1.0.1"
       }
     },
     "global-prefix": {
@@ -5571,11 +5643,11 @@
       "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
       "dev": true,
       "requires": {
-        "expand-tilde": "^2.0.2",
-        "homedir-polyfill": "^1.0.1",
-        "ini": "^1.3.4",
-        "is-windows": "^1.0.1",
-        "which": "^1.2.14"
+        "expand-tilde": "2.0.2",
+        "homedir-polyfill": "1.0.3",
+        "ini": "1.3.5",
+        "is-windows": "1.0.2",
+        "which": "1.3.0"
       }
     },
     "globals": {
@@ -5590,11 +5662,11 @@
       "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
       "dev": true,
       "requires": {
-        "array-union": "^1.0.1",
-        "glob": "^7.0.3",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "array-union": "1.0.2",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "glogg": {
@@ -5603,7 +5675,7 @@
       "integrity": "sha512-5mwUoSuBk44Y4EshyiqcH95ZntbDdTQqA3QYSrxmzj28Ai0vXBGMH1ApSANH14j2sIRtqCEyg6PfsuP7ElOEDA==",
       "dev": true,
       "requires": {
-        "sparkles": "^1.0.0"
+        "sparkles": "1.0.1"
       }
     },
     "graceful-fs": {
@@ -5624,10 +5696,10 @@
       "integrity": "sha1-lXZsYB2t5Kd+0+eyttwDiBtZY2Y=",
       "dev": true,
       "requires": {
-        "glob-watcher": "^5.0.0",
-        "gulp-cli": "^2.0.0",
-        "undertaker": "^1.0.0",
-        "vinyl-fs": "^3.0.0"
+        "glob-watcher": "5.0.3",
+        "gulp-cli": "2.0.1",
+        "undertaker": "1.2.0",
+        "vinyl-fs": "3.0.3"
       },
       "dependencies": {
         "gulp-cli": {
@@ -5636,24 +5708,24 @@
           "integrity": "sha512-RxujJJdN8/O6IW2nPugl7YazhmrIEjmiVfPKrWt68r71UCaLKS71Hp0gpKT+F6qOUFtr7KqtifDKaAJPRVvMYQ==",
           "dev": true,
           "requires": {
-            "ansi-colors": "^1.0.1",
-            "archy": "^1.0.0",
-            "array-sort": "^1.0.0",
-            "color-support": "^1.1.3",
-            "concat-stream": "^1.6.0",
-            "copy-props": "^2.0.1",
-            "fancy-log": "^1.3.2",
-            "gulplog": "^1.0.0",
-            "interpret": "^1.1.0",
-            "isobject": "^3.0.1",
-            "liftoff": "^2.5.0",
-            "matchdep": "^2.0.0",
-            "mute-stdout": "^1.0.0",
-            "pretty-hrtime": "^1.0.0",
-            "replace-homedir": "^1.0.0",
-            "semver-greatest-satisfied-range": "^1.1.0",
-            "v8flags": "^3.0.1",
-            "yargs": "^7.1.0"
+            "ansi-colors": "1.1.0",
+            "archy": "1.0.0",
+            "array-sort": "1.0.0",
+            "color-support": "1.1.3",
+            "concat-stream": "1.6.2",
+            "copy-props": "2.0.4",
+            "fancy-log": "1.3.3",
+            "gulplog": "1.0.0",
+            "interpret": "1.2.0",
+            "isobject": "3.0.1",
+            "liftoff": "2.5.0",
+            "matchdep": "2.0.0",
+            "mute-stdout": "1.0.1",
+            "pretty-hrtime": "1.0.3",
+            "replace-homedir": "1.0.0",
+            "semver-greatest-satisfied-range": "1.1.0",
+            "v8flags": "3.1.2",
+            "yargs": "7.1.0"
           }
         },
         "isobject": {
@@ -5670,10 +5742,10 @@
       "integrity": "sha512-UqHS3AdxZyJCRxqnAX603Dj3k/Wx6hzcgmav3QcxvsIFq3Y8ZkU7iXd0O+JwD5ivqCc6o0r1S7tCB/xxLnuSNw==",
       "dev": true,
       "requires": {
-        "plugin-error": "^1.0.1",
+        "plugin-error": "1.0.1",
         "replace-ext": "0.0.1",
-        "through2": "^2.0.0",
-        "vinyl-sourcemaps-apply": "^0.2.0"
+        "through2": "2.0.5",
+        "vinyl-sourcemaps-apply": "0.2.1"
       },
       "dependencies": {
         "replace-ext": {
@@ -5690,17 +5762,17 @@
       "integrity": "sha512-SYLBRzPTew8T5Suh2U8jCSDKY+4NARua4aqjj8HOysBh2tSgT9u4jc1FYirAdPx1akUxxDeK++fqw6Jg0LkQRg==",
       "dev": true,
       "requires": {
-        "@gulp-sourcemaps/identity-map": "1.X",
-        "@gulp-sourcemaps/map-sources": "1.X",
-        "acorn": "5.X",
-        "convert-source-map": "1.X",
-        "css": "2.X",
-        "debug-fabulous": "1.X",
-        "detect-newline": "2.X",
-        "graceful-fs": "4.X",
-        "source-map": "~0.6.0",
-        "strip-bom-string": "1.X",
-        "through2": "2.X"
+        "@gulp-sourcemaps/identity-map": "1.0.2",
+        "@gulp-sourcemaps/map-sources": "1.0.0",
+        "acorn": "5.7.3",
+        "convert-source-map": "1.5.1",
+        "css": "2.2.4",
+        "debug-fabulous": "1.1.0",
+        "detect-newline": "2.1.0",
+        "graceful-fs": "4.1.11",
+        "source-map": "0.6.1",
+        "strip-bom-string": "1.0.0",
+        "through2": "2.0.5"
       },
       "dependencies": {
         "source-map": {
@@ -5717,7 +5789,7 @@
       "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
       "dev": true,
       "requires": {
-        "glogg": "^1.0.0"
+        "glogg": "1.0.2"
       }
     },
     "handlebars": {
@@ -5726,10 +5798,10 @@
       "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
       "dev": true,
       "requires": {
-        "neo-async": "^2.6.0",
-        "optimist": "^0.6.1",
-        "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4"
+        "neo-async": "2.6.1",
+        "optimist": "0.6.1",
+        "source-map": "0.6.1",
+        "uglify-js": "3.5.15"
       },
       "dependencies": {
         "source-map": {
@@ -5746,7 +5818,7 @@
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "dev": true,
       "requires": {
-        "function-bind": "^1.0.2"
+        "function-bind": "1.1.1"
       }
     },
     "has-ansi": {
@@ -5755,7 +5827,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "has-flag": {
@@ -5776,9 +5848,9 @@
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
-        "get-value": "^2.0.6",
-        "has-values": "^1.0.0",
-        "isobject": "^3.0.0"
+        "get-value": "2.0.6",
+        "has-values": "1.0.0",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -5795,8 +5867,8 @@
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -5805,7 +5877,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -5814,7 +5886,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -5825,7 +5897,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -5836,7 +5908,7 @@
       "integrity": "sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=",
       "dev": true,
       "requires": {
-        "is-stream": "^1.0.1"
+        "is-stream": "1.1.0"
       }
     },
     "he": {
@@ -5850,8 +5922,8 @@
       "resolved": "https://registry.npmjs.org/header-case/-/header-case-1.0.1.tgz",
       "integrity": "sha1-lTWXMZfBRLCWE81l0xfvGZY70C0=",
       "requires": {
-        "no-case": "^2.2.0",
-        "upper-case": "^1.1.3"
+        "no-case": "2.3.2",
+        "upper-case": "1.1.3"
       }
     },
     "home-or-tmp": {
@@ -5860,8 +5932,8 @@
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "dev": true,
       "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.1"
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
       }
     },
     "homedir-polyfill": {
@@ -5870,7 +5942,7 @@
       "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
       "dev": true,
       "requires": {
-        "parse-passwd": "^1.0.0"
+        "parse-passwd": "1.0.0"
       }
     },
     "hosted-git-info": {
@@ -5880,20 +5952,216 @@
       "dev": true
     },
     "husky": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-0.14.3.tgz",
-      "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-2.3.0.tgz",
+      "integrity": "sha512-A/ZQSEILoq+mQM3yC3RIBSaw1bYXdkKnyyKVSUiJl+iBjVZc5LQEXdGY1ZjrDxC4IzfRPiJ0IqzEQGCN5TQa/A==",
       "dev": true,
       "requires": {
-        "is-ci": "^1.0.10",
-        "normalize-path": "^1.0.0",
-        "strip-indent": "^2.0.0"
+        "cosmiconfig": "5.2.1",
+        "execa": "1.0.0",
+        "find-up": "3.0.0",
+        "get-stdin": "7.0.0",
+        "is-ci": "2.0.0",
+        "pkg-dir": "4.2.0",
+        "please-upgrade-node": "3.1.1",
+        "read-pkg": "5.1.1",
+        "run-node": "1.0.0",
+        "slash": "3.0.0"
       },
       "dependencies": {
-        "normalize-path": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "1.0.5",
+            "path-key": "2.0.1",
+            "semver": "5.5.0",
+            "shebang-command": "1.2.0",
+            "which": "1.3.0"
+          }
+        },
+        "execa": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz",
-          "integrity": "sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "6.0.5",
+            "get-stream": "4.1.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          }
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "3.0.0"
+          }
+        },
+        "get-stdin": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
+          "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
+          "dev": true
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "3.0.0",
+            "path-exists": "3.0.0"
+          }
+        },
+        "normalize-package-data": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+          "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "2.5.0",
+            "resolve": "1.11.0",
+            "semver": "5.5.0",
+            "validate-npm-package-license": "3.0.1"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+          "dev": true,
+          "requires": {
+            "p-try": "2.2.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "2.2.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.1",
+            "json-parse-better-errors": "1.0.2"
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        },
+        "path-parse": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+          "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+          "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+          "dev": true,
+          "requires": {
+            "find-up": "4.0.0"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.0.0.tgz",
+              "integrity": "sha512-zoH7ZWPkRdgwYCDVoQTzqjG8JSPANhtvLhh4KVUHyKnaUJJrNeFmWIkTcNuJmR3GLMEmGYEf2S2bjgx26JTF+Q==",
+              "dev": true,
+              "requires": {
+                "locate-path": "5.0.0"
+              }
+            },
+            "locate-path": {
+              "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+              "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+              "dev": true,
+              "requires": {
+                "p-locate": "4.1.0"
+              }
+            },
+            "p-locate": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+              "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+              "dev": true,
+              "requires": {
+                "p-limit": "2.2.0"
+              }
+            }
+          }
+        },
+        "pump": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "dev": true,
+          "requires": {
+            "end-of-stream": "1.4.1",
+            "once": "1.4.0"
+          }
+        },
+        "read-pkg": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.1.1.tgz",
+          "integrity": "sha512-dFcTLQi6BZ+aFUaICg7er+/usEoqFdQxiEBsEMNGoipenihtxxtdrQuBXvyANCEI8VuUIVYFgeHGx9sLLvim4w==",
+          "dev": true,
+          "requires": {
+            "@types/normalize-package-data": "2.4.0",
+            "normalize-package-data": "2.5.0",
+            "parse-json": "4.0.0",
+            "type-fest": "0.4.1"
+          }
+        },
+        "resolve": {
+          "version": "1.11.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.0.tgz",
+          "integrity": "sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==",
+          "dev": true,
+          "requires": {
+            "path-parse": "1.0.6"
+          }
+        },
+        "slash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
           "dev": true
         }
       }
@@ -5904,7 +6172,7 @@
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
       "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": "2.1.2"
       }
     },
     "idtoken-verifier": {
@@ -5912,11 +6180,11 @@
       "resolved": "https://registry.npmjs.org/idtoken-verifier/-/idtoken-verifier-1.2.0.tgz",
       "integrity": "sha512-8jmmFHwdPz8L73zGNAXHHOV9yXNC+Z0TUBN5rafpoaFaLFltlIFr1JkQa3FYAETP23eSsulVw0sBiwrE8jqbUg==",
       "requires": {
-        "base64-js": "^1.2.0",
-        "crypto-js": "^3.1.9-1",
-        "jsbn": "^0.1.0",
-        "superagent": "^3.8.2",
-        "url-join": "^1.1.0"
+        "base64-js": "1.3.0",
+        "crypto-js": "3.1.9-1",
+        "jsbn": "0.1.1",
+        "superagent": "3.8.3",
+        "url-join": "1.1.0"
       }
     },
     "ignore": {
@@ -5931,8 +6199,8 @@
       "integrity": "sha512-pOnA9tfM3Uwics+SaBLCNyZZZbK+4PTu0OPZtLlMIrv17EdBoC15S9Kn8ckJ9TZTyKb3ywNE5y1yeDxxGA7nTQ==",
       "dev": true,
       "requires": {
-        "parent-module": "^1.0.0",
-        "resolve-from": "^4.0.0"
+        "parent-module": "1.0.0",
+        "resolve-from": "4.0.0"
       },
       "dependencies": {
         "resolve-from": {
@@ -5955,8 +6223,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -5976,20 +6244,20 @@
       "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^3.0.0",
-        "chalk": "^2.0.0",
-        "cli-cursor": "^2.1.0",
-        "cli-width": "^2.0.0",
-        "external-editor": "^2.0.4",
-        "figures": "^2.0.0",
-        "lodash": "^4.3.0",
+        "ansi-escapes": "3.2.0",
+        "chalk": "2.4.2",
+        "cli-cursor": "2.1.0",
+        "cli-width": "2.2.0",
+        "external-editor": "2.2.0",
+        "figures": "2.0.0",
+        "lodash": "4.17.11",
         "mute-stream": "0.0.7",
-        "run-async": "^2.2.0",
-        "rx-lite": "^4.0.8",
-        "rx-lite-aggregates": "^4.0.8",
-        "string-width": "^2.1.0",
-        "strip-ansi": "^4.0.0",
-        "through": "^2.3.6"
+        "run-async": "2.3.0",
+        "rx-lite": "4.0.8",
+        "rx-lite-aggregates": "4.0.8",
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
+        "through": "2.3.8"
       },
       "dependencies": {
         "ansi-regex": {
@@ -6004,7 +6272,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -6013,9 +6281,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           }
         },
         "has-flag": {
@@ -6030,7 +6298,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         },
         "supports-color": {
@@ -6039,7 +6307,7 @@
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -6056,7 +6324,7 @@
       "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
       "dev": true,
       "requires": {
-        "loose-envify": "^1.0.0"
+        "loose-envify": "1.3.1"
       }
     },
     "invert-kv": {
@@ -6071,8 +6339,8 @@
       "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
       "dev": true,
       "requires": {
-        "is-relative": "^1.0.0",
-        "is-windows": "^1.0.1"
+        "is-relative": "1.0.0",
+        "is-windows": "1.0.2"
       }
     },
     "is-accessor-descriptor": {
@@ -6081,7 +6349,7 @@
       "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
       "dev": true,
       "requires": {
-        "kind-of": "^6.0.0"
+        "kind-of": "6.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -6104,7 +6372,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "^1.0.0"
+        "binary-extensions": "1.13.0"
       }
     },
     "is-buffer": {
@@ -6118,16 +6386,16 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "^1.0.0"
+        "builtin-modules": "1.1.1"
       }
     },
     "is-ci": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
-      "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+      "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
       "dev": true,
       "requires": {
-        "ci-info": "^1.0.0"
+        "ci-info": "2.0.0"
       }
     },
     "is-data-descriptor": {
@@ -6136,7 +6404,7 @@
       "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
       "dev": true,
       "requires": {
-        "kind-of": "^6.0.0"
+        "kind-of": "6.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -6153,9 +6421,9 @@
       "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
       "dev": true,
       "requires": {
-        "is-accessor-descriptor": "^1.0.0",
-        "is-data-descriptor": "^1.0.0",
-        "kind-of": "^6.0.2"
+        "is-accessor-descriptor": "1.0.0",
+        "is-data-descriptor": "1.0.0",
+        "kind-of": "6.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -6165,6 +6433,12 @@
           "dev": true
         }
       }
+    },
+    "is-directory": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+      "dev": true
     },
     "is-extendable": {
       "version": "0.1.1",
@@ -6178,7 +6452,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-fullwidth-code-point": {
@@ -6192,7 +6466,7 @@
       "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz",
       "integrity": "sha1-fhR75HaNxGbbO/shzGCzHmrWk5M=",
       "requires": {
-        "lower-case": "^1.1.0"
+        "lower-case": "1.1.4"
       }
     },
     "is-negated-glob": {
@@ -6213,7 +6487,7 @@
       "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
       "dev": true,
       "requires": {
-        "is-number": "^4.0.0"
+        "is-number": "4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -6236,7 +6510,7 @@
       "integrity": "sha512-6Vz5Gc9s/sDA3JBVu0FzWufm8xaBsqy1zn8Q6gmvGP6nSDMw78aS4poBNeatWjaRpTpxxLn1WOndAiOlk+qY8A==",
       "dev": true,
       "requires": {
-        "is-path-inside": "^1.0.0"
+        "is-path-inside": "1.0.1"
       }
     },
     "is-path-inside": {
@@ -6245,7 +6519,7 @@
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
-        "path-is-inside": "^1.0.1"
+        "path-is-inside": "1.0.2"
       }
     },
     "is-plain-object": {
@@ -6254,7 +6528,7 @@
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -6277,7 +6551,7 @@
       "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
       "dev": true,
       "requires": {
-        "is-unc-path": "^1.0.0"
+        "is-unc-path": "1.0.0"
       }
     },
     "is-resolvable": {
@@ -6298,7 +6572,7 @@
       "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
       "dev": true,
       "requires": {
-        "unc-path-regex": "^0.1.2"
+        "unc-path-regex": "0.1.2"
       }
     },
     "is-upper-case": {
@@ -6306,7 +6580,7 @@
       "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz",
       "integrity": "sha1-jQsfp+eTOh5YSDYA7H2WYcuvdW8=",
       "requires": {
-        "upper-case": "^1.1.0"
+        "upper-case": "1.1.3"
       }
     },
     "is-utf8": {
@@ -6350,7 +6624,7 @@
       "integrity": "sha512-vrRztU9VRRFDyC+aklfLoeXyNdTfga2EI3udDGn4cZ6fpSXpHLV9X6CHvfoMCPtggg8zvDDmC4b9xfu0z6/llA==",
       "dev": true,
       "requires": {
-        "append-transform": "^1.0.0"
+        "append-transform": "1.0.0"
       }
     },
     "istanbul-lib-instrument": {
@@ -6359,13 +6633,13 @@
       "integrity": "sha512-ooVllVGT38HIk8MxDj/OIHXSYvH+1tq/Vb38s8ixt9GoJadXska4WkGY+0wkmtYCZNYtaARniH/DixUGGLZ0uA==",
       "dev": true,
       "requires": {
-        "@babel/generator": "^7.0.0",
-        "@babel/parser": "^7.0.0",
-        "@babel/template": "^7.0.0",
-        "@babel/traverse": "^7.0.0",
-        "@babel/types": "^7.0.0",
-        "istanbul-lib-coverage": "^2.0.3",
-        "semver": "^5.5.0"
+        "@babel/generator": "7.3.3",
+        "@babel/parser": "7.3.3",
+        "@babel/template": "7.2.2",
+        "@babel/traverse": "7.3.4",
+        "@babel/types": "7.3.4",
+        "istanbul-lib-coverage": "2.0.3",
+        "semver": "5.5.0"
       },
       "dependencies": {
         "@babel/code-frame": {
@@ -6374,7 +6648,7 @@
           "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
           "dev": true,
           "requires": {
-            "@babel/highlight": "^7.0.0"
+            "@babel/highlight": "7.0.0"
           }
         },
         "@babel/helper-function-name": {
@@ -6383,9 +6657,9 @@
           "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
           "dev": true,
           "requires": {
-            "@babel/helper-get-function-arity": "^7.0.0",
-            "@babel/template": "^7.1.0",
-            "@babel/types": "^7.0.0"
+            "@babel/helper-get-function-arity": "7.0.0",
+            "@babel/template": "7.2.2",
+            "@babel/types": "7.3.4"
           }
         },
         "@babel/helper-get-function-arity": {
@@ -6394,7 +6668,7 @@
           "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.0.0"
+            "@babel/types": "7.3.4"
           }
         },
         "@babel/template": {
@@ -6403,9 +6677,9 @@
           "integrity": "sha512-zRL0IMM02AUDwghf5LMSSDEz7sBCO2YnNmpg3uWTZj/v1rcG2BmQUvaGU8GhU8BvfMh1k2KIAYZ7Ji9KXPUg7g==",
           "dev": true,
           "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "@babel/parser": "^7.2.2",
-            "@babel/types": "^7.2.2"
+            "@babel/code-frame": "7.0.0",
+            "@babel/parser": "7.3.3",
+            "@babel/types": "7.3.4"
           }
         },
         "@babel/traverse": {
@@ -6414,15 +6688,15 @@
           "integrity": "sha512-TvTHKp6471OYEcE/91uWmhR6PrrYywQntCHSaZ8CM8Vmp+pjAusal4nGB2WCCQd0rvI7nOMKn9GnbcvTUz3/ZQ==",
           "dev": true,
           "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "@babel/generator": "^7.3.4",
-            "@babel/helper-function-name": "^7.1.0",
-            "@babel/helper-split-export-declaration": "^7.0.0",
-            "@babel/parser": "^7.3.4",
-            "@babel/types": "^7.3.4",
-            "debug": "^4.1.0",
-            "globals": "^11.1.0",
-            "lodash": "^4.17.11"
+            "@babel/code-frame": "7.0.0",
+            "@babel/generator": "7.3.4",
+            "@babel/helper-function-name": "7.1.0",
+            "@babel/helper-split-export-declaration": "7.0.0",
+            "@babel/parser": "7.3.4",
+            "@babel/types": "7.3.4",
+            "debug": "4.1.1",
+            "globals": "11.11.0",
+            "lodash": "4.17.11"
           },
           "dependencies": {
             "@babel/generator": {
@@ -6431,11 +6705,11 @@
               "integrity": "sha512-8EXhHRFqlVVWXPezBW5keTiQi/rJMQTg/Y9uVCEZ0CAF3PKtCCaVRnp64Ii1ujhkoDhhF1fVsImoN4yJ2uz4Wg==",
               "dev": true,
               "requires": {
-                "@babel/types": "^7.3.4",
-                "jsesc": "^2.5.1",
-                "lodash": "^4.17.11",
-                "source-map": "^0.5.0",
-                "trim-right": "^1.0.1"
+                "@babel/types": "7.3.4",
+                "jsesc": "2.5.2",
+                "lodash": "4.17.11",
+                "source-map": "0.5.7",
+                "trim-right": "1.0.1"
               }
             },
             "@babel/parser": {
@@ -6452,9 +6726,9 @@
           "integrity": "sha512-WEkp8MsLftM7O/ty580wAmZzN1nDmCACc5+jFzUt+GUFNNIi3LdRlueYz0YIlmJhlZx1QYDMZL5vdWCL0fNjFQ==",
           "dev": true,
           "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.11",
-            "to-fast-properties": "^2.0.0"
+            "esutils": "2.0.2",
+            "lodash": "4.17.11",
+            "to-fast-properties": "2.0.0"
           }
         },
         "debug": {
@@ -6463,7 +6737,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.1"
           }
         },
         "globals": {
@@ -6498,9 +6772,9 @@
       "integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
       "dev": true,
       "requires": {
-        "istanbul-lib-coverage": "^2.0.5",
-        "make-dir": "^2.1.0",
-        "supports-color": "^6.1.0"
+        "istanbul-lib-coverage": "2.0.5",
+        "make-dir": "2.1.0",
+        "supports-color": "6.1.0"
       },
       "dependencies": {
         "has-flag": {
@@ -6521,7 +6795,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -6532,11 +6806,11 @@
       "integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
       "dev": true,
       "requires": {
-        "debug": "^4.1.1",
-        "istanbul-lib-coverage": "^2.0.5",
-        "make-dir": "^2.1.0",
-        "rimraf": "^2.6.3",
-        "source-map": "^0.6.1"
+        "debug": "4.1.1",
+        "istanbul-lib-coverage": "2.0.5",
+        "make-dir": "2.1.0",
+        "rimraf": "2.6.3",
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "debug": {
@@ -6545,7 +6819,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.1"
           }
         },
         "istanbul-lib-coverage": {
@@ -6574,7 +6848,7 @@
       "integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
       "dev": true,
       "requires": {
-        "handlebars": "^4.1.2"
+        "handlebars": "4.1.2"
       }
     },
     "js-tokens": {
@@ -6589,8 +6863,8 @@
       "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "1.0.9",
+        "esprima": "4.0.0"
       }
     },
     "js2xmlparser": {
@@ -6599,7 +6873,7 @@
       "integrity": "sha512-WuNgdZOXVmBk5kUPMcTcVUpbGRzLfNkv7+7APq7WiDihpXVKrgxo6wwRpRl9OQeEBgKCVk9mR7RbzrnNWC8oBw==",
       "dev": true,
       "requires": {
-        "xmlcreate": "^2.0.0"
+        "xmlcreate": "2.0.1"
       }
     },
     "jsbn": {
@@ -6613,20 +6887,20 @@
       "integrity": "sha512-S2vzg99C5+gb7FWlrK4TVdyzVPGGkdvpDkCEJH1JABi2PKzPeLu5/zZffcJUifgWUJqXWl41Hoc+MmuM2GukIg==",
       "dev": true,
       "requires": {
-        "@babel/parser": "^7.4.4",
-        "bluebird": "^3.5.4",
-        "catharsis": "^0.8.10",
-        "escape-string-regexp": "^2.0.0",
-        "js2xmlparser": "^4.0.0",
-        "klaw": "^3.0.0",
-        "markdown-it": "^8.4.2",
-        "markdown-it-anchor": "^5.0.2",
-        "marked": "^0.6.2",
-        "mkdirp": "^0.5.1",
-        "requizzle": "^0.2.2",
-        "strip-json-comments": "^3.0.1",
+        "@babel/parser": "7.4.5",
+        "bluebird": "3.5.5",
+        "catharsis": "0.8.10",
+        "escape-string-regexp": "2.0.0",
+        "js2xmlparser": "4.0.0",
+        "klaw": "3.0.0",
+        "markdown-it": "8.4.2",
+        "markdown-it-anchor": "5.2.1",
+        "marked": "0.6.2",
+        "mkdirp": "0.5.1",
+        "requizzle": "0.2.2",
+        "strip-json-comments": "3.0.1",
         "taffydb": "2.6.2",
-        "underscore": "~1.9.1"
+        "underscore": "1.9.1"
       },
       "dependencies": {
         "@babel/parser": {
@@ -6655,15 +6929,15 @@
       "integrity": "sha512-bntcT/3No4dPJZs9KX0AN3vrX/7P6PwDXVKANCXYpa0WJsbud41yAunoMxGFS4APHwmDoWl8E0ZuowLCOiOOFw==",
       "dev": true,
       "requires": {
-        "array-back": "^3.1.0",
-        "cache-point": "^0.4.1",
-        "collect-all": "^1.0.3",
-        "file-set": "^2.0.1",
-        "fs-then-native": "^2.0.0",
-        "jsdoc": "^3.6.1",
-        "object-to-spawn-args": "^1.1.1",
-        "temp-path": "^1.0.0",
-        "walk-back": "^3.0.1"
+        "array-back": "3.1.0",
+        "cache-point": "0.4.1",
+        "collect-all": "1.0.3",
+        "file-set": "2.0.1",
+        "fs-then-native": "2.0.0",
+        "jsdoc": "3.6.2",
+        "object-to-spawn-args": "1.1.1",
+        "temp-path": "1.0.0",
+        "walk-back": "3.0.1"
       }
     },
     "jsdoc-parse": {
@@ -6672,12 +6946,12 @@
       "integrity": "sha512-btZLp4wYl90vcAfgk4hoGQbO17iBVrhh3LJRMKZNtZgniO3F8H2CjxXld0owBIB1XxN+j3bAcWZnZKMnSj3iMA==",
       "dev": true,
       "requires": {
-        "array-back": "^2.0.0",
-        "lodash.omit": "^4.5.0",
-        "lodash.pick": "^4.4.0",
-        "reduce-extract": "^1.0.0",
-        "sort-array": "^2.0.0",
-        "test-value": "^3.0.0"
+        "array-back": "2.0.0",
+        "lodash.omit": "4.5.0",
+        "lodash.pick": "4.4.0",
+        "reduce-extract": "1.0.0",
+        "sort-array": "2.0.0",
+        "test-value": "3.0.0"
       },
       "dependencies": {
         "array-back": {
@@ -6686,7 +6960,7 @@
           "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
           "dev": true,
           "requires": {
-            "typical": "^2.6.1"
+            "typical": "2.6.1"
           }
         }
       }
@@ -6697,13 +6971,13 @@
       "integrity": "sha512-3gKEnbay7dSdyvtMDDkUf4r7pmBVgs3aqeT0Cg/ngTILPpJUzf8iKgASIo5psF007L45OIJtIuRX5VL/YUXKaA==",
       "dev": true,
       "requires": {
-        "array-back": "^3.1.0",
-        "command-line-tool": "^0.8.0",
-        "config-master": "^3.1.0",
-        "dmd": "^4.0.0",
-        "jsdoc-api": "^5.0.1",
-        "jsdoc-parse": "^3.0.1",
-        "walk-back": "^3.0.1"
+        "array-back": "3.1.0",
+        "command-line-tool": "0.8.0",
+        "config-master": "3.1.0",
+        "dmd": "4.0.0",
+        "jsdoc-api": "5.0.1",
+        "jsdoc-parse": "3.0.1",
+        "walk-back": "3.0.1"
       }
     },
     "jsesc": {
@@ -6742,7 +7016,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "^1.1.5"
+        "is-buffer": "1.1.6"
       }
     },
     "klaw": {
@@ -6751,7 +7025,7 @@
       "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.9"
+        "graceful-fs": "4.1.11"
       }
     },
     "last-run": {
@@ -6760,8 +7034,8 @@
       "integrity": "sha1-RblpQsF7HHnHchmCWbqUO+v4yls=",
       "dev": true,
       "requires": {
-        "default-resolution": "^2.0.0",
-        "es6-weak-map": "^2.0.1"
+        "default-resolution": "2.0.0",
+        "es6-weak-map": "2.0.2"
       }
     },
     "lazystream": {
@@ -6770,7 +7044,7 @@
       "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.0.5"
+        "readable-stream": "2.3.3"
       }
     },
     "lcid": {
@@ -6779,7 +7053,7 @@
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
-        "invert-kv": "^1.0.0"
+        "invert-kv": "1.0.0"
       }
     },
     "lead": {
@@ -6788,7 +7062,7 @@
       "integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
       "dev": true,
       "requires": {
-        "flush-write-stream": "^1.0.2"
+        "flush-write-stream": "1.1.1"
       }
     },
     "levn": {
@@ -6797,8 +7071,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
       }
     },
     "liftoff": {
@@ -6807,14 +7081,14 @@
       "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
       "dev": true,
       "requires": {
-        "extend": "^3.0.0",
-        "findup-sync": "^2.0.0",
-        "fined": "^1.0.1",
-        "flagged-respawn": "^1.0.0",
-        "is-plain-object": "^2.0.4",
-        "object.map": "^1.0.0",
-        "rechoir": "^0.6.2",
-        "resolve": "^1.1.7"
+        "extend": "3.0.2",
+        "findup-sync": "2.0.0",
+        "fined": "1.1.1",
+        "flagged-respawn": "1.0.1",
+        "is-plain-object": "2.0.4",
+        "object.map": "1.0.1",
+        "rechoir": "0.6.2",
+        "resolve": "1.5.0"
       }
     },
     "linkify-it": {
@@ -6823,7 +7097,7 @@
       "integrity": "sha512-4REs8/062kV2DSHxNfq5183zrqXMl7WP0WzABH9IeJI+NLm429FgE1PDecltYfnOoFDFlZGh2T8PfZn0r+GTRg==",
       "dev": true,
       "requires": {
-        "uc.micro": "^1.0.1"
+        "uc.micro": "1.0.6"
       }
     },
     "load-json-file": {
@@ -6832,10 +7106,10 @@
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "strip-bom": "^3.0.0"
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "strip-bom": "3.0.0"
       }
     },
     "locate-path": {
@@ -6844,8 +7118,8 @@
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
       },
       "dependencies": {
         "path-exists": {
@@ -6938,7 +7212,7 @@
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
       "dev": true,
       "requires": {
-        "js-tokens": "^3.0.0"
+        "js-tokens": "3.0.2"
       }
     },
     "lower-case": {
@@ -6951,7 +7225,7 @@
       "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.2.tgz",
       "integrity": "sha1-5dp8JvKacHO+AtUrrJmA5ZIq36E=",
       "requires": {
-        "lower-case": "^1.1.2"
+        "lower-case": "1.1.4"
       }
     },
     "lru-cache": {
@@ -6960,8 +7234,8 @@
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "dev": true,
       "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
       }
     },
     "lru-queue": {
@@ -6970,7 +7244,7 @@
       "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
       "dev": true,
       "requires": {
-        "es5-ext": "~0.10.2"
+        "es5-ext": "0.10.49"
       }
     },
     "make-dir": {
@@ -6979,8 +7253,8 @@
       "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
       "dev": true,
       "requires": {
-        "pify": "^4.0.1",
-        "semver": "^5.6.0"
+        "pify": "4.0.1",
+        "semver": "5.7.0"
       },
       "dependencies": {
         "pify": {
@@ -7003,7 +7277,7 @@
       "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
       "dev": true,
       "requires": {
-        "kind-of": "^6.0.2"
+        "kind-of": "6.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -7020,7 +7294,7 @@
       "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
       "dev": true,
       "requires": {
-        "p-defer": "^1.0.0"
+        "p-defer": "1.0.0"
       }
     },
     "map-cache": {
@@ -7035,7 +7309,7 @@
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
-        "object-visit": "^1.0.0"
+        "object-visit": "1.0.1"
       }
     },
     "markdown-it": {
@@ -7044,11 +7318,11 @@
       "integrity": "sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.7",
-        "entities": "~1.1.1",
-        "linkify-it": "^2.0.0",
-        "mdurl": "^1.0.1",
-        "uc.micro": "^1.0.5"
+        "argparse": "1.0.9",
+        "entities": "1.1.2",
+        "linkify-it": "2.1.0",
+        "mdurl": "1.0.1",
+        "uc.micro": "1.0.6"
       }
     },
     "markdown-it-anchor": {
@@ -7069,9 +7343,9 @@
       "integrity": "sha1-xvNINKDY28OzfCfui7yyfHd1WC4=",
       "dev": true,
       "requires": {
-        "findup-sync": "^2.0.0",
-        "micromatch": "^3.0.4",
-        "resolve": "^1.4.0",
+        "findup-sync": "2.0.0",
+        "micromatch": "3.1.10",
+        "resolve": "1.5.0",
         "stack-trace": "0.0.10"
       },
       "dependencies": {
@@ -7093,16 +7367,16 @@
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.1",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "extend-shallow": {
@@ -7111,7 +7385,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -7131,13 +7405,13 @@
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.1",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -7146,7 +7420,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -7155,7 +7429,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-descriptor": {
@@ -7164,9 +7438,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
               }
             },
             "kind-of": {
@@ -7183,14 +7457,14 @@
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.1",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -7199,7 +7473,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -7208,7 +7482,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -7219,10 +7493,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -7231,7 +7505,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -7242,7 +7516,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -7251,7 +7525,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -7262,7 +7536,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -7271,7 +7545,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -7282,7 +7556,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -7291,7 +7565,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -7314,19 +7588,19 @@
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.9",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.1",
+            "to-regex": "3.0.2"
           }
         }
       }
@@ -7343,9 +7617,9 @@
       "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
       "dev": true,
       "requires": {
-        "map-age-cleaner": "^0.1.1",
-        "mimic-fn": "^2.0.0",
-        "p-is-promise": "^2.0.0"
+        "map-age-cleaner": "0.1.3",
+        "mimic-fn": "2.1.0",
+        "p-is-promise": "2.1.0"
       },
       "dependencies": {
         "mimic-fn": {
@@ -7362,14 +7636,14 @@
       "integrity": "sha512-/SWFvWegAIYAO4NQMpcX+gcra0yEZu4OntmUdrBaWrJncxOqAziGFlHxc7yjKVK2uu3lpPW27P27wkR82wA8mg==",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.45",
-        "es6-weak-map": "^2.0.2",
-        "event-emitter": "^0.3.5",
-        "is-promise": "^2.1",
-        "lru-queue": "0.1",
-        "next-tick": "1",
-        "timers-ext": "^0.1.5"
+        "d": "1.0.0",
+        "es5-ext": "0.10.49",
+        "es6-weak-map": "2.0.2",
+        "event-emitter": "0.3.5",
+        "is-promise": "2.1.0",
+        "lru-queue": "0.1.0",
+        "next-tick": "1.0.0",
+        "timers-ext": "0.1.7"
       }
     },
     "merge-descriptors": {
@@ -7384,7 +7658,7 @@
       "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
       "dev": true,
       "requires": {
-        "source-map": "^0.6.1"
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -7421,7 +7695,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
       "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
       "requires": {
-        "mime-db": "~1.38.0"
+        "mime-db": "1.38.0"
       }
     },
     "mimic-fn": {
@@ -7436,7 +7710,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.8"
       }
     },
     "minimist": {
@@ -7451,8 +7725,8 @@
       "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
       "dev": true,
       "requires": {
-        "for-in": "^1.0.2",
-        "is-extendable": "^1.0.1"
+        "for-in": "1.0.2",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -7461,7 +7735,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -7514,7 +7788,7 @@
           "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^2.0.0"
+            "has-flag": "2.0.0"
           }
         }
       }
@@ -7525,7 +7799,7 @@
       "integrity": "sha512-dE2EbcxJKQCeYLZSsI7BAiMZCe/bHbJ2LHb5aGwUuDmfoOINEJ8QI6qYJ85NHsSNkNa90F3s6onZcmt/+MppFA==",
       "dev": true,
       "requires": {
-        "url-parse": "^1.2.0"
+        "url-parse": "1.4.3"
       }
     },
     "module-not-found-error": {
@@ -7570,18 +7844,18 @@
       "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
       "dev": true,
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "fragment-cache": "^0.2.1",
-        "is-odd": "^2.0.0",
-        "is-windows": "^1.0.2",
-        "kind-of": "^6.0.2",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "fragment-cache": "0.2.1",
+        "is-odd": "2.0.0",
+        "is-windows": "1.0.2",
+        "kind-of": "6.0.2",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.1",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "arr-diff": {
@@ -7640,11 +7914,11 @@
       "integrity": "sha512-sa0RRbj53dovjc7wombHmVli9ZihXbXCQ2uH3TNm03DyvOSIQbxg+pbqDKrk2oxMK1rtLGVlKxcB9rrc6X5YjA==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "^3.1.0",
-        "@sinonjs/text-encoding": "^0.7.1",
-        "just-extend": "^4.0.2",
-        "lolex": "^2.3.2",
-        "path-to-regexp": "^1.7.0"
+        "@sinonjs/formatio": "3.1.0",
+        "@sinonjs/text-encoding": "0.7.1",
+        "just-extend": "4.0.2",
+        "lolex": "2.7.5",
+        "path-to-regexp": "1.7.0"
       },
       "dependencies": {
         "just-extend": {
@@ -7666,7 +7940,7 @@
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
       "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
       "requires": {
-        "lower-case": "^1.1.1"
+        "lower-case": "1.1.4"
       }
     },
     "normalize-package-data": {
@@ -7675,10 +7949,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "is-builtin-module": "^1.0.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
+        "hosted-git-info": "2.5.0",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.5.0",
+        "validate-npm-package-license": "3.0.1"
       }
     },
     "normalize-path": {
@@ -7687,7 +7961,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "^1.0.1"
+        "remove-trailing-separator": "1.1.0"
       }
     },
     "now-and-later": {
@@ -7696,7 +7970,7 @@
       "integrity": "sha1-vGHLtFbXnLMiB85HygUTb/Ln1u4=",
       "dev": true,
       "requires": {
-        "once": "^1.3.2"
+        "once": "1.4.0"
       }
     },
     "npm-run-path": {
@@ -7705,7 +7979,7 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "^2.0.0"
+        "path-key": "2.0.1"
       }
     },
     "number-is-nan": {
@@ -7720,31 +7994,31 @@
       "integrity": "sha512-OI0vm6ZGUnoGZv/tLdZ2esSVzDwUC88SNs+6JoSOMVxA+gKMB8Tk7jBwgemLx4O40lhhvZCVw1C+OYLOBOPXWw==",
       "dev": true,
       "requires": {
-        "archy": "^1.0.0",
-        "caching-transform": "^3.0.2",
-        "convert-source-map": "^1.6.0",
-        "cp-file": "^6.2.0",
-        "find-cache-dir": "^2.1.0",
-        "find-up": "^3.0.0",
-        "foreground-child": "^1.5.6",
-        "glob": "^7.1.3",
-        "istanbul-lib-coverage": "^2.0.5",
-        "istanbul-lib-hook": "^2.0.7",
-        "istanbul-lib-instrument": "^3.3.0",
-        "istanbul-lib-report": "^2.0.8",
-        "istanbul-lib-source-maps": "^3.0.6",
-        "istanbul-reports": "^2.2.4",
-        "js-yaml": "^3.13.1",
-        "make-dir": "^2.1.0",
-        "merge-source-map": "^1.1.0",
-        "resolve-from": "^4.0.0",
-        "rimraf": "^2.6.3",
-        "signal-exit": "^3.0.2",
-        "spawn-wrap": "^1.4.2",
-        "test-exclude": "^5.2.3",
-        "uuid": "^3.3.2",
-        "yargs": "^13.2.2",
-        "yargs-parser": "^13.0.0"
+        "archy": "1.0.0",
+        "caching-transform": "3.0.2",
+        "convert-source-map": "1.6.0",
+        "cp-file": "6.2.0",
+        "find-cache-dir": "2.1.0",
+        "find-up": "3.0.0",
+        "foreground-child": "1.5.6",
+        "glob": "7.1.4",
+        "istanbul-lib-coverage": "2.0.5",
+        "istanbul-lib-hook": "2.0.7",
+        "istanbul-lib-instrument": "3.3.0",
+        "istanbul-lib-report": "2.0.8",
+        "istanbul-lib-source-maps": "3.0.6",
+        "istanbul-reports": "2.2.6",
+        "js-yaml": "3.13.1",
+        "make-dir": "2.1.0",
+        "merge-source-map": "1.1.0",
+        "resolve-from": "4.0.0",
+        "rimraf": "2.6.3",
+        "signal-exit": "3.0.2",
+        "spawn-wrap": "1.4.2",
+        "test-exclude": "5.2.3",
+        "uuid": "3.3.2",
+        "yargs": "13.2.4",
+        "yargs-parser": "13.1.0"
       },
       "dependencies": {
         "@babel/code-frame": {
@@ -7753,7 +8027,7 @@
           "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
           "dev": true,
           "requires": {
-            "@babel/highlight": "^7.0.0"
+            "@babel/highlight": "7.0.0"
           }
         },
         "@babel/generator": {
@@ -7762,11 +8036,11 @@
           "integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.4.4",
-            "jsesc": "^2.5.1",
-            "lodash": "^4.17.11",
-            "source-map": "^0.5.0",
-            "trim-right": "^1.0.1"
+            "@babel/types": "7.4.4",
+            "jsesc": "2.5.2",
+            "lodash": "4.17.11",
+            "source-map": "0.5.7",
+            "trim-right": "1.0.1"
           }
         },
         "@babel/helper-function-name": {
@@ -7775,9 +8049,9 @@
           "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
           "dev": true,
           "requires": {
-            "@babel/helper-get-function-arity": "^7.0.0",
-            "@babel/template": "^7.1.0",
-            "@babel/types": "^7.0.0"
+            "@babel/helper-get-function-arity": "7.0.0",
+            "@babel/template": "7.4.4",
+            "@babel/types": "7.4.4"
           }
         },
         "@babel/helper-get-function-arity": {
@@ -7786,7 +8060,7 @@
           "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.0.0"
+            "@babel/types": "7.4.4"
           }
         },
         "@babel/helper-split-export-declaration": {
@@ -7795,7 +8069,7 @@
           "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.4.4"
+            "@babel/types": "7.4.4"
           }
         },
         "@babel/parser": {
@@ -7810,9 +8084,9 @@
           "integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
           "dev": true,
           "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "@babel/parser": "^7.4.4",
-            "@babel/types": "^7.4.4"
+            "@babel/code-frame": "7.0.0",
+            "@babel/parser": "7.4.5",
+            "@babel/types": "7.4.4"
           }
         },
         "@babel/traverse": {
@@ -7821,15 +8095,15 @@
           "integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
           "dev": true,
           "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "@babel/generator": "^7.4.4",
-            "@babel/helper-function-name": "^7.1.0",
-            "@babel/helper-split-export-declaration": "^7.4.4",
-            "@babel/parser": "^7.4.5",
-            "@babel/types": "^7.4.4",
-            "debug": "^4.1.0",
-            "globals": "^11.1.0",
-            "lodash": "^4.17.11"
+            "@babel/code-frame": "7.0.0",
+            "@babel/generator": "7.4.4",
+            "@babel/helper-function-name": "7.1.0",
+            "@babel/helper-split-export-declaration": "7.4.4",
+            "@babel/parser": "7.4.5",
+            "@babel/types": "7.4.4",
+            "debug": "4.1.1",
+            "globals": "11.12.0",
+            "lodash": "4.17.11"
           }
         },
         "@babel/types": {
@@ -7838,9 +8112,9 @@
           "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
           "dev": true,
           "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.11",
-            "to-fast-properties": "^2.0.0"
+            "esutils": "2.0.2",
+            "lodash": "4.17.11",
+            "to-fast-properties": "2.0.0"
           }
         },
         "ansi-regex": {
@@ -7855,7 +8129,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "camelcase": {
@@ -7870,9 +8144,9 @@
           "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
           "dev": true,
           "requires": {
-            "string-width": "^3.1.0",
-            "strip-ansi": "^5.2.0",
-            "wrap-ansi": "^5.1.0"
+            "string-width": "3.1.0",
+            "strip-ansi": "5.2.0",
+            "wrap-ansi": "5.1.0"
           }
         },
         "convert-source-map": {
@@ -7881,7 +8155,7 @@
           "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.1"
+            "safe-buffer": "5.1.1"
           }
         },
         "cross-spawn": {
@@ -7890,11 +8164,11 @@
           "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
           "dev": true,
           "requires": {
-            "nice-try": "^1.0.4",
-            "path-key": "^2.0.1",
-            "semver": "^5.5.0",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
+            "nice-try": "1.0.5",
+            "path-key": "2.0.1",
+            "semver": "5.7.0",
+            "shebang-command": "1.2.0",
+            "which": "1.3.0"
           },
           "dependencies": {
             "semver": {
@@ -7911,7 +8185,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.1"
           }
         },
         "execa": {
@@ -7920,13 +8194,13 @@
           "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
           "dev": true,
           "requires": {
-            "cross-spawn": "^6.0.0",
-            "get-stream": "^4.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
+            "cross-spawn": "6.0.5",
+            "get-stream": "4.1.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
           }
         },
         "find-up": {
@@ -7935,7 +8209,7 @@
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
-            "locate-path": "^3.0.0"
+            "locate-path": "3.0.0"
           }
         },
         "get-caller-file": {
@@ -7950,7 +8224,7 @@
           "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
           "dev": true,
           "requires": {
-            "pump": "^3.0.0"
+            "pump": "3.0.0"
           }
         },
         "glob": {
@@ -7959,12 +8233,12 @@
           "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "globals": {
@@ -7991,13 +8265,13 @@
           "integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
           "dev": true,
           "requires": {
-            "@babel/generator": "^7.4.0",
-            "@babel/parser": "^7.4.3",
-            "@babel/template": "^7.4.0",
-            "@babel/traverse": "^7.4.3",
-            "@babel/types": "^7.4.0",
-            "istanbul-lib-coverage": "^2.0.5",
-            "semver": "^6.0.0"
+            "@babel/generator": "7.4.4",
+            "@babel/parser": "7.4.5",
+            "@babel/template": "7.4.4",
+            "@babel/traverse": "7.4.5",
+            "@babel/types": "7.4.4",
+            "istanbul-lib-coverage": "2.0.5",
+            "semver": "6.1.1"
           }
         },
         "jsesc": {
@@ -8012,7 +8286,7 @@
           "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
           "dev": true,
           "requires": {
-            "invert-kv": "^2.0.0"
+            "invert-kv": "2.0.0"
           }
         },
         "load-json-file": {
@@ -8021,10 +8295,10 @@
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^4.0.0",
-            "pify": "^3.0.0",
-            "strip-bom": "^3.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "4.0.0",
+            "pify": "3.0.0",
+            "strip-bom": "3.0.0"
           }
         },
         "locate-path": {
@@ -8033,8 +8307,8 @@
           "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "dev": true,
           "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
+            "p-locate": "3.0.0",
+            "path-exists": "3.0.0"
           }
         },
         "ms": {
@@ -8049,9 +8323,9 @@
           "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
           "dev": true,
           "requires": {
-            "execa": "^1.0.0",
-            "lcid": "^2.0.0",
-            "mem": "^4.0.0"
+            "execa": "1.0.0",
+            "lcid": "2.0.0",
+            "mem": "4.3.0"
           }
         },
         "p-limit": {
@@ -8060,7 +8334,7 @@
           "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
           "dev": true,
           "requires": {
-            "p-try": "^2.0.0"
+            "p-try": "2.2.0"
           }
         },
         "p-locate": {
@@ -8069,7 +8343,7 @@
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "requires": {
-            "p-limit": "^2.0.0"
+            "p-limit": "2.2.0"
           }
         },
         "p-try": {
@@ -8084,8 +8358,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
+            "error-ex": "1.3.1",
+            "json-parse-better-errors": "1.0.2"
           }
         },
         "path-exists": {
@@ -8100,7 +8374,7 @@
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "pify": "^3.0.0"
+            "pify": "3.0.0"
           }
         },
         "pify": {
@@ -8115,8 +8389,8 @@
           "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
           "dev": true,
           "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
+            "end-of-stream": "1.4.1",
+            "once": "1.4.0"
           }
         },
         "read-pkg": {
@@ -8125,9 +8399,9 @@
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
-            "load-json-file": "^4.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^3.0.0"
+            "load-json-file": "4.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "3.0.0"
           }
         },
         "read-pkg-up": {
@@ -8136,8 +8410,8 @@
           "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
           "dev": true,
           "requires": {
-            "find-up": "^3.0.0",
-            "read-pkg": "^3.0.0"
+            "find-up": "3.0.0",
+            "read-pkg": "3.0.0"
           }
         },
         "require-main-filename": {
@@ -8164,9 +8438,9 @@
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
+            "emoji-regex": "7.0.3",
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "5.2.0"
           }
         },
         "strip-ansi": {
@@ -8175,7 +8449,7 @@
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.1.0"
+            "ansi-regex": "4.1.0"
           }
         },
         "test-exclude": {
@@ -8184,10 +8458,10 @@
           "integrity": "sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==",
           "dev": true,
           "requires": {
-            "glob": "^7.1.3",
-            "minimatch": "^3.0.4",
-            "read-pkg-up": "^4.0.0",
-            "require-main-filename": "^2.0.0"
+            "glob": "7.1.4",
+            "minimatch": "3.0.4",
+            "read-pkg-up": "4.0.0",
+            "require-main-filename": "2.0.0"
           }
         },
         "to-fast-properties": {
@@ -8208,9 +8482,9 @@
           "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.0",
-            "string-width": "^3.0.0",
-            "strip-ansi": "^5.0.0"
+            "ansi-styles": "3.2.1",
+            "string-width": "3.1.0",
+            "strip-ansi": "5.2.0"
           }
         },
         "y18n": {
@@ -8225,17 +8499,17 @@
           "integrity": "sha512-HG/DWAJa1PAnHT9JAhNa8AbAv3FPaiLzioSjCcmuXXhP8MlpHO5vwls4g4j6n30Z74GVQj8Xa62dWVx1QCGklg==",
           "dev": true,
           "requires": {
-            "cliui": "^5.0.0",
-            "find-up": "^3.0.0",
-            "get-caller-file": "^2.0.1",
-            "os-locale": "^3.1.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
-            "string-width": "^3.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^13.1.0"
+            "cliui": "5.0.0",
+            "find-up": "3.0.0",
+            "get-caller-file": "2.0.5",
+            "os-locale": "3.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "2.0.0",
+            "set-blocking": "2.0.0",
+            "string-width": "3.1.0",
+            "which-module": "2.0.0",
+            "y18n": "4.0.0",
+            "yargs-parser": "13.1.0"
           }
         },
         "yargs-parser": {
@@ -8244,8 +8518,8 @@
           "integrity": "sha512-Yq+32PrijHRri0vVKQEm+ys8mbqWjLiwQkMFNXEENutzLPP0bE4Lcd4iA3OQY5HF+GD3xXxf0MEHb8E4/SA3AA==",
           "dev": true,
           "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
+            "camelcase": "5.3.1",
+            "decamelize": "1.2.0"
           }
         }
       }
@@ -8262,9 +8536,9 @@
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
-        "copy-descriptor": "^0.1.0",
-        "define-property": "^0.2.5",
-        "kind-of": "^3.0.3"
+        "copy-descriptor": "0.1.1",
+        "define-property": "0.2.5",
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "define-property": {
@@ -8273,7 +8547,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "is-accessor-descriptor": {
@@ -8282,7 +8556,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         },
         "is-data-descriptor": {
@@ -8291,7 +8565,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         },
         "is-descriptor": {
@@ -8300,9 +8574,9 @@
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
           },
           "dependencies": {
             "kind-of": {
@@ -8339,7 +8613,7 @@
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.0"
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -8356,10 +8630,10 @@
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.1.1",
-        "has-symbols": "^1.0.0",
-        "object-keys": "^1.0.11"
+        "define-properties": "1.1.3",
+        "function-bind": "1.1.1",
+        "has-symbols": "1.0.0",
+        "object-keys": "1.1.0"
       }
     },
     "object.defaults": {
@@ -8368,10 +8642,10 @@
       "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
       "dev": true,
       "requires": {
-        "array-each": "^1.0.1",
-        "array-slice": "^1.0.0",
-        "for-own": "^1.0.0",
-        "isobject": "^3.0.0"
+        "array-each": "1.0.1",
+        "array-slice": "1.1.0",
+        "for-own": "1.0.0",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "for-own": {
@@ -8380,7 +8654,7 @@
           "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
           "dev": true,
           "requires": {
-            "for-in": "^1.0.1"
+            "for-in": "1.0.2"
           }
         },
         "isobject": {
@@ -8397,8 +8671,8 @@
       "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
       "dev": true,
       "requires": {
-        "for-own": "^1.0.0",
-        "make-iterator": "^1.0.0"
+        "for-own": "1.0.0",
+        "make-iterator": "1.0.1"
       },
       "dependencies": {
         "for-own": {
@@ -8407,7 +8681,7 @@
           "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
           "dev": true,
           "requires": {
-            "for-in": "^1.0.1"
+            "for-in": "1.0.2"
           }
         }
       }
@@ -8418,7 +8692,7 @@
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -8435,8 +8709,8 @@
       "integrity": "sha1-b+NI8qx/oPlcpiEiZZkJaCW7A60=",
       "dev": true,
       "requires": {
-        "for-own": "^1.0.0",
-        "make-iterator": "^1.0.0"
+        "for-own": "1.0.0",
+        "make-iterator": "1.0.1"
       },
       "dependencies": {
         "for-own": {
@@ -8445,7 +8719,7 @@
           "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
           "dev": true,
           "requires": {
-            "for-in": "^1.0.1"
+            "for-in": "1.0.2"
           }
         }
       }
@@ -8456,7 +8730,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "onetime": {
@@ -8465,7 +8739,7 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "1.1.0"
       }
     },
     "optimist": {
@@ -8474,8 +8748,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
+        "minimist": "0.0.8",
+        "wordwrap": "0.0.3"
       },
       "dependencies": {
         "wordwrap": {
@@ -8492,12 +8766,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
       }
     },
     "ordered-read-streams": {
@@ -8506,7 +8780,7 @@
       "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.0.1"
+        "readable-stream": "2.3.3"
       }
     },
     "os-homedir": {
@@ -8521,7 +8795,7 @@
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
-        "lcid": "^1.0.0"
+        "lcid": "1.0.0"
       }
     },
     "os-tmpdir": {
@@ -8554,7 +8828,7 @@
       "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
       "dev": true,
       "requires": {
-        "p-try": "^1.0.0"
+        "p-try": "1.0.0"
       }
     },
     "p-locate": {
@@ -8563,7 +8837,7 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "^1.1.0"
+        "p-limit": "1.2.0"
       }
     },
     "p-map": {
@@ -8584,10 +8858,10 @@
       "integrity": "sha512-lOtmukMDVvtkL84rJHI7dpTYq+0rli8N2wlnqUcBuDWCfVhRUfOmnR9SsoHFMLpACvEV60dX7rd0rFaYDZI+FA==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.15",
-        "hasha": "^3.0.0",
-        "lodash.flattendeep": "^4.4.0",
-        "release-zalgo": "^1.0.0"
+        "graceful-fs": "4.1.15",
+        "hasha": "3.0.0",
+        "lodash.flattendeep": "4.4.0",
+        "release-zalgo": "1.0.0"
       },
       "dependencies": {
         "graceful-fs": {
@@ -8603,7 +8877,7 @@
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
       "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
       "requires": {
-        "no-case": "^2.2.0"
+        "no-case": "2.3.2"
       }
     },
     "parent-module": {
@@ -8612,7 +8886,7 @@
       "integrity": "sha512-8Mf5juOMmiE4FcmzYc4IaiS9L3+9paz2KOiXzkRviCP6aDmN49Hz6EMWz0lGNp9pX80GvvAuLADtyGfW/Em3TA==",
       "dev": true,
       "requires": {
-        "callsites": "^3.0.0"
+        "callsites": "3.0.0"
       },
       "dependencies": {
         "callsites": {
@@ -8629,9 +8903,9 @@
       "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
       "dev": true,
       "requires": {
-        "is-absolute": "^1.0.0",
-        "map-cache": "^0.2.0",
-        "path-root": "^0.1.1"
+        "is-absolute": "1.0.0",
+        "map-cache": "0.2.2",
+        "path-root": "0.1.1"
       }
     },
     "parse-json": {
@@ -8640,7 +8914,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "^1.2.0"
+        "error-ex": "1.3.1"
       }
     },
     "parse-node-version": {
@@ -8660,8 +8934,8 @@
       "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-2.0.1.tgz",
       "integrity": "sha1-LVeNNFX2YNpl7KGO+VtODekSdh4=",
       "requires": {
-        "camel-case": "^3.0.0",
-        "upper-case-first": "^1.1.0"
+        "camel-case": "3.0.0",
+        "upper-case-first": "1.1.2"
       }
     },
     "pascalcase": {
@@ -8675,7 +8949,7 @@
       "resolved": "https://registry.npmjs.org/path-case/-/path-case-2.1.1.tgz",
       "integrity": "sha1-lLgDfDctP+KQbkZbtF4l0ibo7qU=",
       "requires": {
-        "no-case": "^2.2.0"
+        "no-case": "2.3.2"
       }
     },
     "path-dirname": {
@@ -8690,7 +8964,7 @@
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "^2.0.0"
+        "pinkie-promise": "2.0.1"
       }
     },
     "path-is-absolute": {
@@ -8723,7 +8997,7 @@
       "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
       "dev": true,
       "requires": {
-        "path-root-regex": "^0.1.0"
+        "path-root-regex": "0.1.2"
       }
     },
     "path-root-regex": {
@@ -8755,7 +9029,7 @@
       "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
       "dev": true,
       "requires": {
-        "pify": "^2.0.0"
+        "pify": "2.3.0"
       }
     },
     "pathval": {
@@ -8782,7 +9056,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "^2.0.0"
+        "pinkie": "2.0.4"
       }
     },
     "pkg-dir": {
@@ -8791,7 +9065,16 @@
       "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
       "dev": true,
       "requires": {
-        "find-up": "^1.0.0"
+        "find-up": "1.1.2"
+      }
+    },
+    "please-upgrade-node": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.1.1.tgz",
+      "integrity": "sha512-KY1uHnQ2NlQHqIJQpnh/i54rKkuxCEBx+voJIS/Mvb+L2iYd2NMotwduhKTMjfC1uKoX3VXOxLjIYG66dfJTVQ==",
+      "dev": true,
+      "requires": {
+        "semver-compare": "1.0.0"
       }
     },
     "plugin-error": {
@@ -8800,10 +9083,10 @@
       "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
       "dev": true,
       "requires": {
-        "ansi-colors": "^1.0.1",
-        "arr-diff": "^4.0.0",
-        "arr-union": "^3.1.0",
-        "extend-shallow": "^3.0.2"
+        "ansi-colors": "1.1.0",
+        "arr-diff": "4.0.0",
+        "arr-union": "3.1.0",
+        "extend-shallow": "3.0.2"
       },
       "dependencies": {
         "arr-diff": {
@@ -8850,11 +9133,11 @@
       "integrity": "sha512-Q4V2GAflSaM739kKH63utbfI2n4s2fCDCyjFC4ykxA9ueb7FknLcLAZSKa3DejHMt5q9Fq395eKTZ9wYwoILBw==",
       "dev": true,
       "requires": {
-        "chalk": "^2.3.0",
-        "execa": "^0.8.0",
-        "find-up": "^2.1.0",
-        "ignore": "^3.3.7",
-        "mri": "^1.1.0"
+        "chalk": "2.4.1",
+        "execa": "0.8.0",
+        "find-up": "2.1.0",
+        "ignore": "3.3.7",
+        "mri": "1.1.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -8863,7 +9146,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -8872,9 +9155,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "find-up": {
@@ -8883,7 +9166,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "has-flag": {
@@ -8898,7 +9181,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -8927,9 +9210,9 @@
       "integrity": "sha512-kptdFArCfGRtQFv3Qwjr10lwbEV0TBJYvfqzhwucyfEXqVgmnAkyEw/S3FYzR5HI9i5QOq4rcqQjZ6AlknlCDQ==",
       "dev": true,
       "requires": {
-        "fill-keys": "^1.0.2",
-        "module-not-found-error": "^1.0.0",
-        "resolve": "~1.8.1"
+        "fill-keys": "1.0.2",
+        "module-not-found-error": "1.0.1",
+        "resolve": "1.8.1"
       },
       "dependencies": {
         "resolve": {
@@ -8938,7 +9221,7 @@
           "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
           "dev": true,
           "requires": {
-            "path-parse": "^1.0.5"
+            "path-parse": "1.0.5"
           }
         }
       }
@@ -8955,8 +9238,8 @@
       "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
       "dev": true,
       "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
+        "end-of-stream": "1.4.1",
+        "once": "1.4.0"
       }
     },
     "pumpify": {
@@ -8965,9 +9248,9 @@
       "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
       "dev": true,
       "requires": {
-        "duplexify": "^3.6.0",
-        "inherits": "^2.0.3",
-        "pump": "^2.0.0"
+        "duplexify": "3.7.1",
+        "inherits": "2.0.3",
+        "pump": "2.0.1"
       }
     },
     "punycode": {
@@ -8992,9 +9275,9 @@
       "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
       "dev": true,
       "requires": {
-        "load-json-file": "^2.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^2.0.0"
+        "load-json-file": "2.0.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "2.0.0"
       }
     },
     "read-pkg-up": {
@@ -9003,8 +9286,8 @@
       "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
       "dev": true,
       "requires": {
-        "find-up": "^2.0.0",
-        "read-pkg": "^2.0.0"
+        "find-up": "2.1.0",
+        "read-pkg": "2.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -9013,7 +9296,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         }
       }
@@ -9024,13 +9307,13 @@
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
       "dev": true,
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~1.0.6",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.0.3",
-        "util-deprecate": "~1.0.1"
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
       }
     },
     "readdirp": {
@@ -9039,9 +9322,9 @@
       "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "micromatch": "^3.1.10",
-        "readable-stream": "^2.0.2"
+        "graceful-fs": "4.1.11",
+        "micromatch": "3.1.10",
+        "readable-stream": "2.3.3"
       },
       "dependencies": {
         "arr-diff": {
@@ -9062,16 +9345,16 @@
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.1",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "extend-shallow": {
@@ -9080,7 +9363,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -9100,13 +9383,13 @@
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.1",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -9115,7 +9398,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -9124,7 +9407,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-descriptor": {
@@ -9133,9 +9416,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
               }
             },
             "kind-of": {
@@ -9152,14 +9435,14 @@
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.1",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -9168,7 +9451,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -9177,7 +9460,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -9188,10 +9471,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -9200,7 +9483,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -9211,7 +9494,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -9220,7 +9503,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -9231,7 +9514,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -9240,7 +9523,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -9251,7 +9534,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -9260,7 +9543,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -9283,19 +9566,19 @@
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.9",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.1",
+            "to-regex": "3.0.2"
           }
         }
       }
@@ -9306,7 +9589,7 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "^1.1.6"
+        "resolve": "1.5.0"
       }
     },
     "reduce-extract": {
@@ -9315,7 +9598,7 @@
       "integrity": "sha1-Z/I4W+2mUGG19fQxJmLosIDKFSU=",
       "dev": true,
       "requires": {
-        "test-value": "^1.0.1"
+        "test-value": "1.1.0"
       },
       "dependencies": {
         "array-back": {
@@ -9324,7 +9607,7 @@
           "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
           "dev": true,
           "requires": {
-            "typical": "^2.6.0"
+            "typical": "2.6.1"
           }
         },
         "test-value": {
@@ -9333,8 +9616,8 @@
           "integrity": "sha1-oJE29y7AQ9J8iTcHwrFZv6196T8=",
           "dev": true,
           "requires": {
-            "array-back": "^1.0.2",
-            "typical": "^2.4.2"
+            "array-back": "1.0.4",
+            "typical": "2.6.1"
           }
         }
       }
@@ -9357,7 +9640,7 @@
       "integrity": "sha1-aK0OrRGFXJo31OglbBW7+Hly/Iw=",
       "dev": true,
       "requires": {
-        "test-value": "^2.0.0"
+        "test-value": "2.1.0"
       },
       "dependencies": {
         "array-back": {
@@ -9366,7 +9649,7 @@
           "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
           "dev": true,
           "requires": {
-            "typical": "^2.6.0"
+            "typical": "2.6.1"
           }
         },
         "test-value": {
@@ -9375,8 +9658,8 @@
           "integrity": "sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=",
           "dev": true,
           "requires": {
-            "array-back": "^1.0.3",
-            "typical": "^2.6.0"
+            "array-back": "1.0.4",
+            "typical": "2.6.1"
           }
         }
       }
@@ -9399,9 +9682,9 @@
       "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.18.0",
-        "babel-types": "^6.19.0",
-        "private": "^0.1.6"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "private": "0.1.8"
       }
     },
     "regex-not": {
@@ -9410,8 +9693,8 @@
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^3.0.2",
-        "safe-regex": "^1.1.0"
+        "extend-shallow": "3.0.2",
+        "safe-regex": "1.1.0"
       }
     },
     "regexpp": {
@@ -9426,9 +9709,9 @@
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "dev": true,
       "requires": {
-        "regenerate": "^1.2.1",
-        "regjsgen": "^0.2.0",
-        "regjsparser": "^0.1.4"
+        "regenerate": "1.4.0",
+        "regjsgen": "0.2.0",
+        "regjsparser": "0.1.5"
       }
     },
     "regjsgen": {
@@ -9443,7 +9726,7 @@
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "dev": true,
       "requires": {
-        "jsesc": "~0.5.0"
+        "jsesc": "0.5.0"
       }
     },
     "release-zalgo": {
@@ -9452,7 +9735,7 @@
       "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
       "dev": true,
       "requires": {
-        "es6-error": "^4.0.1"
+        "es6-error": "4.1.1"
       }
     },
     "remove-bom-buffer": {
@@ -9461,8 +9744,8 @@
       "integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
       "dev": true,
       "requires": {
-        "is-buffer": "^1.1.5",
-        "is-utf8": "^0.2.1"
+        "is-buffer": "1.1.6",
+        "is-utf8": "0.2.1"
       }
     },
     "remove-bom-stream": {
@@ -9471,9 +9754,9 @@
       "integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
       "dev": true,
       "requires": {
-        "remove-bom-buffer": "^3.0.0",
-        "safe-buffer": "^5.1.0",
-        "through2": "^2.0.3"
+        "remove-bom-buffer": "3.0.0",
+        "safe-buffer": "5.1.1",
+        "through2": "2.0.5"
       }
     },
     "remove-trailing-separator": {
@@ -9500,7 +9783,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "^1.0.0"
+        "is-finite": "1.0.2"
       }
     },
     "replace-ext": {
@@ -9515,9 +9798,9 @@
       "integrity": "sha1-6H9tUTuSjd6AgmDBK+f+xv9ueYw=",
       "dev": true,
       "requires": {
-        "homedir-polyfill": "^1.0.1",
-        "is-absolute": "^1.0.0",
-        "remove-trailing-separator": "^1.1.0"
+        "homedir-polyfill": "1.0.3",
+        "is-absolute": "1.0.0",
+        "remove-trailing-separator": "1.1.0"
       }
     },
     "require-directory": {
@@ -9538,8 +9821,8 @@
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
-        "caller-path": "^0.1.0",
-        "resolve-from": "^1.0.0"
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
       }
     },
     "requires-port": {
@@ -9553,7 +9836,7 @@
       "integrity": "sha512-oJ6y7JcUJkblRGhMByGNcszeLgU0qDxNKFCiUZR1XyzHyVsev+Mxb1tyygxLd1ORsKee1SA5BInFdUwY64GE/A==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.11"
+        "lodash": "4.17.11"
       }
     },
     "resolve": {
@@ -9562,7 +9845,7 @@
       "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "1.0.5"
       }
     },
     "resolve-dir": {
@@ -9571,8 +9854,8 @@
       "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
       "dev": true,
       "requires": {
-        "expand-tilde": "^2.0.0",
-        "global-modules": "^1.0.0"
+        "expand-tilde": "2.0.2",
+        "global-modules": "1.0.0"
       }
     },
     "resolve-from": {
@@ -9587,7 +9870,7 @@
       "integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
       "dev": true,
       "requires": {
-        "value-or-function": "^3.0.0"
+        "value-or-function": "3.0.0"
       }
     },
     "resolve-url": {
@@ -9602,8 +9885,8 @@
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
-        "onetime": "^2.0.0",
-        "signal-exit": "^3.0.2"
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
       }
     },
     "ret": {
@@ -9618,7 +9901,7 @@
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "dev": true,
       "requires": {
-        "glob": "^7.1.3"
+        "glob": "7.1.3"
       },
       "dependencies": {
         "glob": {
@@ -9627,12 +9910,12 @@
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         }
       }
@@ -9649,8 +9932,14 @@
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
       "requires": {
-        "is-promise": "^2.1.0"
+        "is-promise": "2.1.0"
       }
+    },
+    "run-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/run-node/-/run-node-1.0.0.tgz",
+      "integrity": "sha512-kc120TBlQ3mih1LSzdAJXo4xn/GWS2ec0l3S+syHDXP9uRr0JAT8Qd3mdMuyjqCzeZktgP3try92cEgf9Nks8A==",
+      "dev": true
     },
     "rx-lite": {
       "version": "4.0.8",
@@ -9664,7 +9953,7 @@
       "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
       "dev": true,
       "requires": {
-        "rx-lite": "*"
+        "rx-lite": "4.0.8"
       }
     },
     "rxjs": {
@@ -9673,7 +9962,7 @@
       "integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
       "dev": true,
       "requires": {
-        "tslib": "^1.9.0"
+        "tslib": "1.9.3"
       }
     },
     "safe-buffer": {
@@ -9687,7 +9976,7 @@
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
-        "ret": "~0.1.10"
+        "ret": "0.1.15"
       }
     },
     "safer-buffer": {
@@ -9708,13 +9997,19 @@
       "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
       "dev": true
     },
+    "semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
+      "dev": true
+    },
     "semver-greatest-satisfied-range": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/semver-greatest-satisfied-range/-/semver-greatest-satisfied-range-1.1.0.tgz",
       "integrity": "sha1-E+jCZYq5aRywzXEJMkAoDTb3els=",
       "dev": true,
       "requires": {
-        "sver-compat": "^1.5.0"
+        "sver-compat": "1.5.0"
       }
     },
     "sentence-case": {
@@ -9722,8 +10017,8 @@
       "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-2.1.1.tgz",
       "integrity": "sha1-H24t2jnBaL+S0T+G1KkYkz9mftQ=",
       "requires": {
-        "no-case": "^2.2.0",
-        "upper-case-first": "^1.1.2"
+        "no-case": "2.3.2",
+        "upper-case-first": "1.1.2"
       }
     },
     "set-blocking": {
@@ -9738,7 +10033,7 @@
       "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
       "dev": true,
       "requires": {
-        "to-object-path": "^0.3.0"
+        "to-object-path": "0.3.0"
       }
     },
     "set-value": {
@@ -9747,10 +10042,10 @@
       "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-extendable": "^0.1.1",
-        "is-plain-object": "^2.0.3",
-        "split-string": "^3.0.1"
+        "extend-shallow": "2.0.1",
+        "is-extendable": "0.1.1",
+        "is-plain-object": "2.0.4",
+        "split-string": "3.1.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -9759,7 +10054,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -9770,7 +10065,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "^1.0.0"
+        "shebang-regex": "1.0.0"
       }
     },
     "shebang-regex": {
@@ -9791,13 +10086,13 @@
       "integrity": "sha1-nLNGvdsYDWioBEKf/hSXjX+v1ik=",
       "dev": true,
       "requires": {
-        "diff": "^3.1.0",
+        "diff": "3.3.1",
         "formatio": "1.2.0",
-        "lodash.get": "^4.4.2",
-        "lolex": "^2.2.0",
-        "nise": "^1.2.0",
-        "supports-color": "^5.1.0",
-        "type-detect": "^4.0.5"
+        "lodash.get": "4.4.2",
+        "lolex": "2.3.1",
+        "nise": "1.4.10",
+        "supports-color": "5.1.0",
+        "type-detect": "4.0.6"
       },
       "dependencies": {
         "supports-color": {
@@ -9806,7 +10101,7 @@
           "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^2.0.0"
+            "has-flag": "2.0.0"
           }
         }
       }
@@ -9829,7 +10124,7 @@
       "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0"
+        "is-fullwidth-code-point": "2.0.0"
       }
     },
     "snake-case": {
@@ -9837,7 +10132,7 @@
       "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-2.1.0.tgz",
       "integrity": "sha1-Qb2xtz8w7GagTU4srRt2OH1NbZ8=",
       "requires": {
-        "no-case": "^2.2.0"
+        "no-case": "2.3.2"
       }
     },
     "snapdragon": {
@@ -9846,14 +10141,14 @@
       "integrity": "sha1-4StUh/re0+PeoKyR6UAL91tAE3A=",
       "dev": true,
       "requires": {
-        "base": "^0.11.1",
-        "debug": "^2.2.0",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "map-cache": "^0.2.2",
-        "source-map": "^0.5.6",
-        "source-map-resolve": "^0.5.0",
-        "use": "^2.0.0"
+        "base": "0.11.2",
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "map-cache": "0.2.2",
+        "source-map": "0.5.7",
+        "source-map-resolve": "0.5.1",
+        "use": "2.0.2"
       },
       "dependencies": {
         "debug": {
@@ -9871,7 +10166,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "extend-shallow": {
@@ -9880,7 +10175,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "is-accessor-descriptor": {
@@ -9889,7 +10184,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -9898,7 +10193,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -9909,7 +10204,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -9918,7 +10213,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -9929,9 +10224,9 @@
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
           }
         },
         "kind-of": {
@@ -9948,9 +10243,9 @@
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "dev": true,
       "requires": {
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.0",
-        "snapdragon-util": "^3.0.1"
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "snapdragon-util": "3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -9959,7 +10254,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "isobject": {
@@ -9976,7 +10271,7 @@
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "dev": true,
       "requires": {
-        "kind-of": "^3.2.0"
+        "kind-of": "3.2.2"
       }
     },
     "sort-array": {
@@ -9985,9 +10280,9 @@
       "integrity": "sha1-OKnG2if9fRR7QuYFVPKBGHtN9HI=",
       "dev": true,
       "requires": {
-        "array-back": "^1.0.4",
-        "object-get": "^2.1.0",
-        "typical": "^2.6.0"
+        "array-back": "1.0.4",
+        "object-get": "2.1.0",
+        "typical": "2.6.1"
       },
       "dependencies": {
         "array-back": {
@@ -9996,7 +10291,7 @@
           "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
           "dev": true,
           "requires": {
-            "typical": "^2.6.0"
+            "typical": "2.6.1"
           }
         }
       }
@@ -10013,11 +10308,11 @@
       "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
       "dev": true,
       "requires": {
-        "atob": "^2.0.0",
-        "decode-uri-component": "^0.2.0",
-        "resolve-url": "^0.2.1",
-        "source-map-url": "^0.4.0",
-        "urix": "^0.1.0"
+        "atob": "2.1.1",
+        "decode-uri-component": "0.2.0",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.4.0",
+        "urix": "0.1.0"
       }
     },
     "source-map-support": {
@@ -10026,7 +10321,7 @@
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "dev": true,
       "requires": {
-        "source-map": "^0.5.6"
+        "source-map": "0.5.7"
       }
     },
     "source-map-url": {
@@ -10047,12 +10342,12 @@
       "integrity": "sha512-vMwR3OmmDhnxCVxM8M+xO/FtIp6Ju/mNaDfCMMW7FDcLRTPFWUswec4LXJHTJE2hwTI9O0YBfygu4DalFl7Ylg==",
       "dev": true,
       "requires": {
-        "foreground-child": "^1.5.6",
-        "mkdirp": "^0.5.0",
-        "os-homedir": "^1.0.1",
-        "rimraf": "^2.6.2",
-        "signal-exit": "^3.0.2",
-        "which": "^1.3.0"
+        "foreground-child": "1.5.6",
+        "mkdirp": "0.5.1",
+        "os-homedir": "1.0.2",
+        "rimraf": "2.6.3",
+        "signal-exit": "3.0.2",
+        "which": "1.3.0"
       }
     },
     "spdx-correct": {
@@ -10061,7 +10356,7 @@
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
       "dev": true,
       "requires": {
-        "spdx-license-ids": "^1.0.2"
+        "spdx-license-ids": "1.2.2"
       }
     },
     "spdx-expression-parse": {
@@ -10082,7 +10377,7 @@
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^3.0.0"
+        "extend-shallow": "3.0.2"
       }
     },
     "sprintf-js": {
@@ -10103,8 +10398,8 @@
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
-        "define-property": "^0.2.5",
-        "object-copy": "^0.1.0"
+        "define-property": "0.2.5",
+        "object-copy": "0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -10113,7 +10408,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "is-accessor-descriptor": {
@@ -10122,7 +10417,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -10131,7 +10426,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -10142,7 +10437,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -10151,7 +10446,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -10162,9 +10457,9 @@
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
           }
         },
         "kind-of": {
@@ -10181,7 +10476,7 @@
       "integrity": "sha1-GLyB8u2zW4tdmoAJIAqYUxRCipc=",
       "dev": true,
       "requires": {
-        "array-back": "^1.0.2"
+        "array-back": "1.0.4"
       },
       "dependencies": {
         "array-back": {
@@ -10190,7 +10485,7 @@
           "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
           "dev": true,
           "requires": {
-            "typical": "^2.6.0"
+            "typical": "2.6.1"
           }
         }
       }
@@ -10219,8 +10514,8 @@
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -10235,7 +10530,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -10246,7 +10541,7 @@
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "dev": true,
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {
@@ -10255,7 +10550,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "strip-bom": {
@@ -10276,12 +10571,6 @@
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
-    "strip-indent": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
-      "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
-      "dev": true
-    },
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -10293,16 +10582,16 @@
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
       "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
       "requires": {
-        "component-emitter": "^1.2.0",
-        "cookiejar": "^2.1.0",
-        "debug": "^3.1.0",
-        "extend": "^3.0.0",
-        "form-data": "^2.3.1",
-        "formidable": "^1.2.0",
-        "methods": "^1.1.1",
-        "mime": "^1.4.1",
-        "qs": "^6.5.1",
-        "readable-stream": "^2.3.5"
+        "component-emitter": "1.2.1",
+        "cookiejar": "2.1.2",
+        "debug": "3.1.0",
+        "extend": "3.0.2",
+        "form-data": "2.3.3",
+        "formidable": "1.2.1",
+        "methods": "1.1.2",
+        "mime": "1.6.0",
+        "qs": "6.6.0",
+        "readable-stream": "2.3.6"
       },
       "dependencies": {
         "process-nextick-args": {
@@ -10315,13 +10604,13 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -10329,7 +10618,7 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -10346,8 +10635,8 @@
       "integrity": "sha1-PPh9/rTQe0o/FIJ7wYaz/QxkXNg=",
       "dev": true,
       "requires": {
-        "es6-iterator": "^2.0.1",
-        "es6-symbol": "^3.1.1"
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1"
       }
     },
     "swap-case": {
@@ -10355,8 +10644,8 @@
       "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz",
       "integrity": "sha1-w5IDpFhzhfrTyFCgvRvK+ggZdOM=",
       "requires": {
-        "lower-case": "^1.1.1",
-        "upper-case": "^1.1.1"
+        "lower-case": "1.1.4",
+        "upper-case": "1.1.3"
       }
     },
     "table": {
@@ -10365,12 +10654,12 @@
       "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "dev": true,
       "requires": {
-        "ajv": "^5.2.3",
-        "ajv-keywords": "^2.1.0",
-        "chalk": "^2.1.0",
-        "lodash": "^4.17.4",
+        "ajv": "5.5.2",
+        "ajv-keywords": "2.1.1",
+        "chalk": "2.4.2",
+        "lodash": "4.17.11",
         "slice-ansi": "1.0.0",
-        "string-width": "^2.1.1"
+        "string-width": "2.1.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -10379,7 +10668,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -10388,9 +10677,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           }
         },
         "has-flag": {
@@ -10405,7 +10694,7 @@
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -10416,11 +10705,11 @@
       "integrity": "sha512-uNaR3SRMJwfdp9OUr36eyEi6LLsbcTqTO/hfTsNviKsNeyMBPICJCC7QXRF3+07bAP6FRwA8rczJPBqXDc0CkQ==",
       "dev": true,
       "requires": {
-        "array-back": "^2.0.0",
-        "deep-extend": "~0.6.0",
-        "lodash.padend": "^4.6.1",
-        "typical": "^2.6.1",
-        "wordwrapjs": "^3.0.0"
+        "array-back": "2.0.0",
+        "deep-extend": "0.6.0",
+        "lodash.padend": "4.6.1",
+        "typical": "2.6.1",
+        "wordwrapjs": "3.0.0"
       },
       "dependencies": {
         "array-back": {
@@ -10429,7 +10718,7 @@
           "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
           "dev": true,
           "requires": {
-            "typical": "^2.6.1"
+            "typical": "2.6.1"
           }
         }
       }
@@ -10452,10 +10741,10 @@
       "integrity": "sha512-gwf0S2fFsANC55fSeSqpb8BYk6w3FDvwZxfNjeF6FRgvFa43r+7wRiA/Q0IxoRU37wB/LE8IQ4221BsNucTaCA==",
       "dev": true,
       "requires": {
-        "arrify": "^1.0.1",
-        "minimatch": "^3.0.4",
-        "read-pkg-up": "^4.0.0",
-        "require-main-filename": "^1.0.1"
+        "arrify": "1.0.1",
+        "minimatch": "3.0.4",
+        "read-pkg-up": "4.0.0",
+        "require-main-filename": "1.0.1"
       },
       "dependencies": {
         "find-up": {
@@ -10464,7 +10753,7 @@
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
-            "locate-path": "^3.0.0"
+            "locate-path": "3.0.0"
           }
         },
         "load-json-file": {
@@ -10473,10 +10762,10 @@
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^4.0.0",
-            "pify": "^3.0.0",
-            "strip-bom": "^3.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "4.0.0",
+            "pify": "3.0.0",
+            "strip-bom": "3.0.0"
           }
         },
         "locate-path": {
@@ -10485,8 +10774,8 @@
           "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "dev": true,
           "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
+            "p-locate": "3.0.0",
+            "path-exists": "3.0.0"
           }
         },
         "p-limit": {
@@ -10495,7 +10784,7 @@
           "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
           "dev": true,
           "requires": {
-            "p-try": "^2.0.0"
+            "p-try": "2.0.0"
           }
         },
         "p-locate": {
@@ -10504,7 +10793,7 @@
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "requires": {
-            "p-limit": "^2.0.0"
+            "p-limit": "2.2.0"
           }
         },
         "p-try": {
@@ -10519,8 +10808,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
+            "error-ex": "1.3.1",
+            "json-parse-better-errors": "1.0.2"
           }
         },
         "path-exists": {
@@ -10535,7 +10824,7 @@
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "pify": "^3.0.0"
+            "pify": "3.0.0"
           }
         },
         "pify": {
@@ -10550,9 +10839,9 @@
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
-            "load-json-file": "^4.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^3.0.0"
+            "load-json-file": "4.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "3.0.0"
           }
         },
         "read-pkg-up": {
@@ -10561,8 +10850,8 @@
           "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
           "dev": true,
           "requires": {
-            "find-up": "^3.0.0",
-            "read-pkg": "^3.0.0"
+            "find-up": "3.0.0",
+            "read-pkg": "3.0.0"
           }
         }
       }
@@ -10573,8 +10862,8 @@
       "integrity": "sha512-sVACdAWcZkSU9x7AOmJo5TqE+GyNJknHaHsMrR6ZnhjVlVN9Yx6FjHrsKZ3BjIpPCT68zYesPWkakrNupwfOTQ==",
       "dev": true,
       "requires": {
-        "array-back": "^2.0.0",
-        "typical": "^2.6.1"
+        "array-back": "2.0.0",
+        "typical": "2.6.1"
       },
       "dependencies": {
         "array-back": {
@@ -10583,7 +10872,7 @@
           "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
           "dev": true,
           "requires": {
-            "typical": "^2.6.1"
+            "typical": "2.6.1"
           }
         }
       }
@@ -10606,8 +10895,8 @@
       "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
       "dev": true,
       "requires": {
-        "readable-stream": "~2.3.6",
-        "xtend": "~4.0.1"
+        "readable-stream": "2.3.6",
+        "xtend": "4.0.1"
       },
       "dependencies": {
         "process-nextick-args": {
@@ -10622,13 +10911,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -10637,7 +10926,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -10648,8 +10937,8 @@
       "integrity": "sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==",
       "dev": true,
       "requires": {
-        "through2": "~2.0.0",
-        "xtend": "~4.0.0"
+        "through2": "2.0.5",
+        "xtend": "4.0.1"
       }
     },
     "time-stamp": {
@@ -10664,8 +10953,8 @@
       "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
       "dev": true,
       "requires": {
-        "es5-ext": "~0.10.46",
-        "next-tick": "1"
+        "es5-ext": "0.10.49",
+        "next-tick": "1.0.0"
       }
     },
     "title-case": {
@@ -10673,8 +10962,8 @@
       "resolved": "https://registry.npmjs.org/title-case/-/title-case-2.1.1.tgz",
       "integrity": "sha1-PhJyFtpY0rxb7PE3q5Ha46fNj6o=",
       "requires": {
-        "no-case": "^2.2.0",
-        "upper-case": "^1.0.3"
+        "no-case": "2.3.2",
+        "upper-case": "1.1.3"
       }
     },
     "tmp": {
@@ -10683,7 +10972,7 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "~1.0.2"
+        "os-tmpdir": "1.0.2"
       }
     },
     "to-absolute-glob": {
@@ -10692,8 +10981,8 @@
       "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
       "dev": true,
       "requires": {
-        "is-absolute": "^1.0.0",
-        "is-negated-glob": "^1.0.0"
+        "is-absolute": "1.0.0",
+        "is-negated-glob": "1.0.0"
       }
     },
     "to-fast-properties": {
@@ -10708,7 +10997,7 @@
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "to-regex": {
@@ -10717,10 +11006,10 @@
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "dev": true,
       "requires": {
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "regex-not": "^1.0.2",
-        "safe-regex": "^1.1.0"
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "regex-not": "1.0.2",
+        "safe-regex": "1.1.0"
       }
     },
     "to-regex-range": {
@@ -10729,8 +11018,8 @@
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1"
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1"
       },
       "dependencies": {
         "is-number": {
@@ -10739,7 +11028,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         }
       }
@@ -10750,7 +11039,7 @@
       "integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
       "dev": true,
       "requires": {
-        "through2": "^2.0.3"
+        "through2": "2.0.5"
       }
     },
     "trim-right": {
@@ -10771,13 +11060,19 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2"
+        "prelude-ls": "1.1.2"
       }
     },
     "type-detect": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.6.tgz",
       "integrity": "sha512-qZ3bAurt2IXGPR3c57PyaSYEnQiLRwPeS60G9TahElBZsdOABo+iKYch/PhRjSTZJ5/DF08x43XMt9qec2g3ig==",
+      "dev": true
+    },
+    "type-fest": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.4.1.tgz",
+      "integrity": "sha512-IwzA/LSfD2vC1/YDYMv/zHP4rDF1usCwllsDpbolT3D4fUepIO7f9K70jjmUewU/LmGUKJcwcVtDCpnKk4BPMw==",
       "dev": true
     },
     "typedarray": {
@@ -10805,8 +11100,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "~2.20.0",
-        "source-map": "~0.6.1"
+        "commander": "2.20.0",
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "commander": {
@@ -10843,15 +11138,15 @@
       "integrity": "sha1-M52kZGJS0ILcN45wgGcpl1DhG0k=",
       "dev": true,
       "requires": {
-        "arr-flatten": "^1.0.1",
-        "arr-map": "^2.0.0",
-        "bach": "^1.0.0",
-        "collection-map": "^1.0.0",
-        "es6-weak-map": "^2.0.1",
-        "last-run": "^1.1.0",
-        "object.defaults": "^1.0.0",
-        "object.reduce": "^1.0.0",
-        "undertaker-registry": "^1.0.0"
+        "arr-flatten": "1.1.0",
+        "arr-map": "2.0.2",
+        "bach": "1.2.0",
+        "collection-map": "1.0.0",
+        "es6-weak-map": "2.0.2",
+        "last-run": "1.1.1",
+        "object.defaults": "1.1.0",
+        "object.reduce": "1.0.1",
+        "undertaker-registry": "1.0.1"
       }
     },
     "undertaker-registry": {
@@ -10866,10 +11161,10 @@
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "dev": true,
       "requires": {
-        "arr-union": "^3.1.0",
-        "get-value": "^2.0.6",
-        "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
+        "arr-union": "3.1.0",
+        "get-value": "2.0.6",
+        "is-extendable": "0.1.1",
+        "set-value": "0.4.3"
       },
       "dependencies": {
         "extend-shallow": {
@@ -10878,7 +11173,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "set-value": {
@@ -10887,10 +11182,10 @@
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "to-object-path": "0.3.0"
           }
         }
       }
@@ -10901,8 +11196,8 @@
       "integrity": "sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==",
       "dev": true,
       "requires": {
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "through2-filter": "^3.0.0"
+        "json-stable-stringify-without-jsonify": "1.0.1",
+        "through2-filter": "3.0.0"
       }
     },
     "unset-value": {
@@ -10911,8 +11206,8 @@
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
-        "has-value": "^0.3.1",
-        "isobject": "^3.0.0"
+        "has-value": "0.3.1",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "has-value": {
@@ -10921,9 +11216,9 @@
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
-            "get-value": "^2.0.3",
-            "has-values": "^0.1.4",
-            "isobject": "^2.0.0"
+            "get-value": "2.0.6",
+            "has-values": "0.1.4",
+            "isobject": "2.1.0"
           },
           "dependencies": {
             "isobject": {
@@ -10967,7 +11262,7 @@
       "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz",
       "integrity": "sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=",
       "requires": {
-        "upper-case": "^1.1.1"
+        "upper-case": "1.1.3"
       }
     },
     "uri-js": {
@@ -10976,7 +11271,7 @@
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "dev": true,
       "requires": {
-        "punycode": "^2.1.0"
+        "punycode": "2.1.1"
       }
     },
     "urix": {
@@ -10995,8 +11290,8 @@
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.3.tgz",
       "integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
       "requires": {
-        "querystringify": "^2.0.0",
-        "requires-port": "^1.0.0"
+        "querystringify": "2.0.0",
+        "requires-port": "1.0.0"
       }
     },
     "use": {
@@ -11005,9 +11300,9 @@
       "integrity": "sha1-riig1y+TvyJCKhii43mZMRLeyOg=",
       "dev": true,
       "requires": {
-        "define-property": "^0.2.5",
-        "isobject": "^3.0.0",
-        "lazy-cache": "^2.0.2"
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "lazy-cache": "2.0.2"
       },
       "dependencies": {
         "define-property": {
@@ -11016,7 +11311,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "is-accessor-descriptor": {
@@ -11025,7 +11320,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -11034,7 +11329,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -11045,7 +11340,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -11054,7 +11349,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -11065,9 +11360,9 @@
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
           }
         },
         "isobject": {
@@ -11088,7 +11383,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "^0.1.0"
+            "set-getter": "0.1.0"
           }
         }
       }
@@ -11109,7 +11404,7 @@
       "integrity": "sha512-MtivA7GF24yMPte9Rp/BWGCYQNaUj86zeYxV/x2RRJMKagImbbv3u8iJC57lNhWLPcGLJmHcHmFWkNsplbbLWw==",
       "dev": true,
       "requires": {
-        "homedir-polyfill": "^1.0.1"
+        "homedir-polyfill": "1.0.3"
       }
     },
     "validate-npm-package-license": {
@@ -11118,8 +11413,8 @@
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
       "dev": true,
       "requires": {
-        "spdx-correct": "~1.0.0",
-        "spdx-expression-parse": "~1.0.0"
+        "spdx-correct": "1.0.2",
+        "spdx-expression-parse": "1.0.4"
       }
     },
     "value-or-function": {
@@ -11134,12 +11429,12 @@
       "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
       "dev": true,
       "requires": {
-        "clone": "^2.1.1",
-        "clone-buffer": "^1.0.0",
-        "clone-stats": "^1.0.0",
-        "cloneable-readable": "^1.0.0",
-        "remove-trailing-separator": "^1.0.1",
-        "replace-ext": "^1.0.0"
+        "clone": "2.1.2",
+        "clone-buffer": "1.0.0",
+        "clone-stats": "1.0.0",
+        "cloneable-readable": "1.1.2",
+        "remove-trailing-separator": "1.1.0",
+        "replace-ext": "1.0.0"
       }
     },
     "vinyl-fs": {
@@ -11148,23 +11443,23 @@
       "integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
       "dev": true,
       "requires": {
-        "fs-mkdirp-stream": "^1.0.0",
-        "glob-stream": "^6.1.0",
-        "graceful-fs": "^4.0.0",
-        "is-valid-glob": "^1.0.0",
-        "lazystream": "^1.0.0",
-        "lead": "^1.0.0",
-        "object.assign": "^4.0.4",
-        "pumpify": "^1.3.5",
-        "readable-stream": "^2.3.3",
-        "remove-bom-buffer": "^3.0.0",
-        "remove-bom-stream": "^1.2.0",
-        "resolve-options": "^1.1.0",
-        "through2": "^2.0.0",
-        "to-through": "^2.0.0",
-        "value-or-function": "^3.0.0",
-        "vinyl": "^2.0.0",
-        "vinyl-sourcemap": "^1.1.0"
+        "fs-mkdirp-stream": "1.0.0",
+        "glob-stream": "6.1.0",
+        "graceful-fs": "4.1.11",
+        "is-valid-glob": "1.0.0",
+        "lazystream": "1.0.0",
+        "lead": "1.0.0",
+        "object.assign": "4.1.0",
+        "pumpify": "1.5.1",
+        "readable-stream": "2.3.3",
+        "remove-bom-buffer": "3.0.0",
+        "remove-bom-stream": "1.2.0",
+        "resolve-options": "1.1.0",
+        "through2": "2.0.5",
+        "to-through": "2.0.0",
+        "value-or-function": "3.0.0",
+        "vinyl": "2.2.0",
+        "vinyl-sourcemap": "1.1.0"
       }
     },
     "vinyl-sourcemap": {
@@ -11173,13 +11468,13 @@
       "integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
       "dev": true,
       "requires": {
-        "append-buffer": "^1.0.2",
-        "convert-source-map": "^1.5.0",
-        "graceful-fs": "^4.1.6",
-        "normalize-path": "^2.1.1",
-        "now-and-later": "^2.0.0",
-        "remove-bom-buffer": "^3.0.0",
-        "vinyl": "^2.0.0"
+        "append-buffer": "1.0.2",
+        "convert-source-map": "1.5.1",
+        "graceful-fs": "4.1.11",
+        "normalize-path": "2.1.1",
+        "now-and-later": "2.0.0",
+        "remove-bom-buffer": "3.0.0",
+        "vinyl": "2.2.0"
       }
     },
     "vinyl-sourcemaps-apply": {
@@ -11188,7 +11483,7 @@
       "integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
       "dev": true,
       "requires": {
-        "source-map": "^0.5.1"
+        "source-map": "0.5.7"
       }
     },
     "walk-back": {
@@ -11203,7 +11498,7 @@
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
-        "isexe": "^2.0.0"
+        "isexe": "2.0.0"
       }
     },
     "which-module": {
@@ -11229,8 +11524,8 @@
       "integrity": "sha512-mO8XtqyPvykVCsrwj5MlOVWvSnCdT+C+QVbm6blradR7JExAhbkZ7hZ9A+9NUtwzSqrlUo9a67ws0EiILrvRpw==",
       "dev": true,
       "requires": {
-        "reduce-flatten": "^1.0.1",
-        "typical": "^2.6.1"
+        "reduce-flatten": "1.0.1",
+        "typical": "2.6.1"
       }
     },
     "wrap-ansi": {
@@ -11239,8 +11534,8 @@
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -11249,7 +11544,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "string-width": {
@@ -11258,9 +11553,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         }
       }
@@ -11277,7 +11572,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "^0.5.1"
+        "mkdirp": "0.5.1"
       }
     },
     "write-file-atomic": {
@@ -11286,9 +11581,9 @@
       "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.2"
+        "graceful-fs": "4.1.11",
+        "imurmurhash": "0.1.4",
+        "signal-exit": "3.0.2"
       }
     },
     "ws": {
@@ -11296,7 +11591,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.3.tgz",
       "integrity": "sha512-tbSxiT+qJI223AP4iLfQbkbxkwdFcneYinM2+x46Gx2wgvbaOMO36czfdfVUBRTHvzAMRhDd98sA5d/BuWbQdg==",
       "requires": {
-        "async-limiter": "~1.0.0"
+        "async-limiter": "1.0.0"
       }
     },
     "xmlcreate": {
@@ -11329,19 +11624,19 @@
       "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
       "dev": true,
       "requires": {
-        "camelcase": "^3.0.0",
-        "cliui": "^3.2.0",
-        "decamelize": "^1.1.1",
-        "get-caller-file": "^1.0.1",
-        "os-locale": "^1.4.0",
-        "read-pkg-up": "^1.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
-        "set-blocking": "^2.0.0",
-        "string-width": "^1.0.2",
-        "which-module": "^1.0.0",
-        "y18n": "^3.2.1",
-        "yargs-parser": "^5.0.0"
+        "camelcase": "3.0.0",
+        "cliui": "3.2.0",
+        "decamelize": "1.2.0",
+        "get-caller-file": "1.0.3",
+        "os-locale": "1.4.0",
+        "read-pkg-up": "1.0.1",
+        "require-directory": "2.1.1",
+        "require-main-filename": "1.0.1",
+        "set-blocking": "2.0.0",
+        "string-width": "1.0.2",
+        "which-module": "1.0.0",
+        "y18n": "3.2.1",
+        "yargs-parser": "5.0.0"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -11350,7 +11645,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "load-json-file": {
@@ -11359,11 +11654,11 @@
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
           }
         },
         "path-type": {
@@ -11372,9 +11667,9 @@
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "read-pkg": {
@@ -11383,9 +11678,9 @@
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "dev": true,
           "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
           }
         },
         "read-pkg-up": {
@@ -11394,8 +11689,8 @@
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "dev": true,
           "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
           }
         },
         "string-width": {
@@ -11404,9 +11699,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "strip-bom": {
@@ -11415,7 +11710,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         }
       }
@@ -11426,7 +11721,7 @@
       "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
       "dev": true,
       "requires": {
-        "camelcase": "^3.0.0"
+        "camelcase": "3.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "./lib/bus/webSocketConnection.js": "./lib/bus/webSocketConnection.browser.js"
   },
   "scripts": {
+    "add:docs": "git add docs/",
     "build": "npm run build:js && npm run build:docs",
     "build:docs": "node ./support/docs",
     "build:js": "gulp build",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "build:js": "gulp build",
     "coverage": "nyc npm run test:js",
     "lint": "eslint --format 'node_modules/eslint-friendly-formatter' '+(src|support)/**/*.js'",
-    "precommit": "pretty-quick --staged",
     "prepare": "npm run build",
     "report": "nyc report",
     "test": "npm run lint && npm run coverage",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "gulp": "^4.0.0",
     "gulp-babel": "^7.0.1",
     "gulp-sourcemaps": "^2.6.5",
-    "husky": "^0.14.3",
+    "husky": "^2.3.0",
     "jsdoc-to-markdown": "^5.0.0",
     "lodash.omit": "^4.5.0",
     "lodash.pick": "^4.4.0",


### PR DESCRIPTION
## Why?

Currently, an additional npm script needed to be run before opening a pull request to build the docs. This could lead to someone forgetting to run the script when opening up a pull request or reviewers not knowing that the docs needed to be generated.

This is to have one less point of potential contributor/reviewer error

## What changed?
- Upgraded [`husky`](https://github.com/typicode/husky)
- Added the `build:docs` script to the `pre-commit` hook
- Added a `add:docs` npm script which will `git add` the docs` and added this npm script to the `pre-commit` hook
- Updated the `README.md`