### PR TITLE
Add ability to pass options to Auth0WebAuth#logOut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [v2.3.0](http://github.com/ndustrialio/contxt-sdk-js/tree/v2.3.0) (2019-09-09)
+
+**Added**
+
+- Added the ability to pass options to the Auth0WebAuth#logOut method. This will be useful for setting up Single Logout between Auth0 and an external IdP
+
 ## [v2.2.0](http://github.com/ndustrialio/contxt-sdk-js/tree/v2.2.0) (2019-08-13)
 
 **Added**

--- a/docs/Auth0WebAuth.md
+++ b/docs/Auth0WebAuth.md
@@ -27,7 +27,7 @@ enabled in Auth0.
     * [.handleAuthentication()](#Auth0WebAuth+handleAuthentication) ⇒ <code>Promise</code>
     * [.isAuthenticated()](#Auth0WebAuth+isAuthenticated) ⇒ <code>boolean</code>
     * [.logIn()](#Auth0WebAuth+logIn)
-    * [.logOut()](#Auth0WebAuth+logOut)
+    * [.logOut(options)](#Auth0WebAuth+logOut)
 
 <a name="new_Auth0WebAuth_new"></a>
 
@@ -122,8 +122,15 @@ Starts the Auth0 log in process
 **Kind**: instance method of [<code>Auth0WebAuth</code>](#Auth0WebAuth)  
 <a name="Auth0WebAuth+logOut"></a>
 
-### contxtSdk.auth.logOut()
+### contxtSdk.auth.logOut(options)
 Logs the user out by removing any stored session info, clearing any token
 renewal, and redirecting to the root
 
 **Kind**: instance method of [<code>Auth0WebAuth</code>](#Auth0WebAuth)  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| options | <code>Object</code> |  |  |
+| [options.federated] | <code>Boolean</code> | <code>false</code> | Indicator for if Auth0 should   attempt to log out the user from an external IdP |
+| [options.returnTo] | <code>String</code> | <code>window.location.origin</code> | URL that the   user will be redirected to after a successful log out |
+

--- a/src/sessionTypes/auth0WebAuth.js
+++ b/src/sessionTypes/auth0WebAuth.js
@@ -244,8 +244,14 @@ class Auth0WebAuth {
   /**
    * Logs the user out by removing any stored session info, clearing any token
    * renewal, and redirecting to the root
+   *
+   * @param {Object} options
+   * @param {Boolean} [options.federated = false] Indicator for if Auth0 should
+   *   attempt to log out the user from an external IdP
+   * @param {String} [options.returnTo = window.location.origin] URL that the
+   *   user will be redirected to after a successful log out
    */
-  logOut() {
+  logOut(options) {
     this._sessionInfo = {};
     this._tokenPromises = {};
 
@@ -254,7 +260,10 @@ class Auth0WebAuth {
 
     clearTimeout(this._sessionRenewalTimeout);
 
-    this._auth0.logout({ returnTo: new URL(window.location).origin });
+    this._auth0.logout({
+      returnTo: new URL(window.location).origin,
+      ...options
+    });
   }
 
   /**

--- a/src/sessionTypes/auth0WebAuth.spec.js
+++ b/src/sessionTypes/auth0WebAuth.spec.js
@@ -733,10 +733,16 @@ describe('sessionTypes/Auth0WebAuth', function() {
   describe('logOut', function() {
     let auth0WebAuth;
     let clearTimeout;
+    let expectedOptions;
     let expectedTokenRenewalTimeout;
     let localStorage;
 
     beforeEach(function() {
+      expectedOptions = {
+        federated: true,
+        returnTo: global.window.location,
+        [faker.hacker.adjective()]: faker.hacker.phrase()
+      };
       expectedTokenRenewalTimeout = faker.helpers.createTransaction();
 
       clearTimeout = sinon.stub(global, 'clearTimeout');
@@ -756,7 +762,7 @@ describe('sessionTypes/Auth0WebAuth', function() {
       };
       auth0WebAuth._sessionRenewalTimeout = expectedTokenRenewalTimeout;
 
-      auth0WebAuth.logOut();
+      auth0WebAuth.logOut(omit(expectedOptions, ['returnTo']));
     });
 
     it('resets the session info stored in the auth module instance', function() {
@@ -780,9 +786,7 @@ describe('sessionTypes/Auth0WebAuth', function() {
     });
 
     it('logs the user out from Auth0 and redirects to the project root', function() {
-      expect(webAuthSession.logout).to.be.calledWith({
-        returnTo: global.window.location
-      });
+      expect(webAuthSession.logout).to.be.calledWith(expectedOptions);
     });
   });
 


### PR DESCRIPTION
## Why?
We need the ability pass options (specifically `federated=true`) to Auth0 to fully set up SLO (single log out).

## What changed?
- Added `options` param to `Auth0WebAuth#logOut`
