### PR TITLE
Add email scope for Auth0WebAuth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [v2.2.0](http://github.com/ndustrialio/contxt-sdk-js/tree/v2.2.0) (2019-08-13)
+
+**Added**
+
+- Added the `email` scope when signing in via Auth0WebAuth
+  - Provides additional information when getting a user's info from Auth0
+
 ## [v2.1.1](http://github.com/ndustrialio/contxt-sdk-js/tree/v2.1.1) (2019-07-25)
 
 **Fixed**

--- a/docs/Typedefs.md
+++ b/docs/Typedefs.md
@@ -1072,6 +1072,8 @@ User provided configuration options
 
 | Name | Type | Description |
 | --- | --- | --- |
+| email | <code>string</code> |  |
+| email_verified | <code>boolean</code> |  |
 | name | <code>string</code> |  |
 | nickname | <code>string</code> |  |
 | picture | <code>string</code> | URL to an avatar |

--- a/package-lock.json
+++ b/package-lock.json
@@ -5027,7 +5027,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5048,12 +5049,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5068,17 +5071,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5195,7 +5201,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5207,6 +5214,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5221,6 +5229,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5228,12 +5237,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5252,6 +5263,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5332,7 +5344,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5344,6 +5357,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5429,7 +5443,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5465,6 +5480,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5484,6 +5500,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5527,12 +5544,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/sessionTypes/auth0WebAuth.js
+++ b/src/sessionTypes/auth0WebAuth.js
@@ -4,6 +4,8 @@ import URL from 'url-parse';
 
 /**
  * @typedef {Object} UserProfile
+ * @property {string} email
+ * @property {boolean} email_verified
  * @property {string} name
  * @property {string} nickname
  * @property {string} picture URL to an avatar
@@ -88,7 +90,7 @@ class Auth0WebAuth {
       domain: 'ndustrial.auth0.com',
       redirectUri: `${currentUrl.origin}${currentUrl.pathname}`,
       responseType: 'token',
-      scope: 'profile openid'
+      scope: 'email profile openid'
     });
 
     if (this.isAuthenticated()) {

--- a/src/sessionTypes/auth0WebAuth.spec.js
+++ b/src/sessionTypes/auth0WebAuth.spec.js
@@ -107,7 +107,7 @@ describe('sessionTypes/Auth0WebAuth', function() {
             sdk.config.auth.authorizationPath
           }`,
           responseType: 'token',
-          scope: 'profile openid'
+          scope: 'email profile openid'
         });
       });
 


### PR DESCRIPTION
## Why?
We need more info available when getting a user's info.

## What changed?
- Added the `email` scope when signing in so email information is returned when getting a user's info from Auth0