### PR TITLE
Feat/subscribe to the message bus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [v1.4.0](http://github.com/ndustrialio/contxt-sdk-js/tree/v1.4.0) (2019-06-13)
+
+**Added**
+
+- Added `WebSocketConnection#subscribe` for subscribing to a Message Bus channel
+
 ## [v1.3.0](http://github.com/ndustrialio/contxt-sdk-js/tree/v1.3.0) (2019-06-07)
 
 **Added**

--- a/docs/Typedefs.md
+++ b/docs/Typedefs.md
@@ -1133,7 +1133,9 @@ contxtSdk.bus.connect('4f0e51c6-728b-4892-9863-6d002e61204d')
 <a name="WebSocketConnection+subscribe"></a>
 
 ### webSocketConnection.subscribe(serviceClientId, channel, [group], handler, errorHandler)
-Subscribes to a specific channel on the message bus and handles messages as they are received
+Subscribes to a specific channel on the message bus and handles messages as they are received. When the handler is
+called, the message is automatically acknowledged after the message completes except whenever an Error is thrown.
+The user can also programmatically control when the message is acknowledged by calling `ack` at any time.
 
 **Kind**: instance method of [<code>WebSocketConnection</code>](#WebSocketConnection)  
 
@@ -1145,6 +1147,17 @@ Subscribes to a specific channel on the message bus and handles messages as they
 | handler | <code>function</code> | A function that gets invoked with every received message |
 | errorHandler | <code>function</code> | A function that gets invoked with every error |
 
+**Example**  
+```js
+contxtSdk.bus.connect('4f0e51c6-728b-4892-9863-6d002e61204d')
+    .then((webSocket) => {
+      webSocket.subscribe('GCXd2bwE9fgvqxygrx2J7TkDJ3ef', 'feed:1', 'test-sub', (message) => {
+        console.log('Message received: ', message);
+      }, (error) => {
+        console.log('Error received: ', error);
+      });
+    });
+```
 **Example**  
 ```js
 contxtSdk.bus.connect('4f0e51c6-728b-4892-9863-6d002e61204d')

--- a/docs/Typedefs.md
+++ b/docs/Typedefs.md
@@ -1050,6 +1050,7 @@ A wrapper around the raw WebSocket to provide a finite set of operations
     * [.authorize(token)](#WebSocketConnection+authorize) ⇒ <code>Promise</code>
     * [.close()](#WebSocketConnection+close)
     * [.publish(serviceClientId, channel, message)](#WebSocketConnection+publish) ⇒ <code>Promise</code>
+    * [.subscribe(serviceClientId, channel, [group], handler, errorHandler)](#WebSocketConnection+subscribe)
 
 <a name="new_WebSocketConnection_new"></a>
 
@@ -1127,8 +1128,61 @@ contxtSdk.bus.connect('4f0e51c6-728b-4892-9863-6d002e61204d')
       .catch((error) => {
         console.log(error)
       });
-    })
-});
+    });
+```
+<a name="WebSocketConnection+subscribe"></a>
+
+### webSocketConnection.subscribe(serviceClientId, channel, [group], handler, errorHandler)
+Subscribes to a specific channel on the message bus and handles messages as they are received
+
+**Kind**: instance method of [<code>WebSocketConnection</code>](#WebSocketConnection)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| serviceClientId | <code>string</code> | Client ID of the message bus service |
+| channel | <code>string</code> | Message bus channel the message is being sent to |
+| [group] | <code>string</code> | A unique identifier for the subscriber that can be shared between connections |
+| handler | <code>function</code> | A function that gets invoked with every received message |
+| errorHandler | <code>function</code> | A function that gets invoked with every error |
+
+**Example**  
+```js
+contxtSdk.bus.connect('4f0e51c6-728b-4892-9863-6d002e61204d')
+    .then((webSocket) => {
+      webSocket.subscribe('GCXd2bwE9fgvqxygrx2J7TkDJ3ef', 'feed:1', 'test-sub', (message, ack) => {
+        console.log('Message received: ', message);
+
+        ack();
+      }, (error) => {
+        console.log('Error received: ', error);
+      });
+    });
+```
+**Example**  
+```js
+contxtSdk.bus.connect('4f0e51c6-728b-4892-9863-6d002e61204d')
+    .then((webSocket) => {
+      webSocket.subscribe('GCXd2bwE9fgvqxygrx2J7TkDJ3ef', 'feed:1', (message) => {
+        return db.save(message);
+      }, (error) => {
+        console.log('Error received: ', error);
+      });
+    });
+```
+**Example**  
+```js
+contxtSdk.bus.connect('4f0e51c6-728b-4892-9863-6d002e61204d')
+    .then((webSocket) => {
+      webSocket.subscribe('GCXd2bwE9fgvqxygrx2J7TkDJ3ef', 'feed:1', (message, ack) => {
+        return db.save(message)
+          .then(ack)
+          .then(() => {
+            // additional processing
+          });
+      }, (error) => {
+        console.log('Error received: ', error);
+      });
+    });
 ```
 <a name="WebSocketError"></a>
 

--- a/docs/WebSocketConnection.md
+++ b/docs/WebSocketConnection.md
@@ -96,7 +96,9 @@ contxtSdk.bus.connect('4f0e51c6-728b-4892-9863-6d002e61204d')
 <a name="WebSocketConnection+subscribe"></a>
 
 ### webSocketConnection.subscribe(serviceClientId, channel, [group], handler, errorHandler)
-Subscribes to a specific channel on the message bus and handles messages as they are received
+Subscribes to a specific channel on the message bus and handles messages as they are received. When the handler is
+called, the message is automatically acknowledged after the message completes except whenever an Error is thrown.
+The user can also programmatically control when the message is acknowledged by calling `ack` at any time.
 
 **Kind**: instance method of [<code>WebSocketConnection</code>](#WebSocketConnection)  
 
@@ -108,6 +110,17 @@ Subscribes to a specific channel on the message bus and handles messages as they
 | handler | <code>function</code> | A function that gets invoked with every received message |
 | errorHandler | <code>function</code> | A function that gets invoked with every error |
 
+**Example**  
+```js
+contxtSdk.bus.connect('4f0e51c6-728b-4892-9863-6d002e61204d')
+    .then((webSocket) => {
+      webSocket.subscribe('GCXd2bwE9fgvqxygrx2J7TkDJ3ef', 'feed:1', 'test-sub', (message) => {
+        console.log('Message received: ', message);
+      }, (error) => {
+        console.log('Error received: ', error);
+      });
+    });
+```
 **Example**  
 ```js
 contxtSdk.bus.connect('4f0e51c6-728b-4892-9863-6d002e61204d')

--- a/docs/WebSocketConnection.md
+++ b/docs/WebSocketConnection.md
@@ -13,6 +13,7 @@ environments. Documentation for browser environments is found under
     * [.authorize(token)](#WebSocketConnection+authorize) ⇒ <code>Promise</code>
     * [.close()](#WebSocketConnection+close)
     * [.publish(serviceClientId, channel, message)](#WebSocketConnection+publish) ⇒ <code>Promise</code>
+    * [.subscribe(serviceClientId, channel, [group], handler, errorHandler)](#WebSocketConnection+subscribe)
 
 <a name="new_WebSocketConnection_new"></a>
 
@@ -90,6 +91,59 @@ contxtSdk.bus.connect('4f0e51c6-728b-4892-9863-6d002e61204d')
       .catch((error) => {
         console.log(error)
       });
-    })
-});
+    });
+```
+<a name="WebSocketConnection+subscribe"></a>
+
+### webSocketConnection.subscribe(serviceClientId, channel, [group], handler, errorHandler)
+Subscribes to a specific channel on the message bus and handles messages as they are received
+
+**Kind**: instance method of [<code>WebSocketConnection</code>](#WebSocketConnection)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| serviceClientId | <code>string</code> | Client ID of the message bus service |
+| channel | <code>string</code> | Message bus channel the message is being sent to |
+| [group] | <code>string</code> | A unique identifier for the subscriber that can be shared between connections |
+| handler | <code>function</code> | A function that gets invoked with every received message |
+| errorHandler | <code>function</code> | A function that gets invoked with every error |
+
+**Example**  
+```js
+contxtSdk.bus.connect('4f0e51c6-728b-4892-9863-6d002e61204d')
+    .then((webSocket) => {
+      webSocket.subscribe('GCXd2bwE9fgvqxygrx2J7TkDJ3ef', 'feed:1', 'test-sub', (message, ack) => {
+        console.log('Message received: ', message);
+
+        ack();
+      }, (error) => {
+        console.log('Error received: ', error);
+      });
+    });
+```
+**Example**  
+```js
+contxtSdk.bus.connect('4f0e51c6-728b-4892-9863-6d002e61204d')
+    .then((webSocket) => {
+      webSocket.subscribe('GCXd2bwE9fgvqxygrx2J7TkDJ3ef', 'feed:1', (message) => {
+        return db.save(message);
+      }, (error) => {
+        console.log('Error received: ', error);
+      });
+    });
+```
+**Example**  
+```js
+contxtSdk.bus.connect('4f0e51c6-728b-4892-9863-6d002e61204d')
+    .then((webSocket) => {
+      webSocket.subscribe('GCXd2bwE9fgvqxygrx2J7TkDJ3ef', 'feed:1', (message, ack) => {
+        return db.save(message)
+          .then(ack)
+          .then(() => {
+            // additional processing
+          });
+      }, (error) => {
+        console.log('Error received: ', error);
+      });
+    });
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -303,9 +303,9 @@
       }
     },
     "@sinonjs/commons": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.0.tgz",
-      "integrity": "sha512-j4ZwhaHmwsCb4DlDOIWnI5YyKDNMoNThsmwEpfHx6a1EpsGZ9qYLxP++LMlmBRjtGptGHFsGItJ768snllFWpA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.4.0.tgz",
+      "integrity": "sha512-9jHK3YF/8HtJ9wCAbG+j8cD0i0+ATS9A7gXFqS36TblLPNy6rEEc+SB0imo91eCboGaBYGV/MT1/br/J+EE7Tw==",
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
@@ -320,21 +320,21 @@
       }
     },
     "@sinonjs/formatio": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.1.0.tgz",
-      "integrity": "sha512-ZAR2bPHOl4Xg6eklUGpsdiIJ4+J1SNag1DHHrG/73Uz/nVwXqjgUtRPLoS+aVyieN9cSbc0E4LsU984tWcDyNg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
       "dev": true,
       "requires": {
-        "@sinonjs/samsam": "3.1.1"
+        "samsam": "1.3.0"
       }
     },
     "@sinonjs/samsam": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.1.1.tgz",
-      "integrity": "sha512-ILlwvQUwAiaVBzr3qz8oT1moM7AIUHqUc2UmEjQcH9lLe+E+BZPwUMuc9FFojMswRK4r96x5zDTTrowMLw/vuA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.1.tgz",
+      "integrity": "sha512-wRSfmyd81swH0hA1bxJZJ57xr22kC07a1N4zuIL47yTS04bDk6AoCkczcqHEjcRPmJ+FruGJ9WBQiJwMtIElFw==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "1.3.0",
+        "@sinonjs/commons": "1.4.0",
         "array-from": "2.1.1",
         "lodash": "4.17.11"
       }
@@ -4931,15 +4931,6 @@
         "mime-types": "2.1.22"
       }
     },
-    "formatio": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
-      "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
-      "dev": true,
-      "requires": {
-        "samsam": "1.3.0"
-      }
-    },
     "formidable": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
@@ -7010,6 +7001,12 @@
       "integrity": "sha1-h/zPrv/AtozRnVX2cilD+SnqNeo=",
       "dev": true
     },
+    "just-extend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
+      "dev": true
+    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -7176,6 +7173,11 @@
       "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=",
       "dev": true
     },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+    },
     "lodash.padend": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
@@ -7201,9 +7203,9 @@
       "dev": true
     },
     "lolex": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.1.tgz",
-      "integrity": "sha512-mQuW55GhduF3ppo+ZRUTz1PRjEh1hS5BbqU7d8D0ez2OKxHDod7StPPeAVKisZR5aLkHZjdGWSL42LSONUJsZw==",
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
+      "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
       "dev": true
     },
     "loose-envify": {
@@ -7909,28 +7911,32 @@
       "dev": true
     },
     "nise": {
-      "version": "1.4.10",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.10.tgz",
-      "integrity": "sha512-sa0RRbj53dovjc7wombHmVli9ZihXbXCQ2uH3TNm03DyvOSIQbxg+pbqDKrk2oxMK1rtLGVlKxcB9rrc6X5YjA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.0.tgz",
+      "integrity": "sha512-Z3sfYEkLFzFmL8KY6xnSJLRxwQwYBjOXi/24lb62ZnZiGA0JUzGGTI6TBIgfCSMIDl9Jlu8SRmHNACLTemDHww==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "3.1.0",
+        "@sinonjs/formatio": "3.2.1",
         "@sinonjs/text-encoding": "0.7.1",
         "just-extend": "4.0.2",
-        "lolex": "2.7.5",
+        "lolex": "4.1.0",
         "path-to-regexp": "1.7.0"
       },
       "dependencies": {
-        "just-extend": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
-          "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
-          "dev": true
+        "@sinonjs/formatio": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.1.tgz",
+          "integrity": "sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/commons": "1.4.0",
+            "@sinonjs/samsam": "3.3.1"
+          }
         },
         "lolex": {
-          "version": "2.7.5",
-          "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
-          "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.1.0.tgz",
+          "integrity": "sha512-BYxIEXiVq5lGIXeVHnsFzqa1TxN5acnKnPCdlZSpzm8viNEOhiigupA4vTQ9HEFQ6nLTQ9wQOgBknJgzUYQ9Aw==",
           "dev": true
         }
       }
@@ -10081,27 +10087,33 @@
       "dev": true
     },
     "sinon": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.1.6.tgz",
-      "integrity": "sha1-nLNGvdsYDWioBEKf/hSXjX+v1ik=",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.5.0.tgz",
+      "integrity": "sha512-trdx+mB0VBBgoYucy6a9L7/jfQOmvGeaKZT4OOJ+lPAtI8623xyGr8wLiE4eojzBS8G9yXbhx42GHUOVLr4X2w==",
       "dev": true,
       "requires": {
+        "@sinonjs/formatio": "2.0.0",
         "diff": "3.3.1",
-        "formatio": "1.2.0",
         "lodash.get": "4.4.2",
-        "lolex": "2.3.1",
-        "nise": "1.4.10",
-        "supports-color": "5.1.0",
+        "lolex": "2.7.5",
+        "nise": "1.5.0",
+        "supports-color": "5.5.0",
         "type-detect": "4.0.6"
       },
       "dependencies": {
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
         "supports-color": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
-          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "change-case": "^3.0.2",
     "lodash.has": "^4.5.2",
     "lodash.isplainobject": "^4.0.6",
+    "lodash.once": "^4.1.1",
     "url-parse": "^1.4.3",
     "uuid": "^3.3.2",
     "ws": "^6.1.3"

--- a/src/bus/webSocketConnection.js
+++ b/src/bus/webSocketConnection.js
@@ -175,13 +175,25 @@ class WebSocketConnection {
   }
 
   /**
-   * Subscribes to a specific channel on the message bus and handles messages as they are received
+   * Subscribes to a specific channel on the message bus and handles messages as they are received. When the handler is
+   * called, the message is automatically acknowledged after the message completes except whenever an Error is thrown.
+   * The user can also programmatically control when the message is acknowledged by calling `ack` at any time.
    *
    * @param {string} serviceClientId Client ID of the message bus service
    * @param {string} channel Message bus channel the message is being sent to
    * @param {string} [group] A unique identifier for the subscriber that can be shared between connections
    * @param {function} handler A function that gets invoked with every received message
    * @param {function} errorHandler A function that gets invoked with every error
+   *
+   * @example
+   *   contxtSdk.bus.connect('4f0e51c6-728b-4892-9863-6d002e61204d')
+   *     .then((webSocket) => {
+   *       webSocket.subscribe('GCXd2bwE9fgvqxygrx2J7TkDJ3ef', 'feed:1', 'test-sub', (message) => {
+   *         console.log('Message received: ', message);
+   *       }, (error) => {
+   *         console.log('Error received: ', error);
+   *       });
+   *     });
    *
    * @example
    *   contxtSdk.bus.connect('4f0e51c6-728b-4892-9863-6d002e61204d')

--- a/src/bus/webSocketConnection.js
+++ b/src/bus/webSocketConnection.js
@@ -232,6 +232,12 @@ class WebSocketConnection {
    *     });
    */
   subscribe(serviceClientId, channel, group, handler, errorHandler) {
+    if (typeof group === 'function') {
+      errorHandler = handler;
+      handler = group;
+      group = null;
+    }
+
     if (!serviceClientId) {
       return Promise.reject(
         new Error('A service client id is required for subscribing')
@@ -240,12 +246,6 @@ class WebSocketConnection {
 
     if (!channel) {
       return Promise.reject(new Error('A channel is required for subscribing'));
-    }
-
-    if (typeof group === 'function') {
-      errorHandler = handler;
-      handler = group;
-      group = null;
     }
 
     if (!handler) {


### PR DESCRIPTION
## Why?

- The end user needs to be able to subscribe to Message Bus channels

## What changed?

- Add subscribe method for listening to messages from a channel
- Add private acknowledge method for acknowledging messages from the channel
- Refactor single use JSON RPC listeners
- Refactor is connected check
- Test new methods
- Document new methods