### PR TITLE
MOB-3121: Change contxt coordinator application urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [v3.0.0](TODO: Add URL) (XXXX-XX-XX)
+
+**Breaking Changes**
+
+- All `Coordinator` methods now require an `organizationId`
+
 ## [v2.3.0](http://github.com/ndustrialio/contxt-sdk-js/tree/v2.3.0) (2019-09-09)
 
 **Added**

--- a/docs/Applications.md
+++ b/docs/Applications.md
@@ -7,12 +7,12 @@ Module that provides access to contxt applications
 
 * [Applications](#Applications)
     * [new Applications(sdk, request, baseUrl)](#new_Applications_new)
-    * [.addFavorite(applicationId)](#Applications+addFavorite) ⇒ <code>Promise</code>
-    * [.getAll()](#Applications+getAll) ⇒ <code>Promise</code>
-    * [.getFavorites()](#Applications+getFavorites) ⇒ <code>Promise</code>
+    * [.addFavorite(organizationId, applicationId)](#Applications+addFavorite) ⇒ <code>Promise</code>
+    * [.getAll(organizationId)](#Applications+getAll) ⇒ <code>Promise</code>
+    * [.getFavorites(organizationId)](#Applications+getFavorites) ⇒ <code>Promise</code>
     * [.getFeatured(organizationId)](#Applications+getFeatured) ⇒ <code>Promise</code>
-    * [.getGroupings(applicationId)](#Applications+getGroupings) ⇒ <code>Promise</code>
-    * [.removeFavorite(applicationId)](#Applications+removeFavorite) ⇒ <code>Promise</code>
+    * [.getGroupings(organizationId, applicationId)](#Applications+getGroupings) ⇒ <code>Promise</code>
+    * [.removeFavorite(organizationId, applicationId)](#Applications+removeFavorite) ⇒ <code>Promise</code>
 
 <a name="new_Applications_new"></a>
 
@@ -26,7 +26,7 @@ Module that provides access to contxt applications
 
 <a name="Applications+addFavorite"></a>
 
-### contxtSdk.coordinator.applications.addFavorite(applicationId) ⇒ <code>Promise</code>
+### contxtSdk.coordinator.applications.addFavorite(organizationId, applicationId) ⇒ <code>Promise</code>
 Adds an application to the current user's list of favorited applications
 
 API Endpoint: '/applications/:applicationId/favorites'
@@ -40,18 +40,19 @@ Note: Only valid for web users using auth0WebAuth session type
 
 | Param | Type | Description |
 | --- | --- | --- |
+| organizationId | <code>string</code> | The ID of the organization |
 | applicationId | <code>number</code> | The ID of the application |
 
 **Example**  
 ```js
 contxtSdk.coordinator.applications
-  .addFavorite(25)
+  .addFavorite('36b8421a-cc4a-4204-b839-1397374fb16b', 25)
   .then((favoriteApplication) => console.log(favoriteApplication))
   .catch((err) => console.log(err));
 ```
 <a name="Applications+getAll"></a>
 
-### contxtSdk.coordinator.applications.getAll() ⇒ <code>Promise</code>
+### contxtSdk.coordinator.applications.getAll(organizationId) ⇒ <code>Promise</code>
 Gets information about all contxt applications
 
 API Endpoint: '/applications'
@@ -60,16 +61,21 @@ Method: GET
 **Kind**: instance method of [<code>Applications</code>](#Applications)  
 **Fulfill**: <code>ContxtApplication[]</code> Information about all contxt applications  
 **Reject**: <code>Error</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| organizationId | <code>string</code> | The ID of the organization |
+
 **Example**  
 ```js
 contxtSdk.coordinator.applications
-  .getAll()
+  .getAll('36b8421a-cc4a-4204-b839-1397374fb16b')
   .then((apps) => console.log(apps))
   .catch((err) => console.log(err));
 ```
 <a name="Applications+getFavorites"></a>
 
-### contxtSdk.coordinator.applications.getFavorites() ⇒ <code>Promise</code>
+### contxtSdk.coordinator.applications.getFavorites(organizationId) ⇒ <code>Promise</code>
 Gets the current user's list of favorited applications
 
 API Endpoint: '/applications/favorites'
@@ -80,10 +86,15 @@ Note: Only valid for web users using auth0WebAuth session type
 **Kind**: instance method of [<code>Applications</code>](#Applications)  
 **Fulfill**: <code>ContxtUserFavoriteApplication[]</code> A list of favorited applications  
 **Reject**: <code>Error</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| organizationId | <code>string</code> | The ID of the organization |
+
 **Example**  
 ```js
 contxtSdk.coordinator.applications
-  .getFavorites()
+  .getFavorites('36b8421a-cc4a-4204-b839-1397374fb16b')
   .then((favoriteApplications) => console.log(favoriteApplications))
   .catch((err) => console.log(err));
 ```
@@ -114,7 +125,7 @@ contxtSdk.coordinator.applications
 ```
 <a name="Applications+getGroupings"></a>
 
-### contxtSdk.coordinator.applications.getGroupings(applicationId) ⇒ <code>Promise</code>
+### contxtSdk.coordinator.applications.getGroupings(organizationId, applicationId) ⇒ <code>Promise</code>
 Gets the application groupings (and application modules) of an application
 that are available to the currently authenticated user.
 
@@ -125,20 +136,21 @@ Method: GET
 **Fulfill**: <code>ContxtApplicationGrouping[]</code>  
 **Reject**: <code>Error</code>  
 
-| Param | Type |
-| --- | --- |
-| applicationId | <code>number</code> | 
+| Param | Type | Description |
+| --- | --- | --- |
+| organizationId | <code>string</code> | The ID of the organization |
+| applicationId | <code>number</code> |  |
 
 **Example**  
 ```js
 contxtSdk.coordinator.applications
-  .getGroupings(31)
+  .getGroupings('36b8421a-cc4a-4204-b839-1397374fb16b', 31)
   .then((applicationGroupings) => console.log(applicationGroupings))
   .catch((err) => console.log(err));
 ```
 <a name="Applications+removeFavorite"></a>
 
-### contxtSdk.coordinator.applications.removeFavorite(applicationId) ⇒ <code>Promise</code>
+### contxtSdk.coordinator.applications.removeFavorite(organizationId, applicationId) ⇒ <code>Promise</code>
 Removes an application from the current user's list of favorited applications
 
 API Endpoint: '/applications/:applicationId/favorites'
@@ -152,11 +164,12 @@ Note: Only valid for web users using auth0WebAuth session type
 
 | Param | Type | Description |
 | --- | --- | --- |
+| organizationId | <code>string</code> | The ID of the organization |
 | applicationId | <code>number</code> | The ID of the application |
 
 **Example**  
 ```js
 contxtSdk.coordinator.applications
-  .removeFavorite(25)
+  .removeFavorite('36b8421a-cc4a-4204-b839-1397374fb16b', 25)
   .catch((err) => console.log(err));
 ```

--- a/src/coordinator/applications.js
+++ b/src/coordinator/applications.js
@@ -82,6 +82,7 @@ class Applications {
    *
    * Note: Only valid for web users using auth0WebAuth session type
    *
+   * @param {string} organizationId The ID of the organization
    * @param {number} applicationId The ID of the application
    *
    * @returns {Promise}
@@ -90,11 +91,19 @@ class Applications {
    *
    * @example
    * contxtSdk.coordinator.applications
-   *   .addFavorite(25)
+   *   .addFavorite('36b8421a-cc4a-4204-b839-1397374fb16b', 25)
    *   .then((favoriteApplication) => console.log(favoriteApplication))
    *   .catch((err) => console.log(err));
    */
-  addFavorite(applicationId) {
+  addFavorite(organizationId, applicationId) {
+    if (!organizationId) {
+      return Promise.reject(
+        new Error(
+          'An organization ID is required for creating a favorite application'
+        )
+      );
+    }
+
     if (!applicationId) {
       return Promise.reject(
         new Error(
@@ -104,7 +113,11 @@ class Applications {
     }
 
     return this._request
-      .post(`${this._baseUrl}/applications/${applicationId}/favorites`)
+      .post(
+        `${
+          this._baseUrl
+        }/${organizationId}/applications/${applicationId}/favorites`
+      )
       .then((favoriteApplication) => toCamelCase(favoriteApplication));
   }
 
@@ -114,19 +127,27 @@ class Applications {
    * API Endpoint: '/applications'
    * Method: GET
    *
+   * @param {string} organizationId The ID of the organization
+   *
    * @returns {Promise}
    * @fulfill {ContxtApplication[]} Information about all contxt applications
    * @reject {Error}
    *
    * @example
    * contxtSdk.coordinator.applications
-   *   .getAll()
+   *   .getAll('36b8421a-cc4a-4204-b839-1397374fb16b')
    *   .then((apps) => console.log(apps))
    *   .catch((err) => console.log(err));
    */
-  getAll() {
+  getAll(organizationId) {
+    if (!organizationId) {
+      return Promise.reject(
+        new Error('An organization ID is required for getting all applications')
+      );
+    }
+
     return this._request
-      .get(`${this._baseUrl}/applications`)
+      .get(`${this._baseUrl}/${organizationId}/applications`)
       .then((apps) => apps.map((app) => toCamelCase(app)));
   }
 
@@ -138,19 +159,29 @@ class Applications {
    *
    * Note: Only valid for web users using auth0WebAuth session type
    *
+   * @param {string} organizationId The ID of the organization
+   *
    * @returns {Promise}
    * @fulfill {ContxtUserFavoriteApplication[]} A list of favorited applications
    * @reject {Error}
    *
    * @example
    * contxtSdk.coordinator.applications
-   *   .getFavorites()
+   *   .getFavorites('36b8421a-cc4a-4204-b839-1397374fb16b')
    *   .then((favoriteApplications) => console.log(favoriteApplications))
    *   .catch((err) => console.log(err));
    */
-  getFavorites() {
+  getFavorites(organizationId) {
+    if (!organizationId) {
+      return Promise.reject(
+        new Error(
+          "An organization ID is required for getting a user's list of favorited applications"
+        )
+      );
+    }
+
     return this._request
-      .get(`${this._baseUrl}/applications/favorites`)
+      .get(`${this._baseUrl}/${organizationId}/applications/favorites`)
       .then((favoriteApps) => toCamelCase(favoriteApps));
   }
 
@@ -184,9 +215,7 @@ class Applications {
     }
 
     return this._request
-      .get(
-        `${this._baseUrl}/organizations/${organizationId}/applications/featured`
-      )
+      .get(`${this._baseUrl}/${organizationId}/applications/featured`)
       .then((featuredApplications) => toCamelCase(featuredApplications));
   }
 
@@ -197,6 +226,7 @@ class Applications {
    * API Endpoint: '/applications/:applicationId/groupings'
    * Method: GET
    *
+   * @param {string} organizationId The ID of the organization
    * @param {number} applicationId
    *
    * @returns {Promise}
@@ -205,13 +235,33 @@ class Applications {
    *
    * @example
    * contxtSdk.coordinator.applications
-   *   .getGroupings(31)
+   *   .getGroupings('36b8421a-cc4a-4204-b839-1397374fb16b', 31)
    *   .then((applicationGroupings) => console.log(applicationGroupings))
    *   .catch((err) => console.log(err));
    */
-  getGroupings(applicationId) {
+  getGroupings(organizationId, applicationId) {
+    if (!organizationId) {
+      return Promise.reject(
+        new Error(
+          'An organization ID is required for getting application groupings of an application'
+        )
+      );
+    }
+
+    if (!applicationId) {
+      return Promise.reject(
+        new Error(
+          'An application ID is required for getting application groupings of an application'
+        )
+      );
+    }
+
     return this._request
-      .get(`${this._baseUrl}/applications/${applicationId}/groupings`)
+      .get(
+        `${
+          this._baseUrl
+        }/${organizationId}/applications/${applicationId}/groupings`
+      )
       .then((groupings) => toCamelCase(groupings));
   }
 
@@ -223,6 +273,7 @@ class Applications {
    *
    * Note: Only valid for web users using auth0WebAuth session type
    *
+   * @param {string} organizationId The ID of the organization
    * @param {number} applicationId The ID of the application
    *
    * @returns {Promise}
@@ -231,10 +282,18 @@ class Applications {
    *
    * @example
    * contxtSdk.coordinator.applications
-   *   .removeFavorite(25)
+   *   .removeFavorite('36b8421a-cc4a-4204-b839-1397374fb16b', 25)
    *   .catch((err) => console.log(err));
    */
-  removeFavorite(applicationId) {
+  removeFavorite(organizationId, applicationId) {
+    if (!organizationId) {
+      return Promise.reject(
+        new Error(
+          'An organization ID is required for deleting a favorite application'
+        )
+      );
+    }
+
     if (!applicationId) {
       return Promise.reject(
         new Error(
@@ -244,7 +303,9 @@ class Applications {
     }
 
     return this._request.delete(
-      `${this._baseUrl}/applications/${applicationId}/favorites`
+      `${
+        this._baseUrl
+      }/${organizationId}/applications/${applicationId}/favorites`
     );
   }
 }

--- a/src/coordinator/applications.spec.js
+++ b/src/coordinator/applications.spec.js
@@ -1,7 +1,7 @@
 import Applications from './applications';
 import * as objectUtils from '../utils/objects';
 
-describe('Coordinator/Applications', function() {
+describe.only('Coordinator/Applications', function() {
   let baseRequest;
   let baseSdk;
   let expectedHost;
@@ -48,55 +48,80 @@ describe('Coordinator/Applications', function() {
   });
 
   describe('addFavorite', function() {
-    context('when the application ID is provided', function() {
-      let application;
-      let expectedApplicationFavorite;
-      let applicationFavoriteFromServer;
-      let promise;
-      let request;
-      let toCamelCase;
+    context(
+      'when the organizationID and application ID are provided',
+      function() {
+        let application;
+        let expectedApplicationFavorite;
+        let applicationFavoriteFromServer;
+        let organization;
+        let promise;
+        let request;
+        let toCamelCase;
 
-      beforeEach(function() {
-        application = fixture.build('contxtApplication');
+        beforeEach(function() {
+          application = fixture.build('contxtApplication');
 
-        expectedApplicationFavorite = fixture.build(
-          'contxtUserFavoriteApplication'
-        );
-        applicationFavoriteFromServer = fixture.build(
-          'contxtUserFavoriteApplication',
-          expectedApplicationFavorite,
-          {
-            fromServer: true
-          }
-        );
+          expectedApplicationFavorite = fixture.build(
+            'contxtUserFavoriteApplication'
+          );
+          applicationFavoriteFromServer = fixture.build(
+            'contxtUserFavoriteApplication',
+            expectedApplicationFavorite,
+            {
+              fromServer: true
+            }
+          );
 
-        request = {
-          ...baseRequest,
-          post: sinon.stub().resolves(applicationFavoriteFromServer)
-        };
-        toCamelCase = sinon
-          .stub(objectUtils, 'toCamelCase')
-          .callsFake((app) => expectedApplicationFavorite);
+          organization = fixture.build('organization');
 
-        const applications = new Applications(baseSdk, request, expectedHost);
-        promise = applications.addFavorite(application.id);
-      });
+          request = {
+            ...baseRequest,
+            post: sinon.stub().resolves(applicationFavoriteFromServer)
+          };
+          toCamelCase = sinon
+            .stub(objectUtils, 'toCamelCase')
+            .callsFake((app) => expectedApplicationFavorite);
 
-      it('posts the new application favorite to the server', function() {
-        expect(request.post).to.be.calledWith(
-          `${expectedHost}/applications/${application.id}/favorites`
-        );
-      });
-
-      it('formats the application favorite', function() {
-        return promise.then(() => {
-          expect(toCamelCase).to.be.calledWith(applicationFavoriteFromServer);
+          const applications = new Applications(baseSdk, request, expectedHost);
+          promise = applications.addFavorite(organization.id, application.id);
         });
-      });
 
-      it('returns a fulfilled promise with the application favorite', function() {
-        return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
-          expectedApplicationFavorite
+        it('posts the new application favorite to the server', function() {
+          expect(request.post).to.be.calledWith(
+            `${expectedHost}/${organization.id}/applications/${
+              application.id
+            }/favorites`
+          );
+        });
+
+        it('formats the application favorite', function() {
+          return promise.then(() => {
+            expect(toCamelCase).to.be.calledWith(applicationFavoriteFromServer);
+          });
+        });
+
+        it('returns a fulfilled promise with the application favorite', function() {
+          return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
+            expectedApplicationFavorite
+          );
+        });
+      }
+    );
+
+    context('when the organization ID is not provided', function() {
+      it('throws an error', function() {
+        const applications = new Applications(
+          baseSdk,
+          baseRequest,
+          expectedHost
+        );
+        const application = fixture.build('contxtApplication');
+
+        const promise = applications.addFavorite(undefined, application.id);
+
+        return expect(promise).to.be.rejectedWith(
+          'An organization ID is required for creating a favorite application'
         );
       });
     });
@@ -108,7 +133,9 @@ describe('Coordinator/Applications', function() {
           baseRequest,
           expectedHost
         );
-        const promise = applications.addFavorite();
+        const organization = fixture.build('organization');
+
+        const promise = applications.addFavorite(organization);
 
         return expect(promise).to.be.rejectedWith(
           'An application ID is required for creating a favorite application'
@@ -118,157 +145,151 @@ describe('Coordinator/Applications', function() {
   });
 
   describe('getAll', function() {
-    let expectedApplications;
-    let applicationsFromServer;
-    let promise;
-    let request;
-    let toCamelCase;
+    context('when the organization ID is provided', function() {
+      let expectedApplications;
+      let applicationsFromServer;
+      let organization;
+      let promise;
+      let request;
+      let toCamelCase;
 
-    beforeEach(function() {
-      const numberOfApplications = faker.random.number({
-        min: 1,
-        max: 10
-      });
-      expectedApplications = fixture.buildList(
-        'contxtApplication',
-        numberOfApplications
-      );
-      applicationsFromServer = expectedApplications.map((app) =>
-        fixture.build('contxtApplication', app, { fromServer: true })
-      );
-
-      request = {
-        ...baseRequest,
-        get: sinon.stub().resolves(applicationsFromServer)
-      };
-      toCamelCase = sinon
-        .stub(objectUtils, 'toCamelCase')
-        .callsFake((app) =>
-          expectedApplications.find(({ id }) => id === app.id)
+      beforeEach(function() {
+        const numberOfApplications = faker.random.number({
+          min: 1,
+          max: 10
+        });
+        expectedApplications = fixture.buildList(
+          'contxtApplication',
+          numberOfApplications
+        );
+        applicationsFromServer = expectedApplications.map((app) =>
+          fixture.build('contxtApplication', app, { fromServer: true })
         );
 
-      const applications = new Applications(baseSdk, request, expectedHost);
-      promise = applications.getAll();
-    });
+        organization = fixture.build('organization');
 
-    it('gets the list of applications from the server', function() {
-      expect(request.get).to.be.calledWith(`${expectedHost}/applications`);
-    });
+        request = {
+          ...baseRequest,
+          get: sinon.stub().resolves(applicationsFromServer)
+        };
+        toCamelCase = sinon
+          .stub(objectUtils, 'toCamelCase')
+          .callsFake((app) =>
+            expectedApplications.find(({ id }) => id === app.id)
+          );
 
-    it('formats the list of applications', function() {
-      return promise.then(() => {
-        expect(toCamelCase).to.have.callCount(applicationsFromServer.length);
-        applicationsFromServer.forEach((app) => {
-          expect(toCamelCase).to.be.calledWith(app);
+        const applications = new Applications(baseSdk, request, expectedHost);
+        promise = applications.getAll(organization.id);
+      });
+
+      it('gets the list of applications from the server', function() {
+        expect(request.get).to.be.calledWith(
+          `${expectedHost}/${organization.id}/applications`
+        );
+      });
+
+      it('formats the list of applications', function() {
+        return promise.then(() => {
+          expect(toCamelCase).to.have.callCount(applicationsFromServer.length);
+          applicationsFromServer.forEach((app) => {
+            expect(toCamelCase).to.be.calledWith(app);
+          });
         });
+      });
+
+      it('returns a fulfilled promise with the applications', function() {
+        return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
+          expectedApplications
+        );
       });
     });
 
-    it('returns a fulfilled promise with the applications', function() {
-      return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
-        expectedApplications
-      );
+    context('when the organization ID is not provided', function() {
+      it('throws an error', function() {
+        const applications = new Applications(
+          baseSdk,
+          baseRequest,
+          expectedHost
+        );
+
+        const promise = applications.getAll();
+
+        return expect(promise).to.be.rejectedWith(
+          'An organization ID is required for getting all applications'
+        );
+      });
     });
   });
 
   describe('getFavorites', function() {
-    let expectedFavoriteApplications;
-    let favoritesFromServer;
-    let promise;
-    let request;
-    let toCamelCase;
+    context('when the organization ID is provided', function() {
+      let expectedFavoriteApplications;
+      let favoritesFromServer;
+      let organization;
+      let promise;
+      let request;
+      let toCamelCase;
 
-    beforeEach(function() {
-      expectedFavoriteApplications = fixture.buildList(
-        'contxtUserFavoriteApplication',
-        faker.random.number({
-          min: 1,
-          max: 10
-        })
-      );
-      favoritesFromServer = expectedFavoriteApplications.map((app) =>
-        fixture.build('contxtUserFavoriteApplication', app, {
-          fromServer: true
-        })
-      );
+      beforeEach(function() {
+        expectedFavoriteApplications = fixture.buildList(
+          'contxtUserFavoriteApplication',
+          faker.random.number({
+            min: 1,
+            max: 10
+          })
+        );
+        favoritesFromServer = expectedFavoriteApplications.map((app) =>
+          fixture.build('contxtUserFavoriteApplication', app, {
+            fromServer: true
+          })
+        );
+        organization = fixture.build('organization');
 
-      request = {
-        ...baseRequest,
-        get: sinon.stub().resolves(favoritesFromServer)
-      };
-      toCamelCase = sinon
-        .stub(objectUtils, 'toCamelCase')
-        .returns(expectedFavoriteApplications);
+        request = {
+          ...baseRequest,
+          get: sinon.stub().resolves(favoritesFromServer)
+        };
+        toCamelCase = sinon
+          .stub(objectUtils, 'toCamelCase')
+          .returns(expectedFavoriteApplications);
 
-      const applications = new Applications(baseSdk, request, expectedHost);
-      promise = applications.getFavorites();
-    });
+        const applications = new Applications(baseSdk, request, expectedHost);
+        promise = applications.getFavorites(organization.id);
+      });
 
-    it('gets the list of favorite applications from the server', function() {
-      expect(request.get).to.be.calledWith(
-        `${expectedHost}/applications/favorites`
-      );
-    });
+      it('gets the list of favorite applications from the server', function() {
+        expect(request.get).to.be.calledWith(
+          `${expectedHost}/${organization.id}/applications/favorites`
+        );
+      });
 
-    it('formats the list of favorite applications', function() {
-      return promise.then(() => {
-        expect(toCamelCase).to.be.calledWith(favoritesFromServer);
+      it('formats the list of favorite applications', function() {
+        return promise.then(() => {
+          expect(toCamelCase).to.be.calledWith(favoritesFromServer);
+        });
+      });
+
+      it('returns a fulfilled promise with the favorite applications', function() {
+        return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
+          expectedFavoriteApplications
+        );
       });
     });
 
-    it('returns a fulfilled promise with the favorite applications', function() {
-      return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
-        expectedFavoriteApplications
-      );
-    });
-  });
+    context('when the organization ID is not provided', function() {
+      it('throws an error', function() {
+        const applications = new Applications(
+          baseSdk,
+          baseRequest,
+          expectedHost
+        );
 
-  describe('getGroupings', function() {
-    let expectedApplicationId;
-    let expectedGroupings;
-    let groupingsFromServer;
-    let promise;
-    let request;
-    let toCamelCase;
+        const promise = applications.getFavorites();
 
-    beforeEach(function() {
-      expectedApplicationId = faker.random.uuid();
-      expectedGroupings = fixture.buildList(
-        'applicationGrouping',
-        faker.random.number({ min: 1, max: 10 })
-      );
-      groupingsFromServer = expectedGroupings.map((grouping) =>
-        fixture.build('applicationGrouping', grouping, { fromServer: true })
-      );
-
-      request = {
-        ...baseRequest,
-        get: sinon.stub().resolves(groupingsFromServer)
-      };
-      toCamelCase = sinon
-        .stub(objectUtils, 'toCamelCase')
-        .returns(expectedGroupings);
-
-      const applications = new Applications(baseSdk, request, expectedHost);
-      promise = applications.getGroupings(expectedApplicationId);
-    });
-
-    it('gets the list of application groupings', function() {
-      expect(request.get).to.be.calledWith(
-        `${expectedHost}/applications/${expectedApplicationId}/groupings`
-      );
-    });
-
-    it('formats the list of application groupings', function() {
-      return promise.then(() => {
-        expect(toCamelCase).to.be.calledWith(groupingsFromServer);
+        return expect(promise).to.be.rejectedWith(
+          "An organization ID is required for getting a user's list of favorited applications"
+        );
       });
-    });
-
-    it('returns a fulfilled promise with the application groupings', function() {
-      return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
-        expectedGroupings
-      );
     });
   });
 
@@ -314,7 +335,7 @@ describe('Coordinator/Applications', function() {
 
       it('gets the list of featured applications from the server', function() {
         expect(request.get).to.be.calledWith(
-          `${expectedHost}/organizations/${expectedOrganizationId}/applications/featured`
+          `${expectedHost}/${expectedOrganizationId}/applications/featured`
         );
       });
 
@@ -347,30 +368,79 @@ describe('Coordinator/Applications', function() {
     });
   });
 
-  describe('removeFavorite', function() {
-    context('when the application ID is provided', function() {
-      let application;
-      let promise;
+  describe('getGroupings', function() {
+    context(
+      'when the organization ID and application ID are provided',
+      function() {
+        let expectedApplicationId;
+        let expectedGroupings;
+        let groupingsFromServer;
+        let organization;
+        let promise;
+        let request;
+        let toCamelCase;
 
-      beforeEach(function() {
-        application = fixture.build('contxtApplication');
+        beforeEach(function() {
+          expectedApplicationId = faker.random.uuid();
+          expectedGroupings = fixture.buildList(
+            'applicationGrouping',
+            faker.random.number({ min: 1, max: 10 })
+          );
+          groupingsFromServer = expectedGroupings.map((grouping) =>
+            fixture.build('applicationGrouping', grouping, { fromServer: true })
+          );
+          organization = fixture.build('organization');
 
+          request = {
+            ...baseRequest,
+            get: sinon.stub().resolves(groupingsFromServer)
+          };
+          toCamelCase = sinon
+            .stub(objectUtils, 'toCamelCase')
+            .returns(expectedGroupings);
+
+          const applications = new Applications(baseSdk, request, expectedHost);
+          promise = applications.getGroupings(
+            organization.id,
+            expectedApplicationId
+          );
+        });
+
+        it('gets the list of application groupings', function() {
+          expect(request.get).to.be.calledWith(
+            `${expectedHost}/${
+              organization.id
+            }/applications/${expectedApplicationId}/groupings`
+          );
+        });
+
+        it('formats the list of application groupings', function() {
+          return promise.then(() => {
+            expect(toCamelCase).to.be.calledWith(groupingsFromServer);
+          });
+        });
+
+        it('returns a fulfilled promise with the application groupings', function() {
+          return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
+            expectedGroupings
+          );
+        });
+      }
+    );
+
+    context('when the organization ID is not provided', function() {
+      it('throws an error', function() {
         const applications = new Applications(
           baseSdk,
           baseRequest,
           expectedHost
         );
-        promise = applications.removeFavorite(application.id);
-      });
+        const application = fixture.build('contxtApplication');
+        const promise = applications.getGroupings(undefined, application.id);
 
-      it('requests to delete the application favorite', function() {
-        expect(baseRequest.delete).to.be.calledWith(
-          `${expectedHost}/applications/${application.id}/favorites`
+        return expect(promise).to.be.rejectedWith(
+          'An organization ID is required for getting application groupings of an application'
         );
-      });
-
-      it('returns a resolved promise', function() {
-        return expect(promise).to.be.fulfilled;
       });
     });
 
@@ -381,7 +451,78 @@ describe('Coordinator/Applications', function() {
           baseRequest,
           expectedHost
         );
-        const promise = applications.removeFavorite();
+        const organization = fixture.build('organization');
+        const promise = applications.getGroupings(organization.id);
+
+        return expect(promise).to.be.rejectedWith(
+          'An application ID is required for getting application groupings of an application'
+        );
+      });
+    });
+  });
+
+  describe('removeFavorite', function() {
+    context(
+      'when the organization ID and application ID are provided',
+      function() {
+        let application;
+        let organization;
+        let promise;
+
+        beforeEach(function() {
+          application = fixture.build('contxtApplication');
+          organization = fixture.build('organization');
+
+          const applications = new Applications(
+            baseSdk,
+            baseRequest,
+            expectedHost
+          );
+          promise = applications.removeFavorite(
+            organization.id,
+            application.id
+          );
+        });
+
+        it('requests to delete the application favorite', function() {
+          expect(baseRequest.delete).to.be.calledWith(
+            `${expectedHost}/${organization.id}/applications/${
+              application.id
+            }/favorites`
+          );
+        });
+
+        it('returns a resolved promise', function() {
+          return expect(promise).to.be.fulfilled;
+        });
+      }
+    );
+
+    context('when the organization ID is not provided', function() {
+      it('throws an error', function() {
+        const applications = new Applications(
+          baseSdk,
+          baseRequest,
+          expectedHost
+        );
+        const application = fixture.build('contxtApplication');
+        const promise = applications.removeFavorite(undefined, application.id);
+
+        return expect(promise).to.be.rejectedWith(
+          'An organization ID is required for deleting a favorite application'
+        );
+      });
+    });
+
+    context('when the application ID is not provided', function() {
+      it('throws an error', function() {
+        const applications = new Applications(
+          baseSdk,
+          baseRequest,
+          expectedHost
+        );
+        const organization = fixture.build('organization');
+        const promise = applications.removeFavorite(organization.id);
 
         return expect(promise).to.be.rejectedWith(
           'An application ID is required for deleting a favorite application'

--- a/src/coordinator/index.js
+++ b/src/coordinator/index.js
@@ -17,7 +17,7 @@ class Coordinator {
    * @param {Object} request An instance of the request module tied to this module's audience.
    */
   constructor(sdk, request) {
-    const baseUrl = `${sdk.config.audiences.coordinator.host}/v1`;
+    const baseUrl = `${sdk.config.audiences.coordinator.host}/contxt/v1`;
 
     this._baseUrl = baseUrl;
     this._request = request;

--- a/src/coordinator/index.spec.js
+++ b/src/coordinator/index.spec.js
@@ -40,7 +40,7 @@ describe('Coordinator', function() {
 
     it('sets a base url for the class instance', function() {
       expect(coordinator._baseUrl).to.equal(
-        `${baseSdk.config.audiences.coordinator.host}/v1`
+        `${baseSdk.config.audiences.coordinator.host}/contxt/v1`
       );
     });
 


### PR DESCRIPTION
## Why?

https://lineagelogistics.atlassian.net/browse/MOB-3121

We are updating the URLs for contxt-coordinator to all be tenant based and removing redundant organization params from the routes

Examples:
`/v1/applications` -> `/contxt/v1/:organizationId/applications`
`/v1/organizations/:organizationId/services` -> `/contxt/v1/:organizationId/services`


## What changed?
- Updated the `applications` module within `coordinator`
- Changed the `baseURL` of `coordinator`
- Fixed tests
- Updated `CHANGELOG.md` file but will need more updates later

### NOTE
Since there are a lot of modules under `coordinator` I'm going to be splitting all this work into separate pull requests which will be merged into `release/coordinator-tenancy-urls` and then that branch will be merged into `master`