### PR TITLE
Users#activate no longer uses request interceptor for authorization header 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [v2.1.1](http://github.com/ndustrialio/contxt-sdk-js/tree/v2.1.1) (2019-07-25)
+
+**Fixed**
+
+- `Coordinator.users#activate` no longer attempts to attach an authorization header to the request
+
 ## [v2.1.0](http://github.com/ndustrialio/contxt-sdk-js/tree/v2.1.0) (2019-07-22)
 
 **Added**

--- a/src/coordinator/users.js
+++ b/src/coordinator/users.js
@@ -1,3 +1,5 @@
+import axios from 'axios';
+
 import { toCamelCase, toSnakeCase } from '../utils/objects';
 
 /**
@@ -106,7 +108,8 @@ class Users {
       }
     }
 
-    return this._request.post(
+    // Uses axios directly instead of this.request to bypass authorization interceptors
+    return axios.post(
       `${this._baseUrl}/users/${userId}/activate`,
       toSnakeCase(user)
     );

--- a/src/coordinator/users.spec.js
+++ b/src/coordinator/users.spec.js
@@ -58,7 +58,6 @@ describe('Coordinator/Users', function() {
       let promise;
       let request;
       let toSnakeCase;
-      let axiosStub;
 
       beforeEach(function() {
         user = fixture.build('contxtUser');
@@ -80,7 +79,7 @@ describe('Coordinator/Users', function() {
           post: sinon.stub().resolves()
         };
 
-        axiosStub = sinon.stub(axios, 'post').resolves();
+        sinon.stub(axios, 'post').resolves();
 
         toSnakeCase = sinon
           .stub(objectUtils, 'toSnakeCase')
@@ -97,7 +96,7 @@ describe('Coordinator/Users', function() {
       });
 
       it('posts the new user to the server', function() {
-        expect(axiosStub).to.be.calledWith(
+        expect(axios.post).to.be.calledWith(
           `${expectedHost}/users/${user.id}/activate`,
           userActivationPayloadToServer
         );

--- a/src/coordinator/users.spec.js
+++ b/src/coordinator/users.spec.js
@@ -1,3 +1,4 @@
+import axios from 'axios';
 import omit from 'lodash.omit';
 
 import Users from './users';
@@ -57,6 +58,7 @@ describe('Coordinator/Users', function() {
       let promise;
       let request;
       let toSnakeCase;
+      let axiosStub;
 
       beforeEach(function() {
         user = fixture.build('contxtUser');
@@ -78,6 +80,8 @@ describe('Coordinator/Users', function() {
           post: sinon.stub().resolves()
         };
 
+        axiosStub = sinon.stub(axios, 'post').resolves();
+
         toSnakeCase = sinon
           .stub(objectUtils, 'toSnakeCase')
           .callsFake(() => userActivationPayloadToServer);
@@ -93,7 +97,7 @@ describe('Coordinator/Users', function() {
       });
 
       it('posts the new user to the server', function() {
-        expect(request.post).to.be.calledWith(
+        expect(axiosStub).to.be.calledWith(
           `${expectedHost}/users/${user.id}/activate`,
           userActivationPayloadToServer
         );


### PR DESCRIPTION
## Why?
The endpoint for `coordinator.users#activate` does not require authentication but because it uses the base request object passed into the sdk, it attempts to use the axios authorization interceptors anyway. This causes a 401 error thrown from the sdk for a user who isn't authenticated (i.e, people using the user activation link)

## What changed?
`coordinator.users#activate` uses axios directly to make the request and bypasses the interceptors used on the request object. 