### PR TITLE
Adds the consent module to coordinator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [v1.5.0](http://github.com/ndustrialio/contxt-sdk-js/tree/v1.4.2) (2019-07-03)
+
+**Added**
+
+- Added `Coordinator.consent#verify` for verifying if consent is needed for an application
+- Added `Coordinator.consent#accept` for accepting user consent to an applications
+
 ## [v1.4.2](http://github.com/ndustrialio/contxt-sdk-js/tree/v1.4.2) (2019-06-14)
 
 **Fixed**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [v1.7.0](http://github.com/ndustrialio/contxt-sdk-js/tree/v1.4.2) (2019-07-03)
+## [v1.7.0](http://github.com/ndustrialio/contxt-sdk-js/tree/v1.7.0) (2019-07-03)
 
 **Added**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 **Added**
 
-- Added `Coordinator.consent#get` for getting the current application version's consent form. The current access_token will be used to derive which application is being consented to.
+- Added `Coordinator.consent#getForCurrentApplication` for getting the current application version's consent form. The current access_token will be used to derive which application is being consented to.
 - Added `Coordinator.consent#accept` for accepting user consent to an applications
 
 ## [v1.6.0](http://github.com/ndustrialio/contxt-sdk-js/tree/v1.5.0) (2019-06-25)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 **Added**
 
-- Added `Coordinator.consent#verify` for verifying if consent is needed for an application
+- Added `Coordinator.consent#get` for getting the current application version's consent form. The current access_token will be used to derive which application is being consented to.
 - Added `Coordinator.consent#accept` for accepting user consent to an applications
 
 ## [v1.6.0](http://github.com/ndustrialio/contxt-sdk-js/tree/v1.5.0) (2019-06-25)

--- a/docs/Auth0WebAuth.md
+++ b/docs/Auth0WebAuth.md
@@ -21,6 +21,7 @@ enabled in Auth0.
 * [Auth0WebAuth](#Auth0WebAuth) : [<code>SessionType</code>](./Typedefs.md#SessionType)
     * [new Auth0WebAuth(sdk)](#new_Auth0WebAuth_new)
     * [.clearCurrentApiToken(audienceName)](#Auth0WebAuth+clearCurrentApiToken) ⇒ <code>Promise</code>
+    * [.getCurrentAccessToken()](#Auth0WebAuth+getCurrentAccessToken) ⇒ <code>Promise</code>
     * [.getCurrentApiToken(audienceName)](#Auth0WebAuth+getCurrentApiToken) ⇒ <code>Promise</code>
     * [.getProfile()](#Auth0WebAuth+getProfile) ⇒ <code>Promise</code>
     * [.handleAuthentication()](#Auth0WebAuth+handleAuthentication) ⇒ <code>Promise</code>
@@ -70,10 +71,17 @@ Removes an audience's API token from the in-memory token storage
 | --- |
 | audienceName | 
 
+<a name="Auth0WebAuth+getCurrentAccessToken"></a>
+
+### contxtSdk.auth.getCurrentAccessToken() ⇒ <code>Promise</code>
+Gets the current auth0 access token
+
+**Kind**: instance method of [<code>Auth0WebAuth</code>](#Auth0WebAuth)  
+**Fulfills**: <code>string</code> accessToken  
 <a name="Auth0WebAuth+getCurrentApiToken"></a>
 
 ### contxtSdk.auth.getCurrentApiToken(audienceName) ⇒ <code>Promise</code>
-Requests an access token from Contxt Auth for the correct audience
+Requests an api token from Contxt Auth for the correct audience
 
 **Kind**: instance method of [<code>Auth0WebAuth</code>](#Auth0WebAuth)  
 **Fulfills**: <code>string</code> apiToken  

--- a/docs/Consent.md
+++ b/docs/Consent.md
@@ -8,7 +8,7 @@ Module for managing application consent
 * [Consent](#Consent)
     * [new Consent(sdk, request, baseUrl)](#new_Consent_new)
     * [.accept(consentId)](#Consent+accept) ⇒ <code>Promise</code>
-    * [.get()](#Consent+get) ⇒ <code>Promise</code>
+    * [.getForCurrentApplication()](#Consent+getForCurrentApplication) ⇒ <code>Promise</code>
 
 <a name="new_Consent_new"></a>
 
@@ -44,9 +44,9 @@ contxtSdk.coordinator.consent
   .then((userApproval) => console.log(userApproval))
   .catch((err) => console.log(err));
 ```
-<a name="Consent+get"></a>
+<a name="Consent+getForCurrentApplication"></a>
 
-### contxtSdk.coordinator.consent.get() ⇒ <code>Promise</code>
+### contxtSdk.coordinator.consent.getForCurrentApplication() ⇒ <code>Promise</code>
 Gets the current application version's consent forms. The current
 access_token will be used to derive which application is being consented to.
 
@@ -62,7 +62,7 @@ Note: Only valid for web users using auth0WebAuth session type
 **Example**  
 ```js
 contxtSdk.coordinator.consent
-  .get()
+  .getForCurrentApplication()
   .then((applicationConsent) => console.log(applicationConsent))
   .catch((err) => console.log(err));
 ```

--- a/docs/Consent.md
+++ b/docs/Consent.md
@@ -40,7 +40,7 @@ Method: POST
 **Example**  
 ```js
 contxtSdk.coordinator.consent
-  .accept('coordinator', '36b8421a-cc4a-4204-b839-1397374fb16b')
+  .accept('36b8421a-cc4a-4204-b839-1397374fb16b')
   .then((userApproval) => console.log(userApproval))
   .catch((err) => console.log(err));
 ```
@@ -59,7 +59,7 @@ Method: POST
 **Example**  
 ```js
 contxtSdk.coordinator.consent
-  .verify('coordinator')
+  .verify()
   .then((applicationConsent) => console.log(applicationConsent))
   .catch((err) => console.log(err));
 ```

--- a/docs/Consent.md
+++ b/docs/Consent.md
@@ -23,7 +23,7 @@ Module for managing application consent
 <a name="Consent+accept"></a>
 
 ### contxtSdk.coordinator.consent.accept(audienceName, consentId) ⇒ <code>Promise</code>
-Accepts an application's consent for a given audience name
+Accepts a user's consent to an application for a given audience name
 
 
 API Endpoint: '/consents/:consentId/accept'
@@ -40,7 +40,7 @@ Method: POST
 
 **Example**  
 ```js
-contxtSdk.consent
+contxtSdk.coordinator.consent
   .accept('coordinator', '36b8421a-cc4a-4204-b839-1397374fb16b')
   .then((userApproval) => console.log(userApproval))
   .catch((err) => console.log(err));
@@ -64,7 +64,7 @@ Method: POST
 
 **Example**  
 ```js
-contxtSdk.consent
+contxtSdk.coordinator.consent
   .verify('coordinator')
   .then((applicationConsent) => console.log(applicationConsent))
   .catch((err) => console.log(err));

--- a/docs/Consent.md
+++ b/docs/Consent.md
@@ -8,7 +8,7 @@ Module for managing application consent
 * [Consent](#Consent)
     * [new Consent(sdk, request, baseUrl)](#new_Consent_new)
     * [.accept(consentId)](#Consent+accept) ⇒ <code>Promise</code>
-    * [.verify()](#Consent+verify) ⇒ <code>Promise</code>
+    * [.get()](#Consent+get) ⇒ <code>Promise</code>
 
 <a name="new_Consent_new"></a>
 
@@ -35,7 +35,7 @@ Method: POST
 
 | Param | Type | Description |
 | --- | --- | --- |
-| consentId | <code>string</code> | The ID of the consent form the user is accepting |
+| consentId | <code>string</code> | The ID of the consent form the user is accepting Note: Only valid for web users using auth0WebAuth session type |
 
 **Example**  
 ```js
@@ -44,14 +44,17 @@ contxtSdk.coordinator.consent
   .then((userApproval) => console.log(userApproval))
   .catch((err) => console.log(err));
 ```
-<a name="Consent+verify"></a>
+<a name="Consent+get"></a>
 
-### contxtSdk.coordinator.consent.verify() ⇒ <code>Promise</code>
-Verify if application consent is needed from the user
+### contxtSdk.coordinator.consent.get() ⇒ <code>Promise</code>
+Gets the current application version's consent forms. The current
+access_token will be used to derive which application is being consented to.
 
 
 API Endpoint: '/applications/consent'
 Method: POST
+
+Note: Only valid for web users using auth0WebAuth session type
 
 **Kind**: instance method of [<code>Consent</code>](#Consent)  
 **Fulfill**: [<code>ContxtApplicationConsent</code>](./Typedefs.md#ContxtApplicationConsent)  
@@ -59,7 +62,7 @@ Method: POST
 **Example**  
 ```js
 contxtSdk.coordinator.consent
-  .verify()
+  .get()
   .then((applicationConsent) => console.log(applicationConsent))
   .catch((err) => console.log(err));
 ```

--- a/docs/Consent.md
+++ b/docs/Consent.md
@@ -7,8 +7,8 @@ Module for managing application consent
 
 * [Consent](#Consent)
     * [new Consent(sdk, request, baseUrl)](#new_Consent_new)
-    * [.accept(audienceName, consentId)](#Consent+accept) ⇒ <code>Promise</code>
-    * [.verify(audienceName)](#Consent+verify) ⇒ <code>Promise</code>
+    * [.accept(consentId)](#Consent+accept) ⇒ <code>Promise</code>
+    * [.verify()](#Consent+verify) ⇒ <code>Promise</code>
 
 <a name="new_Consent_new"></a>
 
@@ -22,8 +22,8 @@ Module for managing application consent
 
 <a name="Consent+accept"></a>
 
-### contxtSdk.coordinator.consent.accept(audienceName, consentId) ⇒ <code>Promise</code>
-Accepts a user's consent to an application for a given audience name
+### contxtSdk.coordinator.consent.accept(consentId) ⇒ <code>Promise</code>
+Accepts a user's consent to an application
 
 
 API Endpoint: '/consents/:consentId/accept'
@@ -35,7 +35,6 @@ Method: POST
 
 | Param | Type | Description |
 | --- | --- | --- |
-| audienceName | <code>string</code> | The auth0 audience that the user is consenting with |
 | consentId | <code>string</code> | The ID of the consent form the user is accepting |
 
 **Example**  
@@ -47,8 +46,8 @@ contxtSdk.coordinator.consent
 ```
 <a name="Consent+verify"></a>
 
-### contxtSdk.coordinator.consent.verify(audienceName) ⇒ <code>Promise</code>
-Verify if application consent is needed from the user for a given audience name
+### contxtSdk.coordinator.consent.verify() ⇒ <code>Promise</code>
+Verify if application consent is needed from the user
 
 
 API Endpoint: '/applications/consent'
@@ -57,11 +56,6 @@ Method: POST
 **Kind**: instance method of [<code>Consent</code>](#Consent)  
 **Fulfill**: [<code>ContxtApplicationConsent</code>](./Typedefs.md#ContxtApplicationConsent)  
 **Reject**: <code>Error</code>  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| audienceName | <code>string</code> | The auth0 audience that the user is verifying consent with |
-
 **Example**  
 ```js
 contxtSdk.coordinator.consent

--- a/docs/Consent.md
+++ b/docs/Consent.md
@@ -1,0 +1,71 @@
+<a name="Consent"></a>
+
+## Consent
+Module for managing application consent
+
+**Kind**: global class  
+
+* [Consent](#Consent)
+    * [new Consent(sdk, request, baseUrl)](#new_Consent_new)
+    * [.accept(audienceName, consentId)](#Consent+accept) ⇒ <code>Promise</code>
+    * [.verify(audienceName)](#Consent+verify) ⇒ <code>Promise</code>
+
+<a name="new_Consent_new"></a>
+
+### new Consent(sdk, request, baseUrl)
+
+| Param | Type | Description |
+| --- | --- | --- |
+| sdk | <code>Object</code> | An instance of the SDK so the module can communicate with other modules |
+| request | <code>Object</code> | An instance of the request module tied to this module's audience. |
+| baseUrl | <code>string</code> | The base URL provided by the parent module |
+
+<a name="Consent+accept"></a>
+
+### contxtSdk.coordinator.consent.accept(audienceName, consentId) ⇒ <code>Promise</code>
+Accepts an application's consent for a given audience name
+
+
+API Endpoint: '/consents/:consentId/accept'
+Method: POST
+
+**Kind**: instance method of [<code>Consent</code>](#Consent)  
+**Fulfill**: [<code>ContxtUserConsentApproval</code>](./Typedefs.md#ContxtUserConsentApproval)  
+**Reject**: <code>Error</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| audienceName | <code>string</code> | The auth0 audience that the user is consenting with |
+| consentId | <code>string</code> | The ID of the consent form the user is accepting |
+
+**Example**  
+```js
+contxtSdk.consent
+  .accept('coordinator', '36b8421a-cc4a-4204-b839-1397374fb16b')
+  .then((userApproval) => console.log(userApproval))
+  .catch((err) => console.log(err));
+```
+<a name="Consent+verify"></a>
+
+### contxtSdk.coordinator.consent.verify(audienceName) ⇒ <code>Promise</code>
+Verify if application consent is needed from the user for a given audience name
+
+
+API Endpoint: '/applications/consent'
+Method: POST
+
+**Kind**: instance method of [<code>Consent</code>](#Consent)  
+**Fulfill**: [<code>ContxtApplicationConsent</code>](./Typedefs.md#ContxtApplicationConsent)  
+**Reject**: <code>Error</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| audienceName | <code>string</code> | The auth0 audience that the user is verifying consent with |
+
+**Example**  
+```js
+contxtSdk.consent
+  .verify('coordinator')
+  .then((applicationConsent) => console.log(applicationConsent))
+  .catch((err) => console.log(err));
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,6 +52,9 @@ environments. Documentation for browser environments is found under
 <dt><a href="./Config.md">Config</a></dt>
 <dd><p>Module that merges user assigned configurations with default configurations.</p>
 </dd>
+<dt><a href="./Consent.md">Consent</a></dt>
+<dd><p>Module for managing application consent</p>
+</dd>
 <dt><a href="./ContxtSdk.md">ContxtSdk</a></dt>
 <dd><p>ContxtSdk constructor</p>
 </dd>
@@ -169,9 +172,15 @@ More information at <a href="https://github.com/axios/axios#interceptors">axios 
 </dd>
 <dt><a href="./Typedefs.md#ContxtApplication">ContxtApplication</a> : <code>Object</code></dt>
 <dd></dd>
+<dt><a href="./Typedefs.md#ContxtApplicationConsent">ContxtApplicationConsent</a> : <code>Object</code></dt>
+<dd></dd>
 <dt><a href="./Typedefs.md#ContxtApplicationGrouping">ContxtApplicationGrouping</a> : <code>Object</code></dt>
 <dd></dd>
 <dt><a href="./Typedefs.md#ContxtApplicationModule">ContxtApplicationModule</a> : <code>Object</code></dt>
+<dd></dd>
+<dt><a href="./Typedefs.md#ContxtApplicationVersion">ContxtApplicationVersion</a> : <code>Object</code></dt>
+<dd></dd>
+<dt><a href="./Typedefs.md#ContxtConsent">ContxtConsent</a> : <code>Object</code></dt>
 <dd></dd>
 <dt><a href="./Typedefs.md#ContxtOrganization">ContxtOrganization</a> : <code>Object</code></dt>
 <dd></dd>
@@ -188,6 +197,8 @@ More information at <a href="https://github.com/axios/axios#interceptors">axios 
 <dt><a href="./Typedefs.md#ContxtUser">ContxtUser</a> : <code>Object</code></dt>
 <dd></dd>
 <dt><a href="./Typedefs.md#ContxtUserApplication">ContxtUserApplication</a> : <code>Object</code></dt>
+<dd></dd>
+<dt><a href="./Typedefs.md#ContxtUserConsentApproval">ContxtUserConsentApproval</a> : <code>Object</code></dt>
 <dd></dd>
 <dt><a href="./Typedefs.md#ContxtUserFavoriteApplication">ContxtUserFavoriteApplication</a> : <code>Object</code></dt>
 <dd></dd>

--- a/docs/Typedefs.md
+++ b/docs/Typedefs.md
@@ -238,6 +238,24 @@ More information at [axios Interceptors](https://github.com/axios/axios#intercep
 | type | <code>string</code> |  |
 | updatedAt | <code>string</code> | ISO 8601 Extended Format date/time string |
 
+<a name="ContxtApplicationConsent"></a>
+
+## ContxtApplicationConsent : <code>Object</code>
+**Kind**: global typedef  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| clientId | <code>string</code> |  |
+| clientSecret | <code>string</code> |  |
+| createdAt | <code>string</code> | ISO 8601 Extended Format date/time string |
+| currentVersion | [<code>ContxtApplicationVersion</code>](./Typedefs.md#ContxtApplicationVersion) | The current application version |
+| description | <code>string</code> | Application's description |
+| iconUrl | <code>string</code> | Application's icon url |
+| id | <code>number</code> | Application's ID |
+| name | <code>string</code> | Application's name |
+| serviceId | <code>number</code> | Application's service ID |
+| updatedAt | <code>string</code> | ISO 8601 Extended Format date/time string |
+
 <a name="ContxtApplicationGrouping"></a>
 
 ## ContxtApplicationGrouping : <code>Object</code>
@@ -267,6 +285,37 @@ More information at [axios Interceptors](https://github.com/axios/axios#intercep
 | index | <code>number</code> | The position of the module within the list of all   modules of a the parent application grouping |
 | label | <code>string</code> |  |
 | slug | <code>string</code> | String that corresponds with a front-end package   name (e.g. the `@ndustrial/nsight-example` example application) |
+
+<a name="ContxtApplicationVersion"></a>
+
+## ContxtApplicationVersion : <code>Object</code>
+**Kind**: global typedef  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| applicationId | <code>number</code> |  |
+| [consent] | [<code>ContxtConsent</code>](./Typedefs.md#ContxtConsent) | The consent model associated with this application version |
+| consentId | <code>string</code> |  |
+| createdAt | <code>string</code> | ISO 8601 Extended Format date/time string |
+| description | <code>string</code> |  |
+| id | <code>string</code> | UUID |
+| label | <code>string</code> |  |
+| updatedAt | <code>string</code> | ISO 8601 Extended Format date/time string |
+
+<a name="ContxtConsent"></a>
+
+## ContxtConsent : <code>Object</code>
+**Kind**: global typedef  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| createdAt | <code>string</code> | ISO 8601 Extended Format date/time string |
+| [effectiveEndDate] | <code>string</code> | ISO 8601 Extended Format date/time string |
+| effectiveStartDate | <code>string</code> | ISO 8601 Extended Format date/time string |
+| id | <code>string</code> | UUID |
+| text | <code>string</code> | The body of the consent form in HTML |
+| updatedAt | <code>string</code> | ISO 8601 Extended Format date/time string |
+| userApproval | [<code>Array.&lt;ContxtUser&gt;</code>](#ContxtUser) | An array of users. If empty, the user has not consented |
 
 <a name="ContxtOrganization"></a>
 
@@ -395,6 +444,19 @@ More information at [axios Interceptors](https://github.com/axios/axios#intercep
 | id | <code>string</code> |  |
 | userId | <code>string</code> |  |
 | updatedAt | <code>string</code> | ISO 8601 Extended Format date/time string |
+
+<a name="ContxtUserConsentApproval"></a>
+
+## ContxtUserConsentApproval : <code>Object</code>
+**Kind**: global typedef  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| consentId | <code>string</code> |  |
+| createdAt | <code>string</code> | ISO 8601 Extended Format date/time string |
+| id | <code>string</code> | UUID |
+| updatedAt | <code>string</code> | ISO 8601 Extended Format date/time string |
+| userId | <code>string</code> | UUID |
 
 <a name="ContxtUserFavoriteApplication"></a>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5027,8 +5027,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5049,14 +5048,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5071,20 +5068,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5201,8 +5195,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5214,7 +5207,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5229,7 +5221,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5237,14 +5228,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5263,7 +5252,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5344,8 +5332,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5357,7 +5344,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5443,8 +5429,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5480,7 +5465,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5500,7 +5484,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5544,14 +5527,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/src/coordinator/consent.js
+++ b/src/coordinator/consent.js
@@ -64,7 +64,7 @@ class Consent {
   }
 
   /**
-   * Accepts an application's consent for a given audience name
+   * Accepts a user's consent to an application for a given audience name
    *
    *
    * API Endpoint: '/consents/:consentId/accept'
@@ -78,7 +78,7 @@ class Consent {
    * @reject {Error}
    *
    * @example
-   * contxtSdk.consent
+   * contxtSdk.coordinator.consent
    *   .accept('coordinator', '36b8421a-cc4a-4204-b839-1397374fb16b')
    *   .then((userApproval) => console.log(userApproval))
    *   .catch((err) => console.log(err));
@@ -127,7 +127,7 @@ class Consent {
    * @reject {Error}
    *
    * @example
-   * contxtSdk.consent
+   * contxtSdk.coordinator.consent
    *   .verify('coordinator')
    *   .then((applicationConsent) => console.log(applicationConsent))
    *   .catch((err) => console.log(err));

--- a/src/coordinator/consent.js
+++ b/src/coordinator/consent.js
@@ -120,11 +120,11 @@ class Consent {
    *
    * @example
    * contxtSdk.coordinator.consent
-   *   .get()
+   *   .getForCurrentApplication()
    *   .then((applicationConsent) => console.log(applicationConsent))
    *   .catch((err) => console.log(err));
    */
-  get() {
+  getForCurrentApplication() {
     return this._sdk.auth.getCurrentAccessToken().then((accessToken) => {
       if (!accessToken) {
         return Promise.reject(new Error('A valid JWT token is required'));

--- a/src/coordinator/consent.js
+++ b/src/coordinator/consent.js
@@ -91,17 +91,17 @@ class Consent {
       );
     }
 
-    const { accessToken } = this._sdk.auth._getStoredSession();
+    return this._sdk.auth.getCurrentAccessToken().then((accessToken) => {
+      if (!accessToken) {
+        return Promise.reject(new Error('A valid JWT token is required'));
+      }
 
-    if (!accessToken) {
-      return Promise.reject(new Error('A valid JWT token is required'));
-    }
-
-    return this._request
-      .post(`${this._baseUrl}/consents/${consentId}/accept`, {
-        access_token: accessToken
-      })
-      .then((userApproval) => toCamelCase(userApproval));
+      return this._request
+        .post(`${this._baseUrl}/consents/${consentId}/accept`, {
+          access_token: accessToken
+        })
+        .then((userApproval) => toCamelCase(userApproval));
+    });
   }
 
   /**
@@ -125,17 +125,17 @@ class Consent {
    *   .catch((err) => console.log(err));
    */
   get() {
-    const { accessToken } = this._sdk.auth._getStoredSession();
+    return this._sdk.auth.getCurrentAccessToken().then((accessToken) => {
+      if (!accessToken) {
+        return Promise.reject(new Error('A valid JWT token is required'));
+      }
 
-    if (!accessToken) {
-      return Promise.reject(new Error('A valid JWT token is required'));
-    }
-
-    return this._request
-      .post(`${this._baseUrl}/applications/consent`, {
-        access_token: accessToken
-      })
-      .then((applicationConsent) => toCamelCase(applicationConsent));
+      return this._request
+        .post(`${this._baseUrl}/applications/consent`, {
+          access_token: accessToken
+        })
+        .then((applicationConsent) => toCamelCase(applicationConsent));
+    });
   }
 }
 

--- a/src/coordinator/consent.js
+++ b/src/coordinator/consent.js
@@ -1,0 +1,160 @@
+import { toCamelCase } from '../utils/objects';
+
+/**
+ * @typedef {Object} ContxtApplicationConsent
+ * @param {string} clientId
+ * @param {string} clientSecret
+ * @param {string} createdAt ISO 8601 Extended Format date/time string
+ * @param {ContxtApplicationVersion} currentVersion The current application version
+ * @param {string} description Application's description
+ * @param {string} iconUrl Application's icon url
+ * @param {number} id Application's ID
+ * @param {string} name Application's name
+ * @param {number} serviceId Application's service ID
+ * @param {string} updatedAt ISO 8601 Extended Format date/time string
+ */
+
+/**
+ * @typedef {Object} ContxtApplicationVersion
+ * @param {number} applicationId
+ * @param {ContxtConsent} [consent] The consent model associated with this application version
+ * @param {string} consentId
+ * @param {string} createdAt ISO 8601 Extended Format date/time string
+ * @param {string} description
+ * @param {string} id UUID
+ * @param {string} label
+ * @param {string} updatedAt ISO 8601 Extended Format date/time string
+ */
+
+/**
+ * @typedef {Object} ContxtConsent
+ * @param {string} createdAt ISO 8601 Extended Format date/time string
+ * @param {string} [effectiveEndDate] ISO 8601 Extended Format date/time string
+ * @param {string} effectiveStartDate ISO 8601 Extended Format date/time string
+ * @param {string} id UUID
+ * @param {string} text The body of the consent form in HTML
+ * @param {string} updatedAt ISO 8601 Extended Format date/time string
+ * @param {ContxtUser[]} userApproval An array of users. If empty, the user has not consented
+ */
+
+/**
+ * @typedef {Object} ContxtUserConsentApproval
+ * @param {string} consentId
+ * @param {string} createdAt ISO 8601 Extended Format date/time string
+ * @param {string} id UUID
+ * @param {string} updatedAt ISO 8601 Extended Format date/time string
+ * @param {string} userId UUID
+ */
+
+/**
+ * Module for managing application consent
+ *
+ * @typicalname contxtSdk.coordinator.consent
+ */
+class Consent {
+  /**
+   * @param {Object} sdk An instance of the SDK so the module can communicate with other modules
+   * @param {Object} request An instance of the request module tied to this module's audience.
+   * @param {string} baseUrl The base URL provided by the parent module
+   */
+  constructor(sdk, request, baseUrl) {
+    this._baseUrl = baseUrl;
+    this._request = request;
+    this._sdk = sdk;
+  }
+
+  /**
+   * Accepts an application's consent for a given audience name
+   *
+   *
+   * API Endpoint: '/consents/:consentId/accept'
+   * Method: POST
+   *
+   * @param {string} audienceName The auth0 audience that the user is consenting with
+   * @param {string} consentId The ID of the consent form the user is accepting
+   *
+   * @returns {Promise}
+   * @fulfill {ContxtUserConsentApproval}
+   * @reject {Error}
+   *
+   * @example
+   * contxtSdk.consent
+   *   .accept('coordinator', '36b8421a-cc4a-4204-b839-1397374fb16b')
+   *   .then((userApproval) => console.log(userApproval))
+   *   .catch((err) => console.log(err));
+   */
+  accept(audienceName, consentId) {
+    if (!audienceName) {
+      return Promise.reject(
+        new Error('An audience name is required for accepting consent')
+      );
+    }
+
+    if (!consentId) {
+      return Promise.reject(
+        new Error('A consent ID is required for accepting consent')
+      );
+    }
+
+    return this._sdk.auth
+      .getCurrentApiToken(audienceName)
+      .then((accessToken) => {
+        if (!accessToken) {
+          throw new Error(
+            `A valid JWT token for the audience ${audienceName} is required`
+          );
+        }
+
+        return this._request
+          .post(`${this._baseUrl}/consents/${consentId}/accept`, {
+            access_token: accessToken
+          })
+          .then((userApproval) => toCamelCase(userApproval));
+      });
+  }
+
+  /**
+   * Verify if application consent is needed from the user for a given audience name
+   *
+   *
+   * API Endpoint: '/applications/consent'
+   * Method: POST
+   *
+   * @param {string} audienceName The auth0 audience that the user is verifying consent with
+   *
+   * @returns {Promise}
+   * @fulfill {ContxtApplicationConsent}
+   * @reject {Error}
+   *
+   * @example
+   * contxtSdk.consent
+   *   .verify('coordinator')
+   *   .then((applicationConsent) => console.log(applicationConsent))
+   *   .catch((err) => console.log(err));
+   */
+  verify(audienceName) {
+    if (!audienceName) {
+      return Promise.reject(
+        new Error('An audience name is required for verifying consent')
+      );
+    }
+
+    return this._sdk.auth
+      .getCurrentApiToken(audienceName)
+      .then((accessToken) => {
+        if (!accessToken) {
+          throw new Error(
+            `A valid JWT token for the audience ${audienceName} is required`
+          );
+        }
+
+        return this._request
+          .post(`${this._baseUrl}/applications/consent`, {
+            access_token: accessToken
+          })
+          .then((applicationConsent) => toCamelCase(applicationConsent));
+      });
+  }
+}
+
+export default Consent;

--- a/src/coordinator/consent.js
+++ b/src/coordinator/consent.js
@@ -64,13 +64,12 @@ class Consent {
   }
 
   /**
-   * Accepts a user's consent to an application for a given audience name
+   * Accepts a user's consent to an application
    *
    *
    * API Endpoint: '/consents/:consentId/accept'
    * Method: POST
    *
-   * @param {string} audienceName The auth0 audience that the user is consenting with
    * @param {string} consentId The ID of the consent form the user is accepting
    *
    * @returns {Promise}
@@ -83,44 +82,32 @@ class Consent {
    *   .then((userApproval) => console.log(userApproval))
    *   .catch((err) => console.log(err));
    */
-  accept(audienceName, consentId) {
-    if (!audienceName) {
-      return Promise.reject(
-        new Error('An audience name is required for accepting consent')
-      );
-    }
-
+  accept(consentId) {
     if (!consentId) {
       return Promise.reject(
         new Error('A consent ID is required for accepting consent')
       );
     }
 
-    return this._sdk.auth
-      .getCurrentApiToken(audienceName)
-      .then((accessToken) => {
-        if (!accessToken) {
-          throw new Error(
-            `A valid JWT token for the audience ${audienceName} is required`
-          );
-        }
+    const { accessToken } = this._sdk.auth._getStoredSession();
 
-        return this._request
-          .post(`${this._baseUrl}/consents/${consentId}/accept`, {
-            access_token: accessToken
-          })
-          .then((userApproval) => toCamelCase(userApproval));
-      });
+    if (!accessToken) {
+      return Promise.reject(new Error('A valid JWT token is required'));
+    }
+
+    return this._request
+      .post(`${this._baseUrl}/consents/${consentId}/accept`, {
+        access_token: accessToken
+      })
+      .then((userApproval) => toCamelCase(userApproval));
   }
 
   /**
-   * Verify if application consent is needed from the user for a given audience name
+   * Verify if application consent is needed from the user
    *
    *
    * API Endpoint: '/applications/consent'
    * Method: POST
-   *
-   * @param {string} audienceName The auth0 audience that the user is verifying consent with
    *
    * @returns {Promise}
    * @fulfill {ContxtApplicationConsent}
@@ -132,28 +119,18 @@ class Consent {
    *   .then((applicationConsent) => console.log(applicationConsent))
    *   .catch((err) => console.log(err));
    */
-  verify(audienceName) {
-    if (!audienceName) {
-      return Promise.reject(
-        new Error('An audience name is required for verifying consent')
-      );
+  verify() {
+    const { accessToken } = this._sdk.auth._getStoredSession();
+
+    if (!accessToken) {
+      return Promise.reject(new Error('A valid JWT token is required'));
     }
 
-    return this._sdk.auth
-      .getCurrentApiToken(audienceName)
-      .then((accessToken) => {
-        if (!accessToken) {
-          throw new Error(
-            `A valid JWT token for the audience ${audienceName} is required`
-          );
-        }
-
-        return this._request
-          .post(`${this._baseUrl}/applications/consent`, {
-            access_token: accessToken
-          })
-          .then((applicationConsent) => toCamelCase(applicationConsent));
-      });
+    return this._request
+      .post(`${this._baseUrl}/applications/consent`, {
+        access_token: accessToken
+      })
+      .then((applicationConsent) => toCamelCase(applicationConsent));
   }
 }
 

--- a/src/coordinator/consent.js
+++ b/src/coordinator/consent.js
@@ -72,6 +72,8 @@ class Consent {
    *
    * @param {string} consentId The ID of the consent form the user is accepting
    *
+   * Note: Only valid for web users using auth0WebAuth session type
+   *
    * @returns {Promise}
    * @fulfill {ContxtUserConsentApproval}
    * @reject {Error}
@@ -103,11 +105,14 @@ class Consent {
   }
 
   /**
-   * Verify if application consent is needed from the user
+   * Gets the current application version's consent forms. The current
+   * access_token will be used to derive which application is being consented to.
    *
    *
    * API Endpoint: '/applications/consent'
    * Method: POST
+   *
+   * Note: Only valid for web users using auth0WebAuth session type
    *
    * @returns {Promise}
    * @fulfill {ContxtApplicationConsent}
@@ -115,11 +120,11 @@ class Consent {
    *
    * @example
    * contxtSdk.coordinator.consent
-   *   .verify()
+   *   .get()
    *   .then((applicationConsent) => console.log(applicationConsent))
    *   .catch((err) => console.log(err));
    */
-  verify() {
+  get() {
     const { accessToken } = this._sdk.auth._getStoredSession();
 
     if (!accessToken) {

--- a/src/coordinator/consent.js
+++ b/src/coordinator/consent.js
@@ -78,7 +78,7 @@ class Consent {
    *
    * @example
    * contxtSdk.coordinator.consent
-   *   .accept('coordinator', '36b8421a-cc4a-4204-b839-1397374fb16b')
+   *   .accept('36b8421a-cc4a-4204-b839-1397374fb16b')
    *   .then((userApproval) => console.log(userApproval))
    *   .catch((err) => console.log(err));
    */
@@ -115,7 +115,7 @@ class Consent {
    *
    * @example
    * contxtSdk.coordinator.consent
-   *   .verify('coordinator')
+   *   .verify()
    *   .then((applicationConsent) => console.log(applicationConsent))
    *   .catch((err) => console.log(err));
    */

--- a/src/coordinator/consent.spec.js
+++ b/src/coordinator/consent.spec.js
@@ -112,7 +112,7 @@ describe('Coordinator/Consent', function() {
     });
   });
 
-  describe('get', function() {
+  describe('getForCurrentApplication', function() {
     let consent;
 
     beforeEach(function() {
@@ -123,7 +123,7 @@ describe('Coordinator/Consent', function() {
       let promise;
 
       beforeEach(function() {
-        promise = consent.get();
+        promise = consent.getForCurrentApplication();
       });
 
       it('requests the current accessToken', function() {
@@ -151,7 +151,7 @@ describe('Coordinator/Consent', function() {
         baseSdk.auth.getCurrentAccessToken = sinon.stub().resolves();
         consent = new Consent(baseSdk, baseRequest, expectedHost);
 
-        const promise = consent.get();
+        const promise = consent.getForCurrentApplication();
 
         return expect(promise).to.be.rejectedWith(
           `A valid JWT token is required`

--- a/src/coordinator/consent.spec.js
+++ b/src/coordinator/consent.spec.js
@@ -1,0 +1,190 @@
+import Consent from './consent';
+
+describe('Coordinator/Consent', function() {
+  let baseRequest;
+  let baseSdk;
+  let expectedAccessToken;
+  let expectedHost;
+
+  beforeEach(function() {
+    expectedAccessToken = faker.internet.password();
+
+    baseRequest = {
+      delete: sinon.stub().resolves(),
+      get: sinon.stub().resolves(),
+      post: sinon.stub().resolves(),
+      put: sinon.stub().resolves()
+    };
+    baseSdk = {
+      config: {
+        audiences: {
+          coordinator: fixture.build('audience')
+        }
+      },
+      auth: {
+        getCurrentApiToken: sinon.stub().resolves(expectedAccessToken)
+      }
+    };
+    expectedHost = faker.internet.url();
+  });
+
+  afterEach(function() {
+    sinon.restore();
+  });
+
+  describe('constructor', function() {
+    let consent;
+
+    beforeEach(function() {
+      consent = new Consent(baseSdk, baseRequest, expectedHost);
+    });
+
+    it('sets a base url for the class instance', function() {
+      expect(consent._baseUrl).to.equal(expectedHost);
+    });
+
+    it('appends the supplied request module to the class instance', function() {
+      expect(consent._request).to.deep.equal(baseRequest);
+    });
+
+    it('appends the supplied sdk to the class instance', function() {
+      expect(consent._sdk).to.deep.equal(baseSdk);
+    });
+  });
+
+  describe('accept', function() {
+    let consent;
+    let expectedAudienceName;
+    let expectedConsentId;
+
+    beforeEach(function() {
+      expectedAudienceName = faker.hacker.noun();
+      expectedConsentId = faker.random.uuid();
+      consent = new Consent(baseSdk, baseRequest, expectedHost);
+    });
+
+    context('when all the required parameters are provided', function() {
+      let promise;
+
+      beforeEach(function() {
+        promise = consent.accept(expectedAudienceName, expectedConsentId);
+      });
+
+      it('requests the current accessToken for the given audience name', function() {
+        expect(baseSdk.auth.getCurrentApiToken).to.be.calledOnce.and.calledWith(
+          expectedAudienceName
+        );
+      });
+
+      it('makes a request to the server', function() {
+        return promise.then(() => {
+          expect(baseRequest.post).to.be.calledOnce.and.calledWith(
+            `${expectedHost}/consents/${expectedConsentId}/accept`,
+            {
+              access_token: expectedAccessToken
+            }
+          );
+        });
+      });
+
+      it('returns a fulfilled promise', function() {
+        return expect(promise).to.be.fulfilled;
+      });
+    });
+
+    context('when a consent id is not provided', function() {
+      it('throws an error', function() {
+        const promise = consent.accept(expectedAudienceName, null);
+
+        return expect(promise).to.be.rejectedWith(
+          'A consent ID is required for accepting consent'
+        );
+      });
+    });
+
+    context('when an audience name is not provided', function() {
+      it('throws an error', function() {
+        const promise = consent.accept(null, expectedConsentId);
+
+        return expect(promise).to.be.rejectedWith(
+          'An audience name is required for accepting consent'
+        );
+      });
+    });
+
+    context('when an access token is not found for an audience', function() {
+      it('throws an error', function() {
+        baseSdk.auth.getCurrentApiToken = sinon.stub().resolves(null);
+        consent = new Consent(baseSdk, baseRequest, expectedHost);
+
+        const promise = consent.accept(expectedAudienceName, expectedConsentId);
+
+        return expect(promise).to.be.rejectedWith(
+          `A valid JWT token for the audience ${expectedAudienceName} is required`
+        );
+      });
+    });
+  });
+
+  describe('verify', function() {
+    let consent;
+    let expectedAudienceName;
+
+    beforeEach(function() {
+      expectedAudienceName = faker.hacker.noun();
+      consent = new Consent(baseSdk, baseRequest, expectedHost);
+    });
+
+    context('when all the required parameters are provided', function() {
+      let promise;
+
+      beforeEach(function() {
+        promise = consent.verify(expectedAudienceName);
+      });
+
+      it('requests the current accessToken for the given audience name', function() {
+        expect(baseSdk.auth.getCurrentApiToken).to.be.calledOnce.and.calledWith(
+          expectedAudienceName
+        );
+      });
+
+      it('makes a request to the server', function() {
+        return promise.then(() => {
+          expect(baseRequest.post).to.be.calledOnce.and.calledWith(
+            `${expectedHost}/applications/consent`,
+            {
+              access_token: expectedAccessToken
+            }
+          );
+        });
+      });
+
+      it('returns a fulfilled promise', function() {
+        return expect(promise).to.be.fulfilled;
+      });
+    });
+
+    context('when an audience name is not provided', function() {
+      it('throws an error', function() {
+        const promise = consent.verify(null);
+
+        return expect(promise).to.be.rejectedWith(
+          'An audience name is required for verifying consent'
+        );
+      });
+    });
+
+    context('when an access token is not found for an audience', function() {
+      it('throws an error', function() {
+        baseSdk.auth.getCurrentApiToken = sinon.stub().resolves(null);
+        consent = new Consent(baseSdk, baseRequest, expectedHost);
+
+        const promise = consent.verify(expectedAudienceName);
+
+        return expect(promise).to.be.rejectedWith(
+          `A valid JWT token for the audience ${expectedAudienceName} is required`
+        );
+      });
+    });
+  });
+});

--- a/src/coordinator/consent.spec.js
+++ b/src/coordinator/consent.spec.js
@@ -114,7 +114,7 @@ describe('Coordinator/Consent', function() {
     });
   });
 
-  describe('verify', function() {
+  describe('get', function() {
     let consent;
 
     beforeEach(function() {
@@ -125,7 +125,7 @@ describe('Coordinator/Consent', function() {
       let promise;
 
       beforeEach(function() {
-        promise = consent.verify();
+        promise = consent.get();
       });
 
       it('requests the current accessToken', function() {
@@ -153,7 +153,7 @@ describe('Coordinator/Consent', function() {
         baseSdk.auth._getStoredSession = sinon.stub().returns({});
         consent = new Consent(baseSdk, baseRequest, expectedHost);
 
-        const promise = consent.verify();
+        const promise = consent.get();
 
         return expect(promise).to.be.rejectedWith(
           `A valid JWT token is required`

--- a/src/coordinator/consent.spec.js
+++ b/src/coordinator/consent.spec.js
@@ -22,9 +22,7 @@ describe('Coordinator/Consent', function() {
         }
       },
       auth: {
-        _getStoredSession: sinon.stub().returns({
-          accessToken: expectedAccessToken
-        })
+        getCurrentAccessToken: sinon.stub().resolves(expectedAccessToken)
       }
     };
     expectedHost = faker.internet.url();
@@ -71,7 +69,7 @@ describe('Coordinator/Consent', function() {
       });
 
       it('requests the current accessToken', function() {
-        expect(baseSdk.auth._getStoredSession).to.be.calledOnce;
+        expect(baseSdk.auth.getCurrentAccessToken).to.be.calledOnce;
       });
 
       it('makes a request to the server', function() {
@@ -102,7 +100,7 @@ describe('Coordinator/Consent', function() {
 
     context('when an access token is not found', function() {
       it('throws an error', function() {
-        baseSdk.auth._getStoredSession = sinon.stub().returns({});
+        baseSdk.auth.getCurrentAccessToken = sinon.stub().resolves();
         consent = new Consent(baseSdk, baseRequest, expectedHost);
 
         const promise = consent.accept(expectedConsentId);
@@ -129,7 +127,7 @@ describe('Coordinator/Consent', function() {
       });
 
       it('requests the current accessToken', function() {
-        expect(baseSdk.auth._getStoredSession).to.be.calledOnce;
+        expect(baseSdk.auth.getCurrentAccessToken).to.be.calledOnce;
       });
 
       it('makes a request to the server', function() {
@@ -150,7 +148,7 @@ describe('Coordinator/Consent', function() {
 
     context('when an access token is not found', function() {
       it('throws an error', function() {
-        baseSdk.auth._getStoredSession = sinon.stub().returns({});
+        baseSdk.auth.getCurrentAccessToken = sinon.stub().resolves();
         consent = new Consent(baseSdk, baseRequest, expectedHost);
 
         const promise = consent.get();

--- a/src/coordinator/index.js
+++ b/src/coordinator/index.js
@@ -1,4 +1,5 @@
 import Applications from './applications';
+import Consent from './consent';
 import EdgeNodes from './edgeNodes';
 import Organizations from './organizations';
 import Permissions from './permissions';
@@ -23,6 +24,7 @@ class Coordinator {
     this._sdk = sdk;
 
     this.applications = new Applications(sdk, request, baseUrl);
+    this.consent = new Consent(sdk, request, baseUrl);
     this.edgeNodes = new EdgeNodes(sdk, request, baseUrl);
     this.organizations = new Organizations(sdk, request, baseUrl);
     this.permissions = new Permissions(sdk, request, baseUrl);

--- a/src/coordinator/index.spec.js
+++ b/src/coordinator/index.spec.js
@@ -1,4 +1,5 @@
 import Applications from './applications';
+import Consent from './consent';
 import Coordinator from './index';
 import EdgeNodes from './edgeNodes';
 import Organizations from './organizations';
@@ -53,6 +54,10 @@ describe('Coordinator', function() {
 
     it('appends an instance of Applications to the class instance', function() {
       expect(coordinator.applications).to.be.an.instanceof(Applications);
+    });
+
+    it('appends an instance of Consent to the class instance', function() {
+      expect(coordinator.consent).to.be.an.instanceof(Consent);
     });
 
     it('appends an instance of EdgeNodes to the class instance', function() {

--- a/src/sessionTypes/auth0WebAuth.js
+++ b/src/sessionTypes/auth0WebAuth.js
@@ -112,7 +112,21 @@ class Auth0WebAuth {
   }
 
   /**
-   * Requests an access token from Contxt Auth for the correct audience
+   * Gets the current auth0 access token
+   *
+   * @returns {Promise}
+   * @fulfills {string} accessToken
+   */
+  getCurrentAccessToken() {
+    if (!this.isAuthenticated()) {
+      return Promise.reject(this._generateUnauthorizedError());
+    }
+
+    return Promise.resolve(this._sessionInfo.accessToken);
+  }
+
+  /**
+   * Requests an api token from Contxt Auth for the correct audience
    *
    * @param audienceName
    *

--- a/src/sessionTypes/auth0WebAuth.spec.js
+++ b/src/sessionTypes/auth0WebAuth.spec.js
@@ -332,7 +332,7 @@ describe('sessionTypes/Auth0WebAuth', function() {
         promise = auth0WebAuth.getCurrentAccessToken();
       });
 
-      it('checks if the audience already has a valid token', function() {
+      it('checks if the session has a valid token', function() {
         return promise.then(expect.fail).catch(() => {
           expect(isAuthenticated).to.be.calledOnce;
         });

--- a/src/sessionTypes/auth0WebAuth.spec.js
+++ b/src/sessionTypes/auth0WebAuth.spec.js
@@ -284,6 +284,72 @@ describe('sessionTypes/Auth0WebAuth', function() {
     );
   });
 
+  describe('getCurrentAccessToken', function() {
+    context('when the user is authenticaed', function() {
+      let expectedAccessToken;
+      let promise;
+
+      beforeEach(function() {
+        isAuthenticated.restore();
+        isAuthenticated = sinon
+          .stub(Auth0WebAuth.prototype, 'isAuthenticated')
+          .returns(true);
+
+        const auth0WebAuth = new Auth0WebAuth(sdk);
+
+        expectedAccessToken = faker.internet.password();
+        auth0WebAuth._sessionInfo.accessToken = expectedAccessToken;
+
+        promise = auth0WebAuth.getCurrentAccessToken();
+      });
+
+      it('returns the current access token', function() {
+        return expect(promise).to.be.fulfilled.and.to.eventually.equal(
+          expectedAccessToken
+        );
+      });
+    });
+
+    context('when the user is not authenticated', function() {
+      let expectedError;
+      let generateUnauthorizedError;
+      let promise;
+
+      beforeEach(function() {
+        expectedError = new Error(faker.hacker.phrase());
+
+        generateUnauthorizedError = sinon
+          .stub(Auth0WebAuth.prototype, '_generateUnauthorizedError')
+          .returns(expectedError);
+
+        const auth0WebAuth = new Auth0WebAuth(sdk);
+
+        isAuthenticated.restore();
+        isAuthenticated = sinon
+          .stub(Auth0WebAuth.prototype, 'isAuthenticated')
+          .returns(false);
+
+        promise = auth0WebAuth.getCurrentAccessToken();
+      });
+
+      it('checks if the audience already has a valid token', function() {
+        return promise.then(expect.fail).catch(() => {
+          expect(isAuthenticated).to.be.calledOnce;
+        });
+      });
+
+      it('gets a generated `unauthorized` error', function() {
+        return promise.then(expect.fail).catch(() => {
+          expect(generateUnauthorizedError).to.be.calledOnce;
+        });
+      });
+
+      it('throws an error', function() {
+        return expect(promise).to.be.rejectedWith(expectedError);
+      });
+    });
+  });
+
   describe('getCurrentApiToken', function() {
     let expectedAudienceName;
 


### PR DESCRIPTION
## Why?
A contxt application needs to be able to verify if a user's consent is required and accept the consent form if necessary.  

## What changed?

- Added `Consent` module to `Coordinator` with typedefs.
- Added `Consent#accept`
   - Accepts a user's consent to an application
```js
contxtSdk.coordinator.consent
   .accept('36b8421a-cc4a-4204-b839-1397374fb16b')
   .then((userApproval) => console.log(userApproval))
   .catch((err) => console.log(err));
```

- Added `Consent#verify`
  - Gets the current application version's consent forms. The current access_token will be used to derive which application is being consented to.
```js
contxtSdk.coordinator.consent
   .get()
   .then((applicationConsent) => console.log(applicationConsent))
   .catch((err) => console.log(err));
```
