### PR TITLE
Update internal config to include webSocket key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [v1.2.3](http://github.com/ndustrialio/contxt-sdk-js/tree/v1.2.3) (2019-06-05)
+
+**Fixed**
+
+- Updated internal config builder to include `webSocket` key
+
 ## [v1.2.2](http://github.com/ndustrialio/contxt-sdk-js/tree/v1.2.2) (2019-06-03)
 
 **Fixed**

--- a/docs/Typedefs.md
+++ b/docs/Typedefs.md
@@ -192,6 +192,7 @@ A single audience used for authenticating and communicating with an individual A
 | --- | --- | --- |
 | config.clientId | <code>string</code> | Client Id provided by Auth0 for the environment you are   trying to communicate with |
 | config.host | <code>string</code> | Hostname for the API that corresponds with the clientId provided |
+| [config.webSocket] | <code>string</code> | WebSocket URL for the API that corresponds with the clientId provided |
 
 <a name="Auth0WebAuthSessionInfo"></a>
 
@@ -466,6 +467,7 @@ custom environment.
 | [config.clientId] | <code>string</code> | Client Id provided by Auth0 for the environment you are   trying to communicate with |
 | [config.env] | <code>string</code> | The SDK provided environment name you are trying to reach |
 | [config.host] | <code>string</code> | Hostname for the API that corresponds with the clientId provided |
+| [config.webSocket] | <code>string</code> | WebSocket URL for the API that corresponds with the clientId provided |
 
 <a name="EdgeNode"></a>
 

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -8,6 +8,7 @@ import defaultConfigs from './defaults';
  * @param {string} config.clientId Client Id provided by Auth0 for the environment you are
  *   trying to communicate with
  * @param {string} config.host Hostname for the API that corresponds with the clientId provided
+ * @param {string} [config.webSocket] WebSocket URL for the API that corresponds with the clientId provided
  */
 
 /**
@@ -20,6 +21,7 @@ import defaultConfigs from './defaults';
  *   trying to communicate with
  * @param {string} [config.env] The SDK provided environment name you are trying to reach
  * @param {string} [config.host] Hostname for the API that corresponds with the clientId provided
+ * @param {string} [config.webSocket] WebSocket URL for the API that corresponds with the clientId provided
  */
 
 /**
@@ -114,6 +116,7 @@ class Config {
    * clientId and host, or an environment that matches a default audience/environment.
    *
    * @param {CustomAudience} config A custom audience configuration to parse
+   * @param {Object.<string, Audience>} audiences An object with keys for environment names and values of Audience information
    *
    * @returns {Audience}
    * @throws {Error}
@@ -122,10 +125,16 @@ class Config {
    */
   _getAudienceFromCustomConfig(config, audiences) {
     if (config.clientId && config.host) {
-      return {
+      const audience = {
         clientId: config.clientId,
         host: config.host
       };
+
+      if (config.webSocket) {
+        audience.webSocket = config.webSocket;
+      }
+
+      return audience;
     } else if (config.env) {
       return audiences[config.env];
     } else {

--- a/src/config/index.spec.js
+++ b/src/config/index.spec.js
@@ -119,6 +119,69 @@ describe('Config', function() {
       }
     );
 
+    context(
+      'when providing a custom host, clientId, and webSocket for a module',
+      function() {
+        let audiences;
+        let expectedAudience;
+
+        beforeEach(function() {
+          const env = faker.hacker.adjective();
+          expectedAudience = fixture.build('audience', {
+            webSocket: faker.internet.url()
+          });
+          const config = { ...expectedAudience, env };
+          const initialAudiences = {
+            [env]: fixture.build('audience'),
+            [faker.hacker.verb()]: fixture.build('audience')
+          };
+
+          audiences = Config.prototype._getAudienceFromCustomConfig(
+            config,
+            initialAudiences
+          );
+        });
+
+        it('provides audience information that matches the custom information provided', function() {
+          expect(audiences).to.deep.equal(expectedAudience);
+          expect(audiences).to.have.property('webSocket');
+        });
+      }
+    );
+
+    context(
+      'when providing a custom host and clientId with a property we do not use',
+      function() {
+        let audiences;
+        let expectedAudience;
+        let invalidPropertyName;
+
+        beforeEach(function() {
+          const env = faker.hacker.adjective();
+          invalidPropertyName = 'invalid';
+          expectedAudience = fixture.build('audience', {
+            [invalidPropertyName]: faker.internet.url()
+          });
+          const config = { ...expectedAudience, env };
+          const initialAudiences = {
+            [env]: fixture.build('audience'),
+            [faker.hacker.verb()]: fixture.build('audience')
+          };
+
+          audiences = Config.prototype._getAudienceFromCustomConfig(
+            config,
+            initialAudiences
+          );
+        });
+
+        it('provides audience information that has the host and clientId but no unused property', function() {
+          expect(audiences.host).to.equal(expectedAudience.host);
+          expect(audiences.clientId).to.equal(expectedAudience.clientId);
+          expect(audiences).to.not.have.property(invalidPropertyName);
+        });
+      }
+    );
+
     context('when providing an environment for a module', function() {
       let audiences;
       let expectedAudience;


### PR DESCRIPTION
## Why?

- The `webSocket` key was not included when passed to the module

## What changed?

- Potentially add `webSocket` key in the config builder