### PR TITLE
Adds auth0 full sync endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [v2.1.0](http://github.com/ndustrialio/contxt-sdk-js/tree/v2.1.0) (2019-07-22)
+
+**Added**
+
+- Added `Coordinator.users#syncWithAuth0` for syncing a user's roles and application access with auth0
+
 ## [v2.0.0](http://github.com/ndustrialio/contxt-sdk-js/tree/v2.0.0) (2019-07-17)
 
 **Breaking Changes**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 **Added**
 
-- Added `Coordinator.users#syncWithAuth0` for syncing a user's roles and application access with auth0
+- Added `Coordinator.users#sync` for syncing a user's roles and application access with the external authorization provider
 
 ## [v2.0.0](http://github.com/ndustrialio/contxt-sdk-js/tree/v2.0.0) (2019-07-17)
 

--- a/docs/Users.md
+++ b/docs/Users.md
@@ -313,7 +313,7 @@ contxtSdk.coordinator.users
 <a name="Users+syncWithAuth0"></a>
 
 ### contxtSdk.coordinator.users.syncWithAuth0(userId) ⇒ <code>Promise</code>
-Syncs the user's roles, servies, and application access with auth0
+Syncs the user's roles and application access with auth0
 
 API Endpoint: '/users/:userId/sync'
 Method: GET
@@ -329,6 +329,6 @@ Method: GET
 **Example**  
 ```js
 contxtSdk.coordinator.users
-  .sync('36b8421a-cc4a-4204-b839-1397374fb16b')
+  .syncWithAuth0('36b8421a-cc4a-4204-b839-1397374fb16b')
   .catch((err) => console.log(err));
 ```

--- a/docs/Users.md
+++ b/docs/Users.md
@@ -18,7 +18,7 @@ Module that provides access to contxt users
     * [.removeApplication(userId, applicationId)](#Users+removeApplication) ⇒ <code>Promise</code>
     * [.removeRole(userId, roleId)](#Users+removeRole) ⇒ <code>Promise</code>
     * [.removeStack(userId, stackId)](#Users+removeStack) ⇒ <code>Promise</code>
-    * [.syncWithAuth0(userId)](#Users+syncWithAuth0) ⇒ <code>Promise</code>
+    * [.sync(userId)](#Users+sync) ⇒ <code>Promise</code>
 
 <a name="new_Users_new"></a>
 
@@ -310,10 +310,10 @@ contxtSdk.coordinator.users
   .removeStack('36b8421a-cc4a-4204-b839-1397374fb16b', '007ca9ee-ece7-4931-9d11-9b4fd97d4d58')
   .catch((err) => console.log(err));
 ```
-<a name="Users+syncWithAuth0"></a>
+<a name="Users+sync"></a>
 
-### contxtSdk.coordinator.users.syncWithAuth0(userId) ⇒ <code>Promise</code>
-Syncs the user's roles and application access with auth0
+### contxtSdk.coordinator.users.sync(userId) ⇒ <code>Promise</code>
+Syncs the user's roles and application access with the external auth provider
 
 API Endpoint: '/users/:userId/sync'
 Method: GET
@@ -329,6 +329,6 @@ Method: GET
 **Example**  
 ```js
 contxtSdk.coordinator.users
-  .syncWithAuth0('36b8421a-cc4a-4204-b839-1397374fb16b')
+  .sync('36b8421a-cc4a-4204-b839-1397374fb16b')
   .catch((err) => console.log(err));
 ```

--- a/docs/Users.md
+++ b/docs/Users.md
@@ -18,6 +18,7 @@ Module that provides access to contxt users
     * [.removeApplication(userId, applicationId)](#Users+removeApplication) ⇒ <code>Promise</code>
     * [.removeRole(userId, roleId)](#Users+removeRole) ⇒ <code>Promise</code>
     * [.removeStack(userId, stackId)](#Users+removeStack) ⇒ <code>Promise</code>
+    * [.syncWithAuth0(userId)](#Users+syncWithAuth0) ⇒ <code>Promise</code>
 
 <a name="new_Users_new"></a>
 
@@ -307,5 +308,27 @@ Method: DELETE
 ```js
 contxtSdk.coordinator.users
   .removeStack('36b8421a-cc4a-4204-b839-1397374fb16b', '007ca9ee-ece7-4931-9d11-9b4fd97d4d58')
+  .catch((err) => console.log(err));
+```
+<a name="Users+syncWithAuth0"></a>
+
+### contxtSdk.coordinator.users.syncWithAuth0(userId) ⇒ <code>Promise</code>
+Syncs the user's roles, servies, and application access with auth0
+
+API Endpoint: '/users/:userId/sync'
+Method: GET
+
+**Kind**: instance method of [<code>Users</code>](#Users)  
+**Fulfill**: <code>undefined</code>  
+**Reject**: <code>Error</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| userId | <code>string</code> | The ID of the user |
+
+**Example**  
+```js
+contxtSdk.coordinator.users
+  .sync('36b8421a-cc4a-4204-b839-1397374fb16b')
   .catch((err) => console.log(err));
 ```

--- a/src/coordinator/users.js
+++ b/src/coordinator/users.js
@@ -512,7 +512,7 @@ class Users {
   }
 
   /**
-   * Syncs the user's roles, servies, and application access with auth0
+   * Syncs the user's roles and application access with auth0
    *
    * API Endpoint: '/users/:userId/sync'
    * Method: GET
@@ -525,7 +525,7 @@ class Users {
    *
    * @example
    * contxtSdk.coordinator.users
-   *   .sync('36b8421a-cc4a-4204-b839-1397374fb16b')
+   *   .syncWithAuth0('36b8421a-cc4a-4204-b839-1397374fb16b')
    *   .catch((err) => console.log(err));
    */
   syncWithAuth0(userId) {

--- a/src/coordinator/users.js
+++ b/src/coordinator/users.js
@@ -510,6 +510,33 @@ class Users {
       `${this._baseUrl}/users/${userId}/stacks/${stackId}`
     );
   }
+
+  /**
+   * Syncs the user's roles, servies, and application access with auth0
+   *
+   * API Endpoint: '/users/:userId/sync'
+   * Method: GET
+   *
+   * @param {string} userId The ID of the user
+   *
+   * @returns {Promise}
+   * @fulfill {undefined}
+   * @reject {Error}
+   *
+   * @example
+   * contxtSdk.coordinator.users
+   *   .sync('36b8421a-cc4a-4204-b839-1397374fb16b')
+   *   .catch((err) => console.log(err));
+   */
+  syncWithAuth0(userId) {
+    if (!userId) {
+      return Promise.reject(
+        new Error('A user ID is required for syncing with auth0')
+      );
+    }
+
+    return this._request.get(`${this._baseUrl}/users/${userId}/sync`);
+  }
 }
 
 export default Users;

--- a/src/coordinator/users.js
+++ b/src/coordinator/users.js
@@ -512,7 +512,7 @@ class Users {
   }
 
   /**
-   * Syncs the user's roles and application access with auth0
+   * Syncs the user's roles and application access with the external auth provider
    *
    * API Endpoint: '/users/:userId/sync'
    * Method: GET
@@ -525,13 +525,13 @@ class Users {
    *
    * @example
    * contxtSdk.coordinator.users
-   *   .syncWithAuth0('36b8421a-cc4a-4204-b839-1397374fb16b')
+   *   .sync('36b8421a-cc4a-4204-b839-1397374fb16b')
    *   .catch((err) => console.log(err));
    */
-  syncWithAuth0(userId) {
+  sync(userId) {
     if (!userId) {
       return Promise.reject(
-        new Error('A user ID is required for syncing with auth0')
+        new Error('A user ID is required for syncing user permissions')
       );
     }
 

--- a/src/coordinator/users.spec.js
+++ b/src/coordinator/users.spec.js
@@ -850,4 +850,39 @@ describe('Coordinator/Users', function() {
       });
     });
   });
+
+  describe('syncWithAuth0', function() {
+    context('when all required parameters are present', function() {
+      let user;
+      let promise;
+
+      beforeEach(function() {
+        user = fixture.build('contxtUser');
+
+        const users = new Users(baseSdk, baseRequest, expectedHost);
+        promise = users.syncWithAuth0(user.id);
+      });
+
+      it('sends a request to sync auth0 access', function() {
+        expect(baseRequest.get).to.be.calledWith(
+          `${expectedHost}/users/${user.id}/sync`
+        );
+      });
+
+      it('returns a resolved promise', function() {
+        return expect(promise).to.be.fulfilled;
+      });
+    });
+
+    context('when the user ID is not provided', function() {
+      it('throws an error', function() {
+        const users = new Users(baseSdk, baseRequest, expectedHost);
+        const promise = users.syncWithAuth0(null);
+
+        return expect(promise).to.be.rejectedWith(
+          'A user ID is required for syncing with auth0'
+        );
+      });
+    });
+  });
 });

--- a/src/coordinator/users.spec.js
+++ b/src/coordinator/users.spec.js
@@ -851,7 +851,7 @@ describe('Coordinator/Users', function() {
     });
   });
 
-  describe('syncWithAuth0', function() {
+  describe('sync', function() {
     context('when all required parameters are present', function() {
       let user;
       let promise;
@@ -860,10 +860,10 @@ describe('Coordinator/Users', function() {
         user = fixture.build('contxtUser');
 
         const users = new Users(baseSdk, baseRequest, expectedHost);
-        promise = users.syncWithAuth0(user.id);
+        promise = users.sync(user.id);
       });
 
-      it('sends a request to sync auth0 access', function() {
+      it('sends a request to sync user permissions', function() {
         expect(baseRequest.get).to.be.calledWith(
           `${expectedHost}/users/${user.id}/sync`
         );
@@ -877,10 +877,10 @@ describe('Coordinator/Users', function() {
     context('when the user ID is not provided', function() {
       it('throws an error', function() {
         const users = new Users(baseSdk, baseRequest, expectedHost);
-        const promise = users.syncWithAuth0(null);
+        const promise = users.sync(null);
 
         return expect(promise).to.be.rejectedWith(
-          'A user ID is required for syncing with auth0'
+          'A user ID is required for syncing user permissions'
         );
       });
     });


### PR DESCRIPTION
## Why?

https://developers.ndustrial.io (contxt 1.0) calls `GET /users/:userId/sync` upon login to force a user's role and application access to sync to auth0. This is done because there's a number of contxt-coordinator endpoints that are responsible for updating user access but defer updating that access in Auth0, instead, relying on the `/sync` endpoint as a catch-all for auth0-contxt sync issues. 

https://contxt.ndustrial.io (contxt 2.0) currently does NOT call `GET /users/:userId/sync`. 

It needs to.

## What changed? (v2.1.0)

- Added `Coordinator.users#syncWithAuth0(userId)`
