### PR TITLE
Fix how auth0-js is imported in Session Types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [v1.7.1](http://github.com/ndustrialio/contxt-sdk-js/tree/v1.7.1) (2019-07-12)
+
+**Changed**
+
+- Updated how session types are required/imported into the SDK
+  - Solves a problem where `auth0-js` required `window` in Node environments
+
 ## [v1.7.0](http://github.com/ndustrialio/contxt-sdk-js/tree/v1.7.0) (2019-07-03)
 
 **Added**
@@ -5,7 +12,7 @@
 - Added `Coordinator.consent#getForCurrentApplication` for getting the current application version's consent form. The current access_token will be used to derive which application is being consented to.
 - Added `Coordinator.consent#accept` for accepting user consent to an applications
 
-## [v1.6.0](http://github.com/ndustrialio/contxt-sdk-js/tree/v1.5.0) (2019-06-25)
+## [v1.6.0](http://github.com/ndustrialio/contxt-sdk-js/tree/v1.6.0) (2019-06-25)
 
 **Added**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7199,9 +7199,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
       "dev": true
     },
     "lodash.camelcase": {

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -572,7 +572,8 @@ describe('ContxtSdk', function() {
   describe('_createAuthSession', function() {
     [
       { sessionType: 'auth0WebAuth', moduleName: 'Auth0WebAuth' },
-      { sessionType: 'machineAuth', moduleName: 'MachineAuth' }
+      { sessionType: 'machineAuth', moduleName: 'MachineAuth' },
+      { sessionType: 'passwordGrantAuth', moduleName: 'PasswordGrantAuth' }
     ].forEach(function(authSessionConfig) {
       it(`returns a new ${authSessionConfig.sessionType} session`, function() {
         const instance = { config: baseConfig };

--- a/src/sessionTypes/index.js
+++ b/src/sessionTypes/index.js
@@ -1,13 +1,25 @@
-import Auth0WebAuth, { TYPE as AUTH0_WEB_AUTH } from './auth0WebAuth';
-import PasswordGrantAuth, {
-  TYPE as PASSWORD_GRANT_AUTH
-} from './passwordGrantAuth';
-import MachineAuth, { TYPE as MACHINE_AUTH } from './machineAuth';
-
 const TYPES = {
-  AUTH0_WEB_AUTH,
-  PASSWORD_GRANT_AUTH,
-  MACHINE_AUTH
+  AUTH0_WEB_AUTH: 'auth0WebAuth',
+  MACHINE_AUTH: 'machineAuth',
+  PASSWORD_GRANT_AUTH: 'passwordGrantAuth'
 };
 
-export { Auth0WebAuth, PasswordGrantAuth, MachineAuth, TYPES };
+function Auth0WebAuth(...args) {
+  const Auth = require('./auth0WebAuth').default;
+
+  return new Auth(...args);
+}
+
+function MachineAuth(...args) {
+  const Auth = require('./machineAuth').default;
+
+  return new Auth(...args);
+}
+
+function PasswordGrantAuth(...args) {
+  const Auth = require('./passwordGrantAuth').default;
+
+  return new Auth(...args);
+}
+
+export { Auth0WebAuth, MachineAuth, PasswordGrantAuth, TYPES };

--- a/src/sessionTypes/index.spec.js
+++ b/src/sessionTypes/index.spec.js
@@ -1,0 +1,102 @@
+import auth0 from 'auth0-js';
+import Auth0WebAuth from './auth0WebAuth';
+import PasswordGrantAuth from './passwordGrantAuth';
+import MachineAuth from './machineAuth';
+import * as sessionTypes from './index';
+
+describe('sessionTypes', function() {
+  afterEach(function() {
+    sinon.restore();
+  });
+
+  describe('Auth0WebAuth', function() {
+    let auth;
+    let originalWindow;
+
+    beforeEach(function() {
+      const sdk = {
+        config: {
+          audiences: {
+            contxtAuth: fixture.build('audience'),
+            facilities: fixture.build('audience')
+          },
+          auth: {
+            authorizationPath: faker.hacker.noun(),
+            clientId: faker.internet.password(),
+            tokenExpiresAtBufferMs: faker.random.number()
+          }
+        }
+      };
+
+      originalWindow = global.window;
+      global.window = {
+        location: faker.internet.url()
+      };
+
+      sinon.stub(Auth0WebAuth.prototype, 'isAuthenticated').returns(false);
+      sinon.stub(Auth0WebAuth.prototype, '_getStoredSession');
+      sinon.stub(Auth0WebAuth.prototype, '_scheduleSessionRefresh');
+      sinon.stub(auth0, 'WebAuth');
+
+      auth = new sessionTypes.Auth0WebAuth(sdk);
+    });
+
+    afterEach(function() {
+      global.window = originalWindow;
+    });
+
+    it('instatiates a new instance of Auth0WebAuth', function() {
+      expect(auth).to.be.an.instanceOf(Auth0WebAuth);
+    });
+  });
+
+  describe('MachineAuth', function() {
+    let auth;
+
+    beforeEach(function() {
+      const sdk = {
+        config: {
+          audiences: {
+            contxtAuth: fixture.build('audience')
+          },
+          auth: {
+            clientId: faker.internet.password(),
+            clientSecret: faker.internet.password()
+          }
+        }
+      };
+
+      auth = new sessionTypes.MachineAuth(sdk);
+    });
+
+    it('instatiates a new instance of MachineAuth', function() {
+      expect(auth).to.be.an.instanceOf(MachineAuth);
+    });
+  });
+
+  describe('PasswordGrantAuth', function() {
+    let auth;
+
+    beforeEach(function() {
+      const sdk = {
+        config: {
+          audiences: {
+            contxtAuth: fixture.build('audience'),
+            facilities: fixture.build('audience')
+          },
+          auth: {
+            clientId: faker.internet.password()
+          }
+        }
+      };
+
+      sinon.stub(auth0, 'Authentication');
+
+      auth = new sessionTypes.PasswordGrantAuth(sdk);
+    });
+
+    it('instatiates a new instance of PasswordGrantAuth', function() {
+      expect(auth).to.be.an.instanceOf(PasswordGrantAuth);
+    });
+  });
+});


### PR DESCRIPTION
## Why?
`auth0-js` recently changed code that is run when requiring/importing the module to require `window` to be available before any methods are invoked. This was causing issues in Node environments, even if a session type that used `auth0-js` was not used.

## What changed?
- Added methods that require/import the individual Session Types only when attempting to use them
- Updated the version of `lodash` used by dependencies (I think only `devDependencies`)