### PR TITLE
MOB-3121: Update coordinator modules to use new API endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-## [v3.0.0](TODO: Add URL) (XXXX-XX-XX)
+## [v2.4.0](https://github.com/ndustrialio/contxt-sdk-js/pull/131) (2019-10-07)
 
-**Breaking Changes**
+**Changed**
 
-- All `Coordinator` methods now require an `organizationId`
+- Added `Coordinator.setOrganizationId` which, when set, will use the new tenancy/access based API endpoints
+  - If no `organizationId` has been set, all `Coordinator` endpoints will use the legacy API endpoints
 
 ## [v2.3.0](http://github.com/ndustrialio/contxt-sdk-js/tree/v2.3.0) (2019-09-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [v3.0.0](TODO: Add URL) (XXXX-XX-XX)
+
+**Breaking Changes**
+
+- All `Coordinator` methods now require an `organizationId`
+
 ## [v2.3.0](http://github.com/ndustrialio/contxt-sdk-js/tree/v2.3.0) (2019-09-09)
 
 **Added**

--- a/docs/Applications.md
+++ b/docs/Applications.md
@@ -10,7 +10,7 @@ Module that provides access to contxt applications
     * [.addFavorite(applicationId)](#Applications+addFavorite) ⇒ <code>Promise</code>
     * [.getAll()](#Applications+getAll) ⇒ <code>Promise</code>
     * [.getFavorites()](#Applications+getFavorites) ⇒ <code>Promise</code>
-    * [.getFeatured()](#Applications+getFeatured) ⇒ <code>Promise</code>
+    * [.getFeatured(organizationId)](#Applications+getFeatured) ⇒ <code>Promise</code>
     * [.getGroupings(applicationId)](#Applications+getGroupings) ⇒ <code>Promise</code>
     * [.removeFavorite(applicationId)](#Applications+removeFavorite) ⇒ <code>Promise</code>
 
@@ -89,7 +89,7 @@ contxtSdk.coordinator.applications
 ```
 <a name="Applications+getFeatured"></a>
 
-### contxtSdk.coordinator.applications.getFeatured() ⇒ <code>Promise</code>
+### contxtSdk.coordinator.applications.getFeatured(organizationId) ⇒ <code>Promise</code>
 Gets an organization's list of featured applications
 
 API Endpoint: '/organizations/:organizationId/applications/featured'
@@ -100,10 +100,15 @@ Note: Only valid for web users using auth0WebAuth session type
 **Kind**: instance method of [<code>Applications</code>](#Applications)  
 **Fulfill**: <code>ContxtOrganizationFeaturedApplication[]</code> A list of featured applications  
 **Reject**: <code>Error</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| organizationId | <code>string</code> | The ID of the organization |
+
 **Example**  
 ```js
 contxtSdk.coordinator.applications
-  .getFeatured()
+  .getFeatured('36b8421a-cc4a-4204-b839-1397374fb16b')
   .then((featuredApplications) => console.log(featuredApplications))
   .catch((err) => console.log(err));
 ```

--- a/docs/Applications.md
+++ b/docs/Applications.md
@@ -10,7 +10,7 @@ Module that provides access to contxt applications
     * [.addFavorite(applicationId)](#Applications+addFavorite) ⇒ <code>Promise</code>
     * [.getAll()](#Applications+getAll) ⇒ <code>Promise</code>
     * [.getFavorites()](#Applications+getFavorites) ⇒ <code>Promise</code>
-    * [.getFeatured([organizationId])](#Applications+getFeatured) ⇒ <code>Promise</code>
+    * [.getFeatured(organizationId)](#Applications+getFeatured) ⇒ <code>Promise</code>
     * [.getGroupings(applicationId)](#Applications+getGroupings) ⇒ <code>Promise</code>
     * [.removeFavorite(applicationId)](#Applications+removeFavorite) ⇒ <code>Promise</code>
 
@@ -90,7 +90,7 @@ contxtSdk.coordinator.applications
 ```
 <a name="Applications+getFeatured"></a>
 
-### contxtSdk.coordinator.applications.getFeatured([organizationId]) ⇒ <code>Promise</code>
+### contxtSdk.coordinator.applications.getFeatured(organizationId) ⇒ <code>Promise</code>
 Gets an organization's list of featured applications
 
 Legacy API Endpoint: '/organizations/:organizationId/applications/featured'
@@ -105,7 +105,7 @@ Note: Only valid for web users using auth0WebAuth session type
 
 | Param | Type | Description |
 | --- | --- | --- |
-| [organizationId] | <code>string</code> | The ID of the organization, required when using the legacy API |
+| organizationId | <code>string</code> | The ID of the organization, optional when using the tenant API and an organization ID has been set |
 
 **Example**  
 ```js

--- a/docs/Applications.md
+++ b/docs/Applications.md
@@ -7,12 +7,12 @@ Module that provides access to contxt applications
 
 * [Applications](#Applications)
     * [new Applications(sdk, request, baseUrl)](#new_Applications_new)
-    * [.addFavorite(applicationId)](#Applications+addFavorite) ⇒ <code>Promise</code>
-    * [.getAll()](#Applications+getAll) ⇒ <code>Promise</code>
-    * [.getFavorites()](#Applications+getFavorites) ⇒ <code>Promise</code>
+    * [.addFavorite(organizationId, applicationId)](#Applications+addFavorite) ⇒ <code>Promise</code>
+    * [.getAll(organizationId)](#Applications+getAll) ⇒ <code>Promise</code>
+    * [.getFavorites(organizationId)](#Applications+getFavorites) ⇒ <code>Promise</code>
     * [.getFeatured(organizationId)](#Applications+getFeatured) ⇒ <code>Promise</code>
-    * [.getGroupings(applicationId)](#Applications+getGroupings) ⇒ <code>Promise</code>
-    * [.removeFavorite(applicationId)](#Applications+removeFavorite) ⇒ <code>Promise</code>
+    * [.getGroupings(organizationId, applicationId)](#Applications+getGroupings) ⇒ <code>Promise</code>
+    * [.removeFavorite(organizationId, applicationId)](#Applications+removeFavorite) ⇒ <code>Promise</code>
 
 <a name="new_Applications_new"></a>
 
@@ -26,7 +26,7 @@ Module that provides access to contxt applications
 
 <a name="Applications+addFavorite"></a>
 
-### contxtSdk.coordinator.applications.addFavorite(applicationId) ⇒ <code>Promise</code>
+### contxtSdk.coordinator.applications.addFavorite(organizationId, applicationId) ⇒ <code>Promise</code>
 Adds an application to the current user's list of favorited applications
 
 API Endpoint: '/applications/:applicationId/favorites'
@@ -40,18 +40,19 @@ Note: Only valid for web users using auth0WebAuth session type
 
 | Param | Type | Description |
 | --- | --- | --- |
+| organizationId | <code>string</code> | The ID of the organization |
 | applicationId | <code>number</code> | The ID of the application |
 
 **Example**  
 ```js
 contxtSdk.coordinator.applications
-  .addFavorite(25)
+  .addFavorite('36b8421a-cc4a-4204-b839-1397374fb16b', 25)
   .then((favoriteApplication) => console.log(favoriteApplication))
   .catch((err) => console.log(err));
 ```
 <a name="Applications+getAll"></a>
 
-### contxtSdk.coordinator.applications.getAll() ⇒ <code>Promise</code>
+### contxtSdk.coordinator.applications.getAll(organizationId) ⇒ <code>Promise</code>
 Gets information about all contxt applications
 
 API Endpoint: '/applications'
@@ -60,16 +61,21 @@ Method: GET
 **Kind**: instance method of [<code>Applications</code>](#Applications)  
 **Fulfill**: <code>ContxtApplication[]</code> Information about all contxt applications  
 **Reject**: <code>Error</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| organizationId | <code>string</code> | The ID of the organization |
+
 **Example**  
 ```js
 contxtSdk.coordinator.applications
-  .getAll()
+  .getAll('36b8421a-cc4a-4204-b839-1397374fb16b')
   .then((apps) => console.log(apps))
   .catch((err) => console.log(err));
 ```
 <a name="Applications+getFavorites"></a>
 
-### contxtSdk.coordinator.applications.getFavorites() ⇒ <code>Promise</code>
+### contxtSdk.coordinator.applications.getFavorites(organizationId) ⇒ <code>Promise</code>
 Gets the current user's list of favorited applications
 
 API Endpoint: '/applications/favorites'
@@ -80,10 +86,15 @@ Note: Only valid for web users using auth0WebAuth session type
 **Kind**: instance method of [<code>Applications</code>](#Applications)  
 **Fulfill**: <code>ContxtUserFavoriteApplication[]</code> A list of favorited applications  
 **Reject**: <code>Error</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| organizationId | <code>string</code> | The ID of the organization |
+
 **Example**  
 ```js
 contxtSdk.coordinator.applications
-  .getFavorites()
+  .getFavorites('36b8421a-cc4a-4204-b839-1397374fb16b')
   .then((favoriteApplications) => console.log(favoriteApplications))
   .catch((err) => console.log(err));
 ```
@@ -114,7 +125,7 @@ contxtSdk.coordinator.applications
 ```
 <a name="Applications+getGroupings"></a>
 
-### contxtSdk.coordinator.applications.getGroupings(applicationId) ⇒ <code>Promise</code>
+### contxtSdk.coordinator.applications.getGroupings(organizationId, applicationId) ⇒ <code>Promise</code>
 Gets the application groupings (and application modules) of an application
 that are available to the currently authenticated user.
 
@@ -125,20 +136,21 @@ Method: GET
 **Fulfill**: <code>ContxtApplicationGrouping[]</code>  
 **Reject**: <code>Error</code>  
 
-| Param | Type |
-| --- | --- |
-| applicationId | <code>number</code> | 
+| Param | Type | Description |
+| --- | --- | --- |
+| organizationId | <code>string</code> | The ID of the organization |
+| applicationId | <code>number</code> |  |
 
 **Example**  
 ```js
 contxtSdk.coordinator.applications
-  .getGroupings(31)
+  .getGroupings('36b8421a-cc4a-4204-b839-1397374fb16b', 31)
   .then((applicationGroupings) => console.log(applicationGroupings))
   .catch((err) => console.log(err));
 ```
 <a name="Applications+removeFavorite"></a>
 
-### contxtSdk.coordinator.applications.removeFavorite(applicationId) ⇒ <code>Promise</code>
+### contxtSdk.coordinator.applications.removeFavorite(organizationId, applicationId) ⇒ <code>Promise</code>
 Removes an application from the current user's list of favorited applications
 
 API Endpoint: '/applications/:applicationId/favorites'
@@ -152,11 +164,12 @@ Note: Only valid for web users using auth0WebAuth session type
 
 | Param | Type | Description |
 | --- | --- | --- |
+| organizationId | <code>string</code> | The ID of the organization |
 | applicationId | <code>number</code> | The ID of the application |
 
 **Example**  
 ```js
 contxtSdk.coordinator.applications
-  .removeFavorite(25)
+  .removeFavorite('36b8421a-cc4a-4204-b839-1397374fb16b', 25)
   .catch((err) => console.log(err));
 ```

--- a/docs/Applications.md
+++ b/docs/Applications.md
@@ -7,12 +7,12 @@ Module that provides access to contxt applications
 
 * [Applications](#Applications)
     * [new Applications(sdk, request, baseUrl)](#new_Applications_new)
-    * [.addFavorite(organizationId, applicationId)](#Applications+addFavorite) ⇒ <code>Promise</code>
-    * [.getAll(organizationId)](#Applications+getAll) ⇒ <code>Promise</code>
-    * [.getFavorites(organizationId)](#Applications+getFavorites) ⇒ <code>Promise</code>
-    * [.getFeatured(organizationId)](#Applications+getFeatured) ⇒ <code>Promise</code>
-    * [.getGroupings(organizationId, applicationId)](#Applications+getGroupings) ⇒ <code>Promise</code>
-    * [.removeFavorite(organizationId, applicationId)](#Applications+removeFavorite) ⇒ <code>Promise</code>
+    * [.addFavorite(applicationId)](#Applications+addFavorite) ⇒ <code>Promise</code>
+    * [.getAll()](#Applications+getAll) ⇒ <code>Promise</code>
+    * [.getFavorites()](#Applications+getFavorites) ⇒ <code>Promise</code>
+    * [.getFeatured()](#Applications+getFeatured) ⇒ <code>Promise</code>
+    * [.getGroupings(applicationId)](#Applications+getGroupings) ⇒ <code>Promise</code>
+    * [.removeFavorite(applicationId)](#Applications+removeFavorite) ⇒ <code>Promise</code>
 
 <a name="new_Applications_new"></a>
 
@@ -26,7 +26,7 @@ Module that provides access to contxt applications
 
 <a name="Applications+addFavorite"></a>
 
-### contxtSdk.coordinator.applications.addFavorite(organizationId, applicationId) ⇒ <code>Promise</code>
+### contxtSdk.coordinator.applications.addFavorite(applicationId) ⇒ <code>Promise</code>
 Adds an application to the current user's list of favorited applications
 
 API Endpoint: '/applications/:applicationId/favorites'
@@ -40,19 +40,18 @@ Note: Only valid for web users using auth0WebAuth session type
 
 | Param | Type | Description |
 | --- | --- | --- |
-| organizationId | <code>string</code> | The ID of the organization |
 | applicationId | <code>number</code> | The ID of the application |
 
 **Example**  
 ```js
 contxtSdk.coordinator.applications
-  .addFavorite('36b8421a-cc4a-4204-b839-1397374fb16b', 25)
+  .addFavorite(25)
   .then((favoriteApplication) => console.log(favoriteApplication))
   .catch((err) => console.log(err));
 ```
 <a name="Applications+getAll"></a>
 
-### contxtSdk.coordinator.applications.getAll(organizationId) ⇒ <code>Promise</code>
+### contxtSdk.coordinator.applications.getAll() ⇒ <code>Promise</code>
 Gets information about all contxt applications
 
 API Endpoint: '/applications'
@@ -61,21 +60,16 @@ Method: GET
 **Kind**: instance method of [<code>Applications</code>](#Applications)  
 **Fulfill**: <code>ContxtApplication[]</code> Information about all contxt applications  
 **Reject**: <code>Error</code>  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| organizationId | <code>string</code> | The ID of the organization |
-
 **Example**  
 ```js
 contxtSdk.coordinator.applications
-  .getAll('36b8421a-cc4a-4204-b839-1397374fb16b')
+  .getAll()
   .then((apps) => console.log(apps))
   .catch((err) => console.log(err));
 ```
 <a name="Applications+getFavorites"></a>
 
-### contxtSdk.coordinator.applications.getFavorites(organizationId) ⇒ <code>Promise</code>
+### contxtSdk.coordinator.applications.getFavorites() ⇒ <code>Promise</code>
 Gets the current user's list of favorited applications
 
 API Endpoint: '/applications/favorites'
@@ -86,21 +80,16 @@ Note: Only valid for web users using auth0WebAuth session type
 **Kind**: instance method of [<code>Applications</code>](#Applications)  
 **Fulfill**: <code>ContxtUserFavoriteApplication[]</code> A list of favorited applications  
 **Reject**: <code>Error</code>  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| organizationId | <code>string</code> | The ID of the organization |
-
 **Example**  
 ```js
 contxtSdk.coordinator.applications
-  .getFavorites('36b8421a-cc4a-4204-b839-1397374fb16b')
+  .getFavorites()
   .then((favoriteApplications) => console.log(favoriteApplications))
   .catch((err) => console.log(err));
 ```
 <a name="Applications+getFeatured"></a>
 
-### contxtSdk.coordinator.applications.getFeatured(organizationId) ⇒ <code>Promise</code>
+### contxtSdk.coordinator.applications.getFeatured() ⇒ <code>Promise</code>
 Gets an organization's list of featured applications
 
 API Endpoint: '/organizations/:organizationId/applications/featured'
@@ -111,21 +100,16 @@ Note: Only valid for web users using auth0WebAuth session type
 **Kind**: instance method of [<code>Applications</code>](#Applications)  
 **Fulfill**: <code>ContxtOrganizationFeaturedApplication[]</code> A list of featured applications  
 **Reject**: <code>Error</code>  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| organizationId | <code>string</code> | The ID of the organization |
-
 **Example**  
 ```js
 contxtSdk.coordinator.applications
-  .getFeatured('36b8421a-cc4a-4204-b839-1397374fb16b')
+  .getFeatured()
   .then((featuredApplications) => console.log(featuredApplications))
   .catch((err) => console.log(err));
 ```
 <a name="Applications+getGroupings"></a>
 
-### contxtSdk.coordinator.applications.getGroupings(organizationId, applicationId) ⇒ <code>Promise</code>
+### contxtSdk.coordinator.applications.getGroupings(applicationId) ⇒ <code>Promise</code>
 Gets the application groupings (and application modules) of an application
 that are available to the currently authenticated user.
 
@@ -136,21 +120,20 @@ Method: GET
 **Fulfill**: <code>ContxtApplicationGrouping[]</code>  
 **Reject**: <code>Error</code>  
 
-| Param | Type | Description |
-| --- | --- | --- |
-| organizationId | <code>string</code> | The ID of the organization |
-| applicationId | <code>number</code> |  |
+| Param | Type |
+| --- | --- |
+| applicationId | <code>number</code> | 
 
 **Example**  
 ```js
 contxtSdk.coordinator.applications
-  .getGroupings('36b8421a-cc4a-4204-b839-1397374fb16b', 31)
+  .getGroupings(31)
   .then((applicationGroupings) => console.log(applicationGroupings))
   .catch((err) => console.log(err));
 ```
 <a name="Applications+removeFavorite"></a>
 
-### contxtSdk.coordinator.applications.removeFavorite(organizationId, applicationId) ⇒ <code>Promise</code>
+### contxtSdk.coordinator.applications.removeFavorite(applicationId) ⇒ <code>Promise</code>
 Removes an application from the current user's list of favorited applications
 
 API Endpoint: '/applications/:applicationId/favorites'
@@ -164,12 +147,11 @@ Note: Only valid for web users using auth0WebAuth session type
 
 | Param | Type | Description |
 | --- | --- | --- |
-| organizationId | <code>string</code> | The ID of the organization |
 | applicationId | <code>number</code> | The ID of the application |
 
 **Example**  
 ```js
 contxtSdk.coordinator.applications
-  .removeFavorite('36b8421a-cc4a-4204-b839-1397374fb16b', 25)
+  .removeFavorite(25)
   .catch((err) => console.log(err));
 ```

--- a/docs/Applications.md
+++ b/docs/Applications.md
@@ -105,7 +105,7 @@ Note: Only valid for web users using auth0WebAuth session type
 
 | Param | Type | Description |
 | --- | --- | --- |
-| [organizationId] | <code>string</code> | The ID of the organization |
+| [organizationId] | <code>string</code> | The ID of the organization, required when using the legacy API |
 
 **Example**  
 ```js

--- a/docs/Applications.md
+++ b/docs/Applications.md
@@ -6,23 +6,24 @@ Module that provides access to contxt applications
 **Kind**: global class  
 
 * [Applications](#Applications)
-    * [new Applications(sdk, request, baseUrl)](#new_Applications_new)
+    * [new Applications(sdk, request, baseUrl, [organizationId])](#new_Applications_new)
     * [.addFavorite(applicationId)](#Applications+addFavorite) ⇒ <code>Promise</code>
     * [.getAll()](#Applications+getAll) ⇒ <code>Promise</code>
     * [.getFavorites()](#Applications+getFavorites) ⇒ <code>Promise</code>
-    * [.getFeatured(organizationId)](#Applications+getFeatured) ⇒ <code>Promise</code>
+    * [.getFeatured([organizationId])](#Applications+getFeatured) ⇒ <code>Promise</code>
     * [.getGroupings(applicationId)](#Applications+getGroupings) ⇒ <code>Promise</code>
     * [.removeFavorite(applicationId)](#Applications+removeFavorite) ⇒ <code>Promise</code>
 
 <a name="new_Applications_new"></a>
 
-### new Applications(sdk, request, baseUrl)
+### new Applications(sdk, request, baseUrl, [organizationId])
 
-| Param | Type | Description |
-| --- | --- | --- |
-| sdk | <code>Object</code> | An instance of the SDK so the module can communicate with other modules |
-| request | <code>Object</code> | An instance of the request module tied to this module's audience. |
-| baseUrl | <code>string</code> | The base URL provided by the parent module |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| sdk | <code>Object</code> |  | An instance of the SDK so the module can communicate with other modules |
+| request | <code>Object</code> |  | An instance of the request module tied to this module's audience. |
+| baseUrl | <code>string</code> |  | The base URL provided by the parent module |
+| [organizationId] | <code>string</code> | <code>null</code> | The organization ID to be used in tenant url requests |
 
 <a name="Applications+addFavorite"></a>
 
@@ -89,10 +90,11 @@ contxtSdk.coordinator.applications
 ```
 <a name="Applications+getFeatured"></a>
 
-### contxtSdk.coordinator.applications.getFeatured(organizationId) ⇒ <code>Promise</code>
+### contxtSdk.coordinator.applications.getFeatured([organizationId]) ⇒ <code>Promise</code>
 Gets an organization's list of featured applications
 
-API Endpoint: '/organizations/:organizationId/applications/featured'
+Legacy API Endpoint: '/organizations/:organizationId/applications/featured'
+API Endpoint: '/applications/featured'
 Method: GET
 
 Note: Only valid for web users using auth0WebAuth session type
@@ -103,7 +105,7 @@ Note: Only valid for web users using auth0WebAuth session type
 
 | Param | Type | Description |
 | --- | --- | --- |
-| organizationId | <code>string</code> | The ID of the organization |
+| [organizationId] | <code>string</code> | The ID of the organization |
 
 **Example**  
 ```js

--- a/docs/Consent.md
+++ b/docs/Consent.md
@@ -6,19 +6,20 @@ Module for managing application consent
 **Kind**: global class  
 
 * [Consent](#Consent)
-    * [new Consent(sdk, request, baseUrl)](#new_Consent_new)
+    * [new Consent(sdk, request, baseUrl, [organizationId])](#new_Consent_new)
     * [.accept(consentId)](#Consent+accept) ⇒ <code>Promise</code>
     * [.getForCurrentApplication()](#Consent+getForCurrentApplication) ⇒ <code>Promise</code>
 
 <a name="new_Consent_new"></a>
 
-### new Consent(sdk, request, baseUrl)
+### new Consent(sdk, request, baseUrl, [organizationId])
 
-| Param | Type | Description |
-| --- | --- | --- |
-| sdk | <code>Object</code> | An instance of the SDK so the module can communicate with other modules |
-| request | <code>Object</code> | An instance of the request module tied to this module's audience. |
-| baseUrl | <code>string</code> | The base URL provided by the parent module |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| sdk | <code>Object</code> |  | An instance of the SDK so the module can communicate with other modules |
+| request | <code>Object</code> |  | An instance of the request module tied to this module's audience. |
+| baseUrl | <code>string</code> |  | The base URL provided by the parent module |
+| [organizationId] | <code>string</code> | <code>null</code> | The organization ID to be used in tenant url requests |
 
 <a name="Consent+accept"></a>
 

--- a/docs/Coordinator.md
+++ b/docs/Coordinator.md
@@ -4,6 +4,11 @@
 Module that provides access to information about Contxt
 
 **Kind**: global class  
+
+* [Coordinator](#Coordinator)
+    * [new Coordinator(sdk, request)](#new_Coordinator_new)
+    * [.setOrganizationId(organizationId)](#Coordinator+setOrganizationId)
+
 <a name="new_Coordinator_new"></a>
 
 ### new Coordinator(sdk, request)
@@ -13,3 +18,19 @@ Module that provides access to information about Contxt
 | sdk | <code>Object</code> | An instance of the SDK so the module can communicate with other modules |
 | request | <code>Object</code> | An instance of the request module tied to this module's audience. |
 
+<a name="Coordinator+setOrganizationId"></a>
+
+### contxtSdk.coordinator.setOrganizationId(organizationId)
+Sets a selected oranization ID to be used in tenant based requests
+
+**Kind**: instance method of [<code>Coordinator</code>](#Coordinator)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| organizationId | <code>string</code> | the ID of the organization |
+
+**Example**  
+```js
+contxtSdk.coordinator
+  .setOrganizationId('36b8421a-cc4a-4204-b839-1397374fb16b');
+```

--- a/docs/EdgeNodes.md
+++ b/docs/EdgeNodes.md
@@ -6,25 +6,27 @@ Module that provides access to contxt edge nodes
 **Kind**: global class  
 
 * [EdgeNodes](#EdgeNodes)
-    * [new EdgeNodes(sdk, request, baseUrl)](#new_EdgeNodes_new)
-    * [.get(organizationId, edgeNodeClientId)](#EdgeNodes+get) ⇒ <code>Promise</code>
+    * [new EdgeNodes(sdk, request, baseUrl, [organizationId])](#new_EdgeNodes_new)
+    * [.get([organizationId], edgeNodeClientId)](#EdgeNodes+get) ⇒ <code>Promise</code>
 
 <a name="new_EdgeNodes_new"></a>
 
-### new EdgeNodes(sdk, request, baseUrl)
+### new EdgeNodes(sdk, request, baseUrl, [organizationId])
 
-| Param | Type | Description |
-| --- | --- | --- |
-| sdk | <code>Object</code> | An instance of the SDK so the module can communicate with other modules |
-| request | <code>Object</code> | An instance of the request module tied to this module's audience. |
-| baseUrl | <code>string</code> | The base URL provided by the parent module |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| sdk | <code>Object</code> |  | An instance of the SDK so the module can communicate with other modules |
+| request | <code>Object</code> |  | An instance of the request module tied to this module's audience. |
+| baseUrl | <code>string</code> |  | The base URL provided by the parent module |
+| [organizationId] | <code>string</code> | <code>null</code> | The organization ID to be used in tenant url requests |
 
 <a name="EdgeNodes+get"></a>
 
-### contxtSdk.coordinator.edgeNodes.get(organizationId, edgeNodeClientId) ⇒ <code>Promise</code>
+### contxtSdk.coordinator.edgeNodes.get([organizationId], edgeNodeClientId) ⇒ <code>Promise</code>
 Get an edge node
 
-API Endpoint: '/organizations/:organizationId/edgenodes/:edgeNodeClientId'
+Legacy API Endpoint: '/organizations/:organizationId/edgenodes/:edgeNodeClientId'
+API Endpoint: 'edgenodes/:edgeNodeClientId'
 METHOD: GET
 
 **Kind**: instance method of [<code>EdgeNodes</code>](#EdgeNodes)  
@@ -33,7 +35,7 @@ METHOD: GET
 
 | Param | Type | Description |
 | --- | --- | --- |
-| organizationId | <code>string</code> | UUID |
+| [organizationId] | <code>string</code> | UUID Required when using the legacy API |
 | edgeNodeClientId | <code>string</code> |  |
 
 **Example**  

--- a/docs/EdgeNodes.md
+++ b/docs/EdgeNodes.md
@@ -7,7 +7,7 @@ Module that provides access to contxt edge nodes
 
 * [EdgeNodes](#EdgeNodes)
     * [new EdgeNodes(sdk, request, baseUrl, [organizationId])](#new_EdgeNodes_new)
-    * [.get([organizationId], edgeNodeClientId)](#EdgeNodes+get) ⇒ <code>Promise</code>
+    * [.get(organizationId, edgeNodeClientId)](#EdgeNodes+get) ⇒ <code>Promise</code>
 
 <a name="new_EdgeNodes_new"></a>
 
@@ -22,7 +22,7 @@ Module that provides access to contxt edge nodes
 
 <a name="EdgeNodes+get"></a>
 
-### contxtSdk.coordinator.edgeNodes.get([organizationId], edgeNodeClientId) ⇒ <code>Promise</code>
+### contxtSdk.coordinator.edgeNodes.get(organizationId, edgeNodeClientId) ⇒ <code>Promise</code>
 Get an edge node
 
 Legacy API Endpoint: '/organizations/:organizationId/edgenodes/:edgeNodeClientId'
@@ -35,7 +35,7 @@ METHOD: GET
 
 | Param | Type | Description |
 | --- | --- | --- |
-| [organizationId] | <code>string</code> | UUID Required when using the legacy API |
+| organizationId | <code>string</code> | The ID of the organization, optional when using the tenant API and an organization ID has been set |
 | edgeNodeClientId | <code>string</code> |  |
 
 **Example**  

--- a/docs/Organizations.md
+++ b/docs/Organizations.md
@@ -6,26 +6,28 @@ Module that provides access to contxt organizations
 **Kind**: global class  
 
 * [Organizations](#Organizations)
-    * [new Organizations(sdk, request, baseUrl)](#new_Organizations_new)
+    * [new Organizations(sdk, request, baseUrl, [organizationId])](#new_Organizations_new)
     * [.get(organizationId)](#Organizations+get) ⇒ <code>Promise</code>
     * [.getAll()](#Organizations+getAll) ⇒ <code>Promise</code>
 
 <a name="new_Organizations_new"></a>
 
-### new Organizations(sdk, request, baseUrl)
+### new Organizations(sdk, request, baseUrl, [organizationId])
 
-| Param | Type | Description |
-| --- | --- | --- |
-| sdk | <code>Object</code> | An instance of the SDK so the module can communicate with other modules |
-| request | <code>Object</code> | An instance of the request module tied to this module's audience. |
-| baseUrl | <code>string</code> | The base URL provided by the parent module |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| sdk | <code>Object</code> |  | An instance of the SDK so the module can communicate with other modules |
+| request | <code>Object</code> |  | An instance of the request module tied to this module's audience. |
+| baseUrl | <code>string</code> |  | The base URL provided by the parent module |
+| [organizationId] | <code>string</code> | <code>null</code> | The organization ID to be used in tenant url requests |
 
 <a name="Organizations+get"></a>
 
 ### contxtSdk.coordinator.organizations.get(organizationId) ⇒ <code>Promise</code>
 Gets information about a contxt organization
 
-API Endpoint: '/organizations/:organizationId'
+Legacy API Endpoint: '/organizations/:organizationId'
+API Endpoint: ''
 Method: GET
 
 **Kind**: instance method of [<code>Organizations</code>](#Organizations)  

--- a/docs/Organizations.md
+++ b/docs/Organizations.md
@@ -27,7 +27,7 @@ Module that provides access to contxt organizations
 Gets information about a contxt organization
 
 Legacy API Endpoint: '/organizations/:organizationId'
-API Endpoint: ''
+API Endpoint: '/'
 Method: GET
 
 **Kind**: instance method of [<code>Organizations</code>](#Organizations)  

--- a/docs/Organizations.md
+++ b/docs/Organizations.md
@@ -36,7 +36,7 @@ Method: GET
 
 | Param | Type | Description |
 | --- | --- | --- |
-| organizationId | <code>string</code> | The ID of the organization |
+| organizationId | <code>string</code> | The ID of the organization, optional when using the tenant API and an organization ID has been set |
 
 **Example**  
 ```js

--- a/docs/Permissions.md
+++ b/docs/Permissions.md
@@ -7,8 +7,8 @@ Module that provides access to contxt user permissions
 
 * [Permissions](#Permissions)
     * [new Permissions(sdk, request, baseUrl, [organizationId])](#new_Permissions_new)
-    * [.getAllByOrganizationId([organizationId])](#Permissions+getAllByOrganizationId) ⇒ <code>Promise</code>
-    * [.getOneByOrganizationId([organizationId], userId)](#Permissions+getOneByOrganizationId) ⇒ <code>Promise</code>
+    * [.getAllByOrganizationId(organizationId)](#Permissions+getAllByOrganizationId) ⇒ <code>Promise</code>
+    * [.getOneByOrganizationId(organizationId, userId)](#Permissions+getOneByOrganizationId) ⇒ <code>Promise</code>
     * [.getByUserId(userId)](#Permissions+getByUserId) ⇒ <code>Promise</code>
 
 <a name="new_Permissions_new"></a>
@@ -24,7 +24,7 @@ Module that provides access to contxt user permissions
 
 <a name="Permissions+getAllByOrganizationId"></a>
 
-### contxtSdk.coordinator.permissions.getAllByOrganizationId([organizationId]) ⇒ <code>Promise</code>
+### contxtSdk.coordinator.permissions.getAllByOrganizationId(organizationId) ⇒ <code>Promise</code>
 Gets a list of user permissions for each user in an organization
 
 Legacy API Endpoint: '/organizations/:organizationId/users/permissions'
@@ -37,7 +37,7 @@ Method: GET
 
 | Param | Type | Description |
 | --- | --- | --- |
-| [organizationId] | <code>string</code> | The ID of the organization. Required when using the legacy API |
+| organizationId | <code>string</code> | The ID of the organization, optional when using the tenant API and an organization ID has been set |
 
 **Example**  
 ```js
@@ -48,7 +48,7 @@ contxtSdk.coordinator.permissions
 ```
 <a name="Permissions+getOneByOrganizationId"></a>
 
-### contxtSdk.coordinator.permissions.getOneByOrganizationId([organizationId], userId) ⇒ <code>Promise</code>
+### contxtSdk.coordinator.permissions.getOneByOrganizationId(organizationId, userId) ⇒ <code>Promise</code>
 Gets a single user's permissions within an organization
 
 Legacy API Endpoint: '/organizations/:organizationId/users/:userId/permissions'
@@ -61,7 +61,7 @@ Method: GET
 
 | Param | Type | Description |
 | --- | --- | --- |
-| [organizationId] | <code>string</code> | The ID of the organization. Required when using the legacy API |
+| organizationId | <code>string</code> | The ID of the organization, optional when using the tenant API and an organization ID has been set |
 | userId | <code>string</code> | The ID of the user |
 
 **Example**  

--- a/docs/Permissions.md
+++ b/docs/Permissions.md
@@ -6,27 +6,29 @@ Module that provides access to contxt user permissions
 **Kind**: global class  
 
 * [Permissions](#Permissions)
-    * [new Permissions(sdk, request, baseUrl)](#new_Permissions_new)
-    * [.getAllByOrganizationId(organizationId)](#Permissions+getAllByOrganizationId) ⇒ <code>Promise</code>
-    * [.getOneByOrganizationId(organizationId, userId)](#Permissions+getOneByOrganizationId) ⇒ <code>Promise</code>
+    * [new Permissions(sdk, request, baseUrl, [organizationId])](#new_Permissions_new)
+    * [.getAllByOrganizationId([organizationId])](#Permissions+getAllByOrganizationId) ⇒ <code>Promise</code>
+    * [.getOneByOrganizationId([organizationId], userId)](#Permissions+getOneByOrganizationId) ⇒ <code>Promise</code>
     * [.getByUserId(userId)](#Permissions+getByUserId) ⇒ <code>Promise</code>
 
 <a name="new_Permissions_new"></a>
 
-### new Permissions(sdk, request, baseUrl)
+### new Permissions(sdk, request, baseUrl, [organizationId])
 
-| Param | Type | Description |
-| --- | --- | --- |
-| sdk | <code>Object</code> | An instance of the SDK so the module can communicate with other modules |
-| request | <code>Object</code> | An instance of the request module tied to this module's audience. |
-| baseUrl | <code>string</code> | The base URL provided by the parent module |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| sdk | <code>Object</code> |  | An instance of the SDK so the module can communicate with other modules |
+| request | <code>Object</code> |  | An instance of the request module tied to this module's audience. |
+| baseUrl | <code>string</code> |  | The base URL provided by the parent module |
+| [organizationId] | <code>string</code> | <code>null</code> | The organization ID to be used in tenant url requests |
 
 <a name="Permissions+getAllByOrganizationId"></a>
 
-### contxtSdk.coordinator.permissions.getAllByOrganizationId(organizationId) ⇒ <code>Promise</code>
+### contxtSdk.coordinator.permissions.getAllByOrganizationId([organizationId]) ⇒ <code>Promise</code>
 Gets a list of user permissions for each user in an organization
 
-API Endpoint: '/organizations/:organizationId/users/permissions'
+Legacy API Endpoint: '/organizations/:organizationId/users/permissions'
+API Endpoint: '/users/permissions/'
 Method: GET
 
 **Kind**: instance method of [<code>Permissions</code>](#Permissions)  
@@ -35,7 +37,7 @@ Method: GET
 
 | Param | Type | Description |
 | --- | --- | --- |
-| organizationId | <code>string</code> | The ID of the organization |
+| [organizationId] | <code>string</code> | The ID of the organization. Required when using the legacy API |
 
 **Example**  
 ```js
@@ -46,10 +48,11 @@ contxtSdk.coordinator.permissions
 ```
 <a name="Permissions+getOneByOrganizationId"></a>
 
-### contxtSdk.coordinator.permissions.getOneByOrganizationId(organizationId, userId) ⇒ <code>Promise</code>
+### contxtSdk.coordinator.permissions.getOneByOrganizationId([organizationId], userId) ⇒ <code>Promise</code>
 Gets a single user's permissions within an organization
 
-API Endpoint: '/organizations/:organizationId/users/:userId/permissions'
+Legacy API Endpoint: '/organizations/:organizationId/users/:userId/permissions'
+API Endpoint: '/users/:userId/permissions'
 Method: GET
 
 **Kind**: instance method of [<code>Permissions</code>](#Permissions)  
@@ -58,7 +61,7 @@ Method: GET
 
 | Param | Type | Description |
 | --- | --- | --- |
-| organizationId | <code>string</code> | The ID of the organization |
+| [organizationId] | <code>string</code> | The ID of the organization. Required when using the legacy API |
 | userId | <code>string</code> | The ID of the user |
 
 **Example**  

--- a/docs/Roles.md
+++ b/docs/Roles.md
@@ -9,9 +9,9 @@ Module that provides access to contxt roles
     * [new Roles(sdk, request, baseUrl, [organizationId])](#new_Roles_new)
     * [.addApplication(roleId, applicationId)](#Roles+addApplication) ⇒ <code>Promise</code>
     * [.addStack(roleId, stackId, accessType)](#Roles+addStack) ⇒ <code>Promise</code>
-    * [.create([organizationId], role)](#Roles+create) ⇒ <code>Promise</code>
-    * [.delete([organizationId], roleId)](#Roles+delete) ⇒ <code>Promise</code>
-    * [.getByOrganizationId([organizationId])](#Roles+getByOrganizationId) ⇒ <code>Promise</code>
+    * [.create(organizationId, role)](#Roles+create) ⇒ <code>Promise</code>
+    * [.delete(organizationId, roleId)](#Roles+delete) ⇒ <code>Promise</code>
+    * [.getByOrganizationId(organizationId)](#Roles+getByOrganizationId) ⇒ <code>Promise</code>
     * [.removeApplication(roleId, applicationId)](#Roles+removeApplication) ⇒ <code>Promise</code>
     * [.removeStack(roleId, stackId)](#Roles+removeStack) ⇒ <code>Promise</code>
 
@@ -77,7 +77,7 @@ contxtSdk.roles
 ```
 <a name="Roles+create"></a>
 
-### contxtSdk.coordinator.roles.create([organizationId], role) ⇒ <code>Promise</code>
+### contxtSdk.coordinator.roles.create(organizationId, role) ⇒ <code>Promise</code>
 Create a new role for an organization
 
 **Kind**: instance method of [<code>Roles</code>](#Roles)  
@@ -86,7 +86,7 @@ Create a new role for an organization
 
 | Param | Type | Description |
 | --- | --- | --- |
-| [organizationId] | <code>string</code> | The ID of the organization. Required when using the legacy API |
+| organizationId | <code>string</code> | The ID of the organization, optional when using the tenant API and an organization ID has been set |
 | role | <code>Object</code> |  |
 | role.name | <code>string</code> | The name of the new role |
 | role.description | <code>string</code> | Some text describing the purpose of the role |
@@ -103,7 +103,7 @@ contxtSdk.coordinator.roles
 ```
 <a name="Roles+delete"></a>
 
-### contxtSdk.coordinator.roles.delete([organizationId], roleId) ⇒ <code>Promise</code>
+### contxtSdk.coordinator.roles.delete(organizationId, roleId) ⇒ <code>Promise</code>
 Deletes a role from an organization
 
 Legacy API Endpoint: '/organizations/:organizationId/roles/:roleId'
@@ -116,7 +116,7 @@ Method: DELETE
 
 | Param | Type | Description |
 | --- | --- | --- |
-| [organizationId] | <code>string</code> | The ID of the organization. Required when using the legacy API |
+| organizationId | <code>string</code> | The ID of the organization, optional when using the tenant API and an organization ID has been set |
 | roleId | <code>string</code> | The UUID formatted ID of the role |
 
 **Example**  
@@ -125,7 +125,7 @@ contxtSdk.roles.delete('4f0e51c6-728b-4892-9863-6d002e61204d', '8b64fb12-e649-46
 ```
 <a name="Roles+getByOrganizationId"></a>
 
-### contxtSdk.coordinator.roles.getByOrganizationId([organizationId]) ⇒ <code>Promise</code>
+### contxtSdk.coordinator.roles.getByOrganizationId(organizationId) ⇒ <code>Promise</code>
 Gets an organization's list of roles
 
 Legacy API Endpoint: '/organizations/:organizationId/roles'
@@ -138,7 +138,7 @@ Method: GET
 
 | Param | Type | Description |
 | --- | --- | --- |
-| [organizationId] | <code>string</code> | The ID of the organization. Required when using the legacy API |
+| organizationId | <code>string</code> | The ID of the organization, optional when using the tenant API and an organization ID has been set |
 
 **Example**  
 ```js

--- a/docs/Roles.md
+++ b/docs/Roles.md
@@ -6,24 +6,25 @@ Module that provides access to contxt roles
 **Kind**: global class  
 
 * [Roles](#Roles)
-    * [new Roles(sdk, request, baseUrl)](#new_Roles_new)
+    * [new Roles(sdk, request, baseUrl, [organizationId])](#new_Roles_new)
     * [.addApplication(roleId, applicationId)](#Roles+addApplication) ⇒ <code>Promise</code>
     * [.addStack(roleId, stackId, accessType)](#Roles+addStack) ⇒ <code>Promise</code>
-    * [.create(organizationId, role)](#Roles+create) ⇒ <code>Promise</code>
-    * [.delete(organizationId, roleId)](#Roles+delete) ⇒ <code>Promise</code>
-    * [.getByOrganizationId(organizationId)](#Roles+getByOrganizationId) ⇒ <code>Promise</code>
+    * [.create([organizationId], role)](#Roles+create) ⇒ <code>Promise</code>
+    * [.delete([organizationId], roleId)](#Roles+delete) ⇒ <code>Promise</code>
+    * [.getByOrganizationId([organizationId])](#Roles+getByOrganizationId) ⇒ <code>Promise</code>
     * [.removeApplication(roleId, applicationId)](#Roles+removeApplication) ⇒ <code>Promise</code>
     * [.removeStack(roleId, stackId)](#Roles+removeStack) ⇒ <code>Promise</code>
 
 <a name="new_Roles_new"></a>
 
-### new Roles(sdk, request, baseUrl)
+### new Roles(sdk, request, baseUrl, [organizationId])
 
-| Param | Type | Description |
-| --- | --- | --- |
-| sdk | <code>Object</code> | An instance of the SDK so the module can communicate with other modules |
-| request | <code>Object</code> | An instance of the request module tied to this module's audience. |
-| baseUrl | <code>string</code> | The base URL provided by the parent module |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| sdk | <code>Object</code> |  | An instance of the SDK so the module can communicate with other modules |
+| request | <code>Object</code> |  | An instance of the request module tied to this module's audience. |
+| baseUrl | <code>string</code> |  | The base URL provided by the parent module |
+| [organizationId] | <code>string</code> | <code>null</code> | The organization ID to be used in tenant url requests |
 
 <a name="Roles+addApplication"></a>
 
@@ -76,7 +77,7 @@ contxtSdk.roles
 ```
 <a name="Roles+create"></a>
 
-### contxtSdk.coordinator.roles.create(organizationId, role) ⇒ <code>Promise</code>
+### contxtSdk.coordinator.roles.create([organizationId], role) ⇒ <code>Promise</code>
 Create a new role for an organization
 
 **Kind**: instance method of [<code>Roles</code>](#Roles)  
@@ -85,7 +86,7 @@ Create a new role for an organization
 
 | Param | Type | Description |
 | --- | --- | --- |
-| organizationId | <code>string</code> | The ID of the organization |
+| [organizationId] | <code>string</code> | The ID of the organization. Required when using the legacy API |
 | role | <code>Object</code> |  |
 | role.name | <code>string</code> | The name of the new role |
 | role.description | <code>string</code> | Some text describing the purpose of the role |
@@ -102,10 +103,11 @@ contxtSdk.coordinator.roles
 ```
 <a name="Roles+delete"></a>
 
-### contxtSdk.coordinator.roles.delete(organizationId, roleId) ⇒ <code>Promise</code>
+### contxtSdk.coordinator.roles.delete([organizationId], roleId) ⇒ <code>Promise</code>
 Deletes a role from an organization
 
-API Endpoint: '/organizations/:organizationId/roles/:roleId'
+Legacy API Endpoint: '/organizations/:organizationId/roles/:roleId'
+API Endpiont: '/roles/:roleId'
 Method: DELETE
 
 **Kind**: instance method of [<code>Roles</code>](#Roles)  
@@ -114,19 +116,20 @@ Method: DELETE
 
 | Param | Type | Description |
 | --- | --- | --- |
-| organizationId | <code>string</code> | The ID of the organization |
+| [organizationId] | <code>string</code> | The ID of the organization. Required when using the legacy API |
 | roleId | <code>string</code> | The UUID formatted ID of the role |
 
 **Example**  
 ```js
-contxtSdk.roles.delete('4f0e51c6-728b-4892-9863-6d002e61204d');
+contxtSdk.roles.delete('4f0e51c6-728b-4892-9863-6d002e61204d', '8b64fb12-e649-46be-b330-e672d28eed99s');
 ```
 <a name="Roles+getByOrganizationId"></a>
 
-### contxtSdk.coordinator.roles.getByOrganizationId(organizationId) ⇒ <code>Promise</code>
+### contxtSdk.coordinator.roles.getByOrganizationId([organizationId]) ⇒ <code>Promise</code>
 Gets an organization's list of roles
 
-API Endpoint: '/organizations/:organizationId/roles'
+Legacy API Endpoint: '/organizations/:organizationId/roles'
+API Endpoint: '/roles'
 Method: GET
 
 **Kind**: instance method of [<code>Roles</code>](#Roles)  
@@ -135,7 +138,7 @@ Method: GET
 
 | Param | Type | Description |
 | --- | --- | --- |
-| organizationId | <code>string</code> | The ID of the organization |
+| [organizationId] | <code>string</code> | The ID of the organization. Required when using the legacy API |
 
 **Example**  
 ```js

--- a/docs/Users.md
+++ b/docs/Users.md
@@ -175,7 +175,7 @@ Method: GET
 
 | Param | Type | Description |
 | --- | --- | --- |
-| organizationId | <code>string</code> | The ID of the organization |
+| organizationId | <code>string</code> | The ID of the organization, optional when using the tenant API and an organization ID has been set |
 
 **Example**  
 ```js
@@ -202,7 +202,7 @@ Note: Only valid for web users using auth0WebAuth session type
 
 | Param | Type | Description |
 | --- | --- | --- |
-| organizationId | <code>string</code> | The ID of the organization |
+| organizationId | <code>string</code> | The ID of the organization, optional when using the tenant API and an organization ID has been set |
 | user | <code>Object</code> |  |
 | user.email | <code>string</code> | The email address of the new user |
 | user.firstName | <code>string</code> | The first name of the new user |
@@ -236,7 +236,7 @@ Method: DELETE
 
 | Param | Type | Description |
 | --- | --- | --- |
-| organizationId | <code>string</code> | The ID of the organization |
+| organizationId | <code>string</code> | The ID of the organization, optional when using the tenant API and an organization ID has been set |
 | userId | <code>string</code> | The ID of the user |
 
 **Example**  

--- a/docs/Users.md
+++ b/docs/Users.md
@@ -6,7 +6,7 @@ Module that provides access to contxt users
 **Kind**: global class  
 
 * [Users](#Users)
-    * [new Users(sdk, request, baseUrl)](#new_Users_new)
+    * [new Users(sdk, request, baseUrl, [organizationId])](#new_Users_new)
     * [.activate(userId, user)](#Users+activate) ⇒ <code>Promise</code>
     * [.addApplication(userId, applicationId)](#Users+addApplication) ⇒ <code>Promise</code>
     * [.addRole(userId, roleId)](#Users+addRole) ⇒ <code>Promise</code>
@@ -22,13 +22,14 @@ Module that provides access to contxt users
 
 <a name="new_Users_new"></a>
 
-### new Users(sdk, request, baseUrl)
+### new Users(sdk, request, baseUrl, [organizationId])
 
-| Param | Type | Description |
-| --- | --- | --- |
-| sdk | <code>Object</code> | An instance of the SDK so the module can communicate with other modules |
-| request | <code>Object</code> | An instance of the request module tied to this module's audience. |
-| baseUrl | <code>string</code> | The base URL provided by the parent module |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| sdk | <code>Object</code> |  | An instance of the SDK so the module can communicate with other modules |
+| request | <code>Object</code> |  | An instance of the request module tied to this module's audience. |
+| baseUrl | <code>string</code> |  | The base URL provided by the parent module |
+| [organizationId] | <code>string</code> | <code>null</code> | The organization ID to be used in tenant url requests |
 
 <a name="Users+activate"></a>
 
@@ -164,7 +165,8 @@ contxtSdk.coordinator.users
 ### contxtSdk.coordinator.users.getByOrganizationId(organizationId) ⇒ <code>Promise</code>
 Gets a list of users for a contxt organization
 
-API Endpoint: '/organizations/:organizationId/users'
+Legacy API Endpoint: '/organizations/:organizationId/users'
+API Endpoint: '/users'
 Method: GET
 
 **Kind**: instance method of [<code>Users</code>](#Users)  
@@ -188,7 +190,8 @@ contxtSdk.coordinator.users
 Creates a new contxt user, adds them to an organization, and
 sends them an email invite link to do final account setup.
 
-API Endpoint: '/organizations/:organizationId/users'
+Legacy API Endpoint: '/organizations/:organizationId/users'
+API Endpoint: '/users'
 Method: POST
 
 Note: Only valid for web users using auth0WebAuth session type
@@ -223,7 +226,8 @@ contxtSdk.coordinator.users
 ### contxtSdk.coordinator.users.remove(organizationId, userId) ⇒ <code>Promise</code>
 Removes a user from an organization
 
-API Endpoint: '/organizations/:organizationId/users/:userId'
+Legacy API Endpoint: '/organizations/:organizationId/users/:userId'
+API Endpoint: '/users/:userId'
 Method: DELETE
 
 **Kind**: instance method of [<code>Users</code>](#Users)  

--- a/src/coordinator/applications.js
+++ b/src/coordinator/applications.js
@@ -165,7 +165,7 @@ class Applications {
    *
    * Note: Only valid for web users using auth0WebAuth session type
    *
-   * @param {string} [organizationId] The ID of the organization, required when using the legacy API
+   * @param {string} organizationId The ID of the organization, optional when using the tenant API and an organization ID has been set
    *
    * @returns {Promise}
    * @fulfill {ContxtOrganizationFeaturedApplication[]} A list of featured applications

--- a/src/coordinator/applications.js
+++ b/src/coordinator/applications.js
@@ -67,11 +67,13 @@ class Applications {
    * @param {Object} sdk An instance of the SDK so the module can communicate with other modules
    * @param {Object} request An instance of the request module tied to this module's audience.
    * @param {string} baseUrl The base URL provided by the parent module
+   * @param {string} [organizationId] The organization ID to be used in tenant url requests
    */
-  constructor(sdk, request, baseUrl) {
+  constructor(sdk, request, baseUrl, organizationId = null) {
     this._baseUrl = baseUrl;
     this._request = request;
     this._sdk = sdk;
+    this._organizationId = organizationId;
   }
 
   /**
@@ -157,12 +159,13 @@ class Applications {
   /**
    * Gets an organization's list of featured applications
    *
-   * API Endpoint: '/organizations/:organizationId/applications/featured'
+   * Legacy API Endpoint: '/organizations/:organizationId/applications/featured'
+   * API Endpoint: '/applications/featured'
    * Method: GET
    *
    * Note: Only valid for web users using auth0WebAuth session type
    *
-   * @param {string} organizationId The ID of the organization
+   * @param {string} [organizationId] The ID of the organization, required when using the legacy API
    *
    * @returns {Promise}
    * @fulfill {ContxtOrganizationFeaturedApplication[]} A list of featured applications
@@ -175,6 +178,12 @@ class Applications {
    *   .catch((err) => console.log(err));
    */
   getFeatured(organizationId) {
+    if (this._organizationId) {
+      return this._request
+        .get(`${this._baseUrl}/applications/featured`)
+        .then((featuredApplications) => toCamelCase(featuredApplications));
+    }
+
     if (!organizationId) {
       return Promise.reject(
         new Error(

--- a/src/coordinator/applications.js
+++ b/src/coordinator/applications.js
@@ -82,7 +82,6 @@ class Applications {
    *
    * Note: Only valid for web users using auth0WebAuth session type
    *
-   * @param {string} organizationId The ID of the organization
    * @param {number} applicationId The ID of the application
    *
    * @returns {Promise}
@@ -91,19 +90,11 @@ class Applications {
    *
    * @example
    * contxtSdk.coordinator.applications
-   *   .addFavorite('36b8421a-cc4a-4204-b839-1397374fb16b', 25)
+   *   .addFavorite(25)
    *   .then((favoriteApplication) => console.log(favoriteApplication))
    *   .catch((err) => console.log(err));
    */
-  addFavorite(organizationId, applicationId) {
-    if (!organizationId) {
-      return Promise.reject(
-        new Error(
-          'An organization ID is required for creating a favorite application'
-        )
-      );
-    }
-
+  addFavorite(applicationId) {
     if (!applicationId) {
       return Promise.reject(
         new Error(
@@ -113,11 +104,7 @@ class Applications {
     }
 
     return this._request
-      .post(
-        `${
-          this._baseUrl
-        }/${organizationId}/applications/${applicationId}/favorites`
-      )
+      .post(`${this._baseUrl}/applications/${applicationId}/favorites`)
       .then((favoriteApplication) => toCamelCase(favoriteApplication));
   }
 
@@ -127,27 +114,19 @@ class Applications {
    * API Endpoint: '/applications'
    * Method: GET
    *
-   * @param {string} organizationId The ID of the organization
-   *
    * @returns {Promise}
    * @fulfill {ContxtApplication[]} Information about all contxt applications
    * @reject {Error}
    *
    * @example
    * contxtSdk.coordinator.applications
-   *   .getAll('36b8421a-cc4a-4204-b839-1397374fb16b')
+   *   .getAll()
    *   .then((apps) => console.log(apps))
    *   .catch((err) => console.log(err));
    */
-  getAll(organizationId) {
-    if (!organizationId) {
-      return Promise.reject(
-        new Error('An organization ID is required for getting all applications')
-      );
-    }
-
+  getAll() {
     return this._request
-      .get(`${this._baseUrl}/${organizationId}/applications`)
+      .get(`${this._baseUrl}/applications`)
       .then((apps) => apps.map((app) => toCamelCase(app)));
   }
 
@@ -159,29 +138,19 @@ class Applications {
    *
    * Note: Only valid for web users using auth0WebAuth session type
    *
-   * @param {string} organizationId The ID of the organization
-   *
    * @returns {Promise}
    * @fulfill {ContxtUserFavoriteApplication[]} A list of favorited applications
    * @reject {Error}
    *
    * @example
    * contxtSdk.coordinator.applications
-   *   .getFavorites('36b8421a-cc4a-4204-b839-1397374fb16b')
+   *   .getFavorites()
    *   .then((favoriteApplications) => console.log(favoriteApplications))
    *   .catch((err) => console.log(err));
    */
-  getFavorites(organizationId) {
-    if (!organizationId) {
-      return Promise.reject(
-        new Error(
-          "An organization ID is required for getting a user's list of favorited applications"
-        )
-      );
-    }
-
+  getFavorites() {
     return this._request
-      .get(`${this._baseUrl}/${organizationId}/applications/favorites`)
+      .get(`${this._baseUrl}/applications/favorites`)
       .then((favoriteApps) => toCamelCase(favoriteApps));
   }
 
@@ -215,7 +184,9 @@ class Applications {
     }
 
     return this._request
-      .get(`${this._baseUrl}/${organizationId}/applications/featured`)
+      .get(
+        `${this._baseUrl}/organizations/${organizationId}/applications/featured`
+      )
       .then((featuredApplications) => toCamelCase(featuredApplications));
   }
 
@@ -226,7 +197,6 @@ class Applications {
    * API Endpoint: '/applications/:applicationId/groupings'
    * Method: GET
    *
-   * @param {string} organizationId The ID of the organization
    * @param {number} applicationId
    *
    * @returns {Promise}
@@ -235,33 +205,13 @@ class Applications {
    *
    * @example
    * contxtSdk.coordinator.applications
-   *   .getGroupings('36b8421a-cc4a-4204-b839-1397374fb16b', 31)
+   *   .getGroupings(31)
    *   .then((applicationGroupings) => console.log(applicationGroupings))
    *   .catch((err) => console.log(err));
    */
-  getGroupings(organizationId, applicationId) {
-    if (!organizationId) {
-      return Promise.reject(
-        new Error(
-          'An organization ID is required for getting application groupings of an application'
-        )
-      );
-    }
-
-    if (!applicationId) {
-      return Promise.reject(
-        new Error(
-          'An application ID is required for getting application groupings of an application'
-        )
-      );
-    }
-
+  getGroupings(applicationId) {
     return this._request
-      .get(
-        `${
-          this._baseUrl
-        }/${organizationId}/applications/${applicationId}/groupings`
-      )
+      .get(`${this._baseUrl}/applications/${applicationId}/groupings`)
       .then((groupings) => toCamelCase(groupings));
   }
 
@@ -273,7 +223,6 @@ class Applications {
    *
    * Note: Only valid for web users using auth0WebAuth session type
    *
-   * @param {string} organizationId The ID of the organization
    * @param {number} applicationId The ID of the application
    *
    * @returns {Promise}
@@ -282,18 +231,10 @@ class Applications {
    *
    * @example
    * contxtSdk.coordinator.applications
-   *   .removeFavorite('36b8421a-cc4a-4204-b839-1397374fb16b', 25)
+   *   .removeFavorite(25)
    *   .catch((err) => console.log(err));
    */
-  removeFavorite(organizationId, applicationId) {
-    if (!organizationId) {
-      return Promise.reject(
-        new Error(
-          'An organization ID is required for deleting a favorite application'
-        )
-      );
-    }
-
+  removeFavorite(applicationId) {
     if (!applicationId) {
       return Promise.reject(
         new Error(
@@ -303,9 +244,7 @@ class Applications {
     }
 
     return this._request.delete(
-      `${
-        this._baseUrl
-      }/${organizationId}/applications/${applicationId}/favorites`
+      `${this._baseUrl}/applications/${applicationId}/favorites`
     );
   }
 }

--- a/src/coordinator/applications.js
+++ b/src/coordinator/applications.js
@@ -82,6 +82,7 @@ class Applications {
    *
    * Note: Only valid for web users using auth0WebAuth session type
    *
+   * @param {string} organizationId The ID of the organization
    * @param {number} applicationId The ID of the application
    *
    * @returns {Promise}
@@ -90,11 +91,19 @@ class Applications {
    *
    * @example
    * contxtSdk.coordinator.applications
-   *   .addFavorite(25)
+   *   .addFavorite('36b8421a-cc4a-4204-b839-1397374fb16b', 25)
    *   .then((favoriteApplication) => console.log(favoriteApplication))
    *   .catch((err) => console.log(err));
    */
-  addFavorite(applicationId) {
+  addFavorite(organizationId, applicationId) {
+    if (!organizationId) {
+      return Promise.reject(
+        new Error(
+          'An organization ID is required for creating a favorite application'
+        )
+      );
+    }
+
     if (!applicationId) {
       return Promise.reject(
         new Error(
@@ -104,7 +113,11 @@ class Applications {
     }
 
     return this._request
-      .post(`${this._baseUrl}/applications/${applicationId}/favorites`)
+      .post(
+        `${
+          this._baseUrl
+        }/${organizationId}/applications/${applicationId}/favorites`
+      )
       .then((favoriteApplication) => toCamelCase(favoriteApplication));
   }
 
@@ -114,19 +127,27 @@ class Applications {
    * API Endpoint: '/applications'
    * Method: GET
    *
+   * @param {string} organizationId The ID of the organization
+   *
    * @returns {Promise}
    * @fulfill {ContxtApplication[]} Information about all contxt applications
    * @reject {Error}
    *
    * @example
    * contxtSdk.coordinator.applications
-   *   .getAll()
+   *   .getAll('36b8421a-cc4a-4204-b839-1397374fb16b')
    *   .then((apps) => console.log(apps))
    *   .catch((err) => console.log(err));
    */
-  getAll() {
+  getAll(organizationId) {
+    if (!organizationId) {
+      return Promise.reject(
+        new Error('An organization ID is required for getting all applications')
+      );
+    }
+
     return this._request
-      .get(`${this._baseUrl}/applications`)
+      .get(`${this._baseUrl}/${organizationId}/applications`)
       .then((apps) => apps.map((app) => toCamelCase(app)));
   }
 
@@ -138,19 +159,29 @@ class Applications {
    *
    * Note: Only valid for web users using auth0WebAuth session type
    *
+   * @param {string} organizationId The ID of the organization
+   *
    * @returns {Promise}
    * @fulfill {ContxtUserFavoriteApplication[]} A list of favorited applications
    * @reject {Error}
    *
    * @example
    * contxtSdk.coordinator.applications
-   *   .getFavorites()
+   *   .getFavorites('36b8421a-cc4a-4204-b839-1397374fb16b')
    *   .then((favoriteApplications) => console.log(favoriteApplications))
    *   .catch((err) => console.log(err));
    */
-  getFavorites() {
+  getFavorites(organizationId) {
+    if (!organizationId) {
+      return Promise.reject(
+        new Error(
+          "An organization ID is required for getting a user's list of favorited applications"
+        )
+      );
+    }
+
     return this._request
-      .get(`${this._baseUrl}/applications/favorites`)
+      .get(`${this._baseUrl}/${organizationId}/applications/favorites`)
       .then((favoriteApps) => toCamelCase(favoriteApps));
   }
 
@@ -184,9 +215,7 @@ class Applications {
     }
 
     return this._request
-      .get(
-        `${this._baseUrl}/organizations/${organizationId}/applications/featured`
-      )
+      .get(`${this._baseUrl}/${organizationId}/applications/featured`)
       .then((featuredApplications) => toCamelCase(featuredApplications));
   }
 
@@ -197,6 +226,7 @@ class Applications {
    * API Endpoint: '/applications/:applicationId/groupings'
    * Method: GET
    *
+   * @param {string} organizationId The ID of the organization
    * @param {number} applicationId
    *
    * @returns {Promise}
@@ -205,13 +235,33 @@ class Applications {
    *
    * @example
    * contxtSdk.coordinator.applications
-   *   .getGroupings(31)
+   *   .getGroupings('36b8421a-cc4a-4204-b839-1397374fb16b', 31)
    *   .then((applicationGroupings) => console.log(applicationGroupings))
    *   .catch((err) => console.log(err));
    */
-  getGroupings(applicationId) {
+  getGroupings(organizationId, applicationId) {
+    if (!organizationId) {
+      return Promise.reject(
+        new Error(
+          'An organization ID is required for getting application groupings of an application'
+        )
+      );
+    }
+
+    if (!applicationId) {
+      return Promise.reject(
+        new Error(
+          'An application ID is required for getting application groupings of an application'
+        )
+      );
+    }
+
     return this._request
-      .get(`${this._baseUrl}/applications/${applicationId}/groupings`)
+      .get(
+        `${
+          this._baseUrl
+        }/${organizationId}/applications/${applicationId}/groupings`
+      )
       .then((groupings) => toCamelCase(groupings));
   }
 
@@ -223,6 +273,7 @@ class Applications {
    *
    * Note: Only valid for web users using auth0WebAuth session type
    *
+   * @param {string} organizationId The ID of the organization
    * @param {number} applicationId The ID of the application
    *
    * @returns {Promise}
@@ -231,10 +282,18 @@ class Applications {
    *
    * @example
    * contxtSdk.coordinator.applications
-   *   .removeFavorite(25)
+   *   .removeFavorite('36b8421a-cc4a-4204-b839-1397374fb16b', 25)
    *   .catch((err) => console.log(err));
    */
-  removeFavorite(applicationId) {
+  removeFavorite(organizationId, applicationId) {
+    if (!organizationId) {
+      return Promise.reject(
+        new Error(
+          'An organization ID is required for deleting a favorite application'
+        )
+      );
+    }
+
     if (!applicationId) {
       return Promise.reject(
         new Error(
@@ -244,7 +303,9 @@ class Applications {
     }
 
     return this._request.delete(
-      `${this._baseUrl}/applications/${applicationId}/favorites`
+      `${
+        this._baseUrl
+      }/${organizationId}/applications/${applicationId}/favorites`
     );
   }
 }

--- a/src/coordinator/applications.spec.js
+++ b/src/coordinator/applications.spec.js
@@ -1,7 +1,7 @@
 import Applications from './applications';
 import * as objectUtils from '../utils/objects';
 
-describe.only('Coordinator/Applications', function() {
+describe('Coordinator/Applications', function() {
   let baseRequest;
   let baseSdk;
   let expectedHost;
@@ -28,22 +28,60 @@ describe.only('Coordinator/Applications', function() {
   });
 
   describe('constructor', function() {
-    let applications;
+    context('when organization ID is provided', function() {
+      let applications;
+      let organizationId;
 
-    beforeEach(function() {
-      applications = new Applications(baseSdk, baseRequest, expectedHost);
+      beforeEach(function() {
+        organizationId = fixture.build('organization').id;
+
+        applications = new Applications(
+          baseSdk,
+          baseRequest,
+          expectedHost,
+          organizationId
+        );
+      });
+
+      it('sets a base url for the class instance', function() {
+        expect(applications._baseUrl).to.equal(expectedHost);
+      });
+
+      it('appends the supplied request module to the class instance', function() {
+        expect(applications._request).to.deep.equal(baseRequest);
+      });
+
+      it('appends the supplied sdk to the class instance', function() {
+        expect(applications._sdk).to.deep.equal(baseSdk);
+      });
+
+      it('sets the organization ID for the class instance', function() {
+        expect(applications._organizationId).to.equal(organizationId);
+      });
     });
 
-    it('sets a base url for the class instance', function() {
-      expect(applications._baseUrl).to.equal(expectedHost);
-    });
+    context('when organization ID is not provided', function() {
+      let applications;
 
-    it('appends the supplied request module to the class instance', function() {
-      expect(applications._request).to.deep.equal(baseRequest);
-    });
+      beforeEach(function() {
+        applications = new Applications(baseSdk, baseRequest, expectedHost);
+      });
 
-    it('appends the supplied sdk to the class instance', function() {
-      expect(applications._sdk).to.deep.equal(baseSdk);
+      it('sets a base url for the class instance', function() {
+        expect(applications._baseUrl).to.equal(expectedHost);
+      });
+
+      it('appends the supplied request module to the class instance', function() {
+        expect(applications._request).to.deep.equal(baseRequest);
+      });
+
+      it('appends the supplied sdk to the class instance', function() {
+        expect(applications._sdk).to.deep.equal(baseSdk);
+      });
+
+      it('sets the organization ID for the class instance', function() {
+        expect(applications._organizationId).to.equal(null);
+      });
     });
   });
 

--- a/src/coordinator/applications.spec.js
+++ b/src/coordinator/applications.spec.js
@@ -1,7 +1,7 @@
 import Applications from './applications';
 import * as objectUtils from '../utils/objects';
 
-describe('Coordinator/Applications', function() {
+describe.only('Coordinator/Applications', function() {
   let baseRequest;
   let baseSdk;
   let expectedHost;
@@ -48,55 +48,80 @@ describe('Coordinator/Applications', function() {
   });
 
   describe('addFavorite', function() {
-    context('when the application ID is provided', function() {
-      let application;
-      let expectedApplicationFavorite;
-      let applicationFavoriteFromServer;
-      let promise;
-      let request;
-      let toCamelCase;
+    context(
+      'when the organizationID and application ID are provided',
+      function() {
+        let application;
+        let expectedApplicationFavorite;
+        let applicationFavoriteFromServer;
+        let organization;
+        let promise;
+        let request;
+        let toCamelCase;
 
-      beforeEach(function() {
-        application = fixture.build('contxtApplication');
+        beforeEach(function() {
+          application = fixture.build('contxtApplication');
 
-        expectedApplicationFavorite = fixture.build(
-          'contxtUserFavoriteApplication'
-        );
-        applicationFavoriteFromServer = fixture.build(
-          'contxtUserFavoriteApplication',
-          expectedApplicationFavorite,
-          {
-            fromServer: true
-          }
-        );
+          expectedApplicationFavorite = fixture.build(
+            'contxtUserFavoriteApplication'
+          );
+          applicationFavoriteFromServer = fixture.build(
+            'contxtUserFavoriteApplication',
+            expectedApplicationFavorite,
+            {
+              fromServer: true
+            }
+          );
 
-        request = {
-          ...baseRequest,
-          post: sinon.stub().resolves(applicationFavoriteFromServer)
-        };
-        toCamelCase = sinon
-          .stub(objectUtils, 'toCamelCase')
-          .callsFake((app) => expectedApplicationFavorite);
+          organization = fixture.build('organization');
 
-        const applications = new Applications(baseSdk, request, expectedHost);
-        promise = applications.addFavorite(application.id);
-      });
+          request = {
+            ...baseRequest,
+            post: sinon.stub().resolves(applicationFavoriteFromServer)
+          };
+          toCamelCase = sinon
+            .stub(objectUtils, 'toCamelCase')
+            .callsFake((app) => expectedApplicationFavorite);
 
-      it('posts the new application favorite to the server', function() {
-        expect(request.post).to.be.calledWith(
-          `${expectedHost}/applications/${application.id}/favorites`
-        );
-      });
-
-      it('formats the application favorite', function() {
-        return promise.then(() => {
-          expect(toCamelCase).to.be.calledWith(applicationFavoriteFromServer);
+          const applications = new Applications(baseSdk, request, expectedHost);
+          promise = applications.addFavorite(organization.id, application.id);
         });
-      });
 
-      it('returns a fulfilled promise with the application favorite', function() {
-        return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
-          expectedApplicationFavorite
+        it('posts the new application favorite to the server', function() {
+          expect(request.post).to.be.calledWith(
+            `${expectedHost}/${organization.id}/applications/${
+              application.id
+            }/favorites`
+          );
+        });
+
+        it('formats the application favorite', function() {
+          return promise.then(() => {
+            expect(toCamelCase).to.be.calledWith(applicationFavoriteFromServer);
+          });
+        });
+
+        it('returns a fulfilled promise with the application favorite', function() {
+          return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
+            expectedApplicationFavorite
+          );
+        });
+      }
+    );
+
+    context('when the organization ID is not provided', function() {
+      it('throws an error', function() {
+        const applications = new Applications(
+          baseSdk,
+          baseRequest,
+          expectedHost
+        );
+        const application = fixture.build('contxtApplication');
+
+        const promise = applications.addFavorite(undefined, application.id);
+
+        return expect(promise).to.be.rejectedWith(
+          'An organization ID is required for creating a favorite application'
         );
       });
     });
@@ -108,7 +133,9 @@ describe('Coordinator/Applications', function() {
           baseRequest,
           expectedHost
         );
-        const promise = applications.addFavorite();
+        const organization = fixture.build('organization');
+
+        const promise = applications.addFavorite(organization);
 
         return expect(promise).to.be.rejectedWith(
           'An application ID is required for creating a favorite application'
@@ -118,157 +145,151 @@ describe('Coordinator/Applications', function() {
   });
 
   describe('getAll', function() {
-    let expectedApplications;
-    let applicationsFromServer;
-    let promise;
-    let request;
-    let toCamelCase;
+    context('when the organization ID is provided', function() {
+      let expectedApplications;
+      let applicationsFromServer;
+      let organization;
+      let promise;
+      let request;
+      let toCamelCase;
 
-    beforeEach(function() {
-      const numberOfApplications = faker.random.number({
-        min: 1,
-        max: 10
-      });
-      expectedApplications = fixture.buildList(
-        'contxtApplication',
-        numberOfApplications
-      );
-      applicationsFromServer = expectedApplications.map((app) =>
-        fixture.build('contxtApplication', app, { fromServer: true })
-      );
-
-      request = {
-        ...baseRequest,
-        get: sinon.stub().resolves(applicationsFromServer)
-      };
-      toCamelCase = sinon
-        .stub(objectUtils, 'toCamelCase')
-        .callsFake((app) =>
-          expectedApplications.find(({ id }) => id === app.id)
+      beforeEach(function() {
+        const numberOfApplications = faker.random.number({
+          min: 1,
+          max: 10
+        });
+        expectedApplications = fixture.buildList(
+          'contxtApplication',
+          numberOfApplications
+        );
+        applicationsFromServer = expectedApplications.map((app) =>
+          fixture.build('contxtApplication', app, { fromServer: true })
         );
 
-      const applications = new Applications(baseSdk, request, expectedHost);
-      promise = applications.getAll();
-    });
+        organization = fixture.build('organization');
 
-    it('gets the list of applications from the server', function() {
-      expect(request.get).to.be.calledWith(`${expectedHost}/applications`);
-    });
+        request = {
+          ...baseRequest,
+          get: sinon.stub().resolves(applicationsFromServer)
+        };
+        toCamelCase = sinon
+          .stub(objectUtils, 'toCamelCase')
+          .callsFake((app) =>
+            expectedApplications.find(({ id }) => id === app.id)
+          );
 
-    it('formats the list of applications', function() {
-      return promise.then(() => {
-        expect(toCamelCase).to.have.callCount(applicationsFromServer.length);
-        applicationsFromServer.forEach((app) => {
-          expect(toCamelCase).to.be.calledWith(app);
+        const applications = new Applications(baseSdk, request, expectedHost);
+        promise = applications.getAll(organization.id);
+      });
+
+      it('gets the list of applications from the server', function() {
+        expect(request.get).to.be.calledWith(
+          `${expectedHost}/${organization.id}/applications`
+        );
+      });
+
+      it('formats the list of applications', function() {
+        return promise.then(() => {
+          expect(toCamelCase).to.have.callCount(applicationsFromServer.length);
+          applicationsFromServer.forEach((app) => {
+            expect(toCamelCase).to.be.calledWith(app);
+          });
         });
+      });
+
+      it('returns a fulfilled promise with the applications', function() {
+        return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
+          expectedApplications
+        );
       });
     });
 
-    it('returns a fulfilled promise with the applications', function() {
-      return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
-        expectedApplications
-      );
+    context('when the organization ID is not provided', function() {
+      it('throws an error', function() {
+        const applications = new Applications(
+          baseSdk,
+          baseRequest,
+          expectedHost
+        );
+
+        const promise = applications.getAll();
+
+        return expect(promise).to.be.rejectedWith(
+          'An organization ID is required for getting all applications'
+        );
+      });
     });
   });
 
   describe('getFavorites', function() {
-    let expectedFavoriteApplications;
-    let favoritesFromServer;
-    let promise;
-    let request;
-    let toCamelCase;
+    context('when the organization ID is provided', function() {
+      let expectedFavoriteApplications;
+      let favoritesFromServer;
+      let organization;
+      let promise;
+      let request;
+      let toCamelCase;
 
-    beforeEach(function() {
-      expectedFavoriteApplications = fixture.buildList(
-        'contxtUserFavoriteApplication',
-        faker.random.number({
-          min: 1,
-          max: 10
-        })
-      );
-      favoritesFromServer = expectedFavoriteApplications.map((app) =>
-        fixture.build('contxtUserFavoriteApplication', app, {
-          fromServer: true
-        })
-      );
+      beforeEach(function() {
+        expectedFavoriteApplications = fixture.buildList(
+          'contxtUserFavoriteApplication',
+          faker.random.number({
+            min: 1,
+            max: 10
+          })
+        );
+        favoritesFromServer = expectedFavoriteApplications.map((app) =>
+          fixture.build('contxtUserFavoriteApplication', app, {
+            fromServer: true
+          })
+        );
+        organization = fixture.build('organization');
 
-      request = {
-        ...baseRequest,
-        get: sinon.stub().resolves(favoritesFromServer)
-      };
-      toCamelCase = sinon
-        .stub(objectUtils, 'toCamelCase')
-        .returns(expectedFavoriteApplications);
+        request = {
+          ...baseRequest,
+          get: sinon.stub().resolves(favoritesFromServer)
+        };
+        toCamelCase = sinon
+          .stub(objectUtils, 'toCamelCase')
+          .returns(expectedFavoriteApplications);
 
-      const applications = new Applications(baseSdk, request, expectedHost);
-      promise = applications.getFavorites();
-    });
+        const applications = new Applications(baseSdk, request, expectedHost);
+        promise = applications.getFavorites(organization.id);
+      });
 
-    it('gets the list of favorite applications from the server', function() {
-      expect(request.get).to.be.calledWith(
-        `${expectedHost}/applications/favorites`
-      );
-    });
+      it('gets the list of favorite applications from the server', function() {
+        expect(request.get).to.be.calledWith(
+          `${expectedHost}/${organization.id}/applications/favorites`
+        );
+      });
 
-    it('formats the list of favorite applications', function() {
-      return promise.then(() => {
-        expect(toCamelCase).to.be.calledWith(favoritesFromServer);
+      it('formats the list of favorite applications', function() {
+        return promise.then(() => {
+          expect(toCamelCase).to.be.calledWith(favoritesFromServer);
+        });
+      });
+
+      it('returns a fulfilled promise with the favorite applications', function() {
+        return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
+          expectedFavoriteApplications
+        );
       });
     });
 
-    it('returns a fulfilled promise with the favorite applications', function() {
-      return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
-        expectedFavoriteApplications
-      );
-    });
-  });
+    context('when the organization ID is not provided', function() {
+      it('throws an error', function() {
+        const applications = new Applications(
+          baseSdk,
+          baseRequest,
+          expectedHost
+        );
 
-  describe('getGroupings', function() {
-    let expectedApplicationId;
-    let expectedGroupings;
-    let groupingsFromServer;
-    let promise;
-    let request;
-    let toCamelCase;
+        const promise = applications.getFavorites();
 
-    beforeEach(function() {
-      expectedApplicationId = faker.random.uuid();
-      expectedGroupings = fixture.buildList(
-        'applicationGrouping',
-        faker.random.number({ min: 1, max: 10 })
-      );
-      groupingsFromServer = expectedGroupings.map((grouping) =>
-        fixture.build('applicationGrouping', grouping, { fromServer: true })
-      );
-
-      request = {
-        ...baseRequest,
-        get: sinon.stub().resolves(groupingsFromServer)
-      };
-      toCamelCase = sinon
-        .stub(objectUtils, 'toCamelCase')
-        .returns(expectedGroupings);
-
-      const applications = new Applications(baseSdk, request, expectedHost);
-      promise = applications.getGroupings(expectedApplicationId);
-    });
-
-    it('gets the list of application groupings', function() {
-      expect(request.get).to.be.calledWith(
-        `${expectedHost}/applications/${expectedApplicationId}/groupings`
-      );
-    });
-
-    it('formats the list of application groupings', function() {
-      return promise.then(() => {
-        expect(toCamelCase).to.be.calledWith(groupingsFromServer);
+        return expect(promise).to.be.rejectedWith(
+          "An organization ID is required for getting a user's list of favorited applications"
+        );
       });
-    });
-
-    it('returns a fulfilled promise with the application groupings', function() {
-      return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
-        expectedGroupings
-      );
     });
   });
 
@@ -314,7 +335,7 @@ describe('Coordinator/Applications', function() {
 
       it('gets the list of featured applications from the server', function() {
         expect(request.get).to.be.calledWith(
-          `${expectedHost}/organizations/${expectedOrganizationId}/applications/featured`
+          `${expectedHost}/${expectedOrganizationId}/applications/featured`
         );
       });
 
@@ -347,30 +368,79 @@ describe('Coordinator/Applications', function() {
     });
   });
 
-  describe('removeFavorite', function() {
-    context('when the application ID is provided', function() {
-      let application;
-      let promise;
+  describe('getGroupings', function() {
+    context(
+      'when the organization ID and application ID are provided',
+      function() {
+        let expectedApplicationId;
+        let expectedGroupings;
+        let groupingsFromServer;
+        let organization;
+        let promise;
+        let request;
+        let toCamelCase;
 
-      beforeEach(function() {
-        application = fixture.build('contxtApplication');
+        beforeEach(function() {
+          expectedApplicationId = faker.random.uuid();
+          expectedGroupings = fixture.buildList(
+            'applicationGrouping',
+            faker.random.number({ min: 1, max: 10 })
+          );
+          groupingsFromServer = expectedGroupings.map((grouping) =>
+            fixture.build('applicationGrouping', grouping, { fromServer: true })
+          );
+          organization = fixture.build('organization');
 
+          request = {
+            ...baseRequest,
+            get: sinon.stub().resolves(groupingsFromServer)
+          };
+          toCamelCase = sinon
+            .stub(objectUtils, 'toCamelCase')
+            .returns(expectedGroupings);
+
+          const applications = new Applications(baseSdk, request, expectedHost);
+          promise = applications.getGroupings(
+            organization.id,
+            expectedApplicationId
+          );
+        });
+
+        it('gets the list of application groupings', function() {
+          expect(request.get).to.be.calledWith(
+            `${expectedHost}/${
+              organization.id
+            }/applications/${expectedApplicationId}/groupings`
+          );
+        });
+
+        it('formats the list of application groupings', function() {
+          return promise.then(() => {
+            expect(toCamelCase).to.be.calledWith(groupingsFromServer);
+          });
+        });
+
+        it('returns a fulfilled promise with the application groupings', function() {
+          return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
+            expectedGroupings
+          );
+        });
+      }
+    );
+
+    context('when the organization ID is not provided', function() {
+      it('throws an error', function() {
         const applications = new Applications(
           baseSdk,
           baseRequest,
           expectedHost
         );
-        promise = applications.removeFavorite(application.id);
-      });
+        const application = fixture.build('contxtApplication');
+        const promise = applications.getGroupings(undefined, application.id);
 
-      it('requests to delete the application favorite', function() {
-        expect(baseRequest.delete).to.be.calledWith(
-          `${expectedHost}/applications/${application.id}/favorites`
+        return expect(promise).to.be.rejectedWith(
+          'An organization ID is required for getting application groupings of an application'
         );
-      });
-
-      it('returns a resolved promise', function() {
-        return expect(promise).to.be.fulfilled;
       });
     });
 
@@ -381,7 +451,78 @@ describe('Coordinator/Applications', function() {
           baseRequest,
           expectedHost
         );
-        const promise = applications.removeFavorite();
+        const organization = fixture.build('organization');
+        const promise = applications.getGroupings(organization.id);
+
+        return expect(promise).to.be.rejectedWith(
+          'An application ID is required for getting application groupings of an application'
+        );
+      });
+    });
+  });
+
+  describe('removeFavorite', function() {
+    context(
+      'when the organization ID and application ID are provided',
+      function() {
+        let application;
+        let organization;
+        let promise;
+
+        beforeEach(function() {
+          application = fixture.build('contxtApplication');
+          organization = fixture.build('organization');
+
+          const applications = new Applications(
+            baseSdk,
+            baseRequest,
+            expectedHost
+          );
+          promise = applications.removeFavorite(
+            organization.id,
+            application.id
+          );
+        });
+
+        it('requests to delete the application favorite', function() {
+          expect(baseRequest.delete).to.be.calledWith(
+            `${expectedHost}/${organization.id}/applications/${
+              application.id
+            }/favorites`
+          );
+        });
+
+        it('returns a resolved promise', function() {
+          return expect(promise).to.be.fulfilled;
+        });
+      }
+    );
+
+    context('when the organization ID is not provided', function() {
+      it('throws an error', function() {
+        const applications = new Applications(
+          baseSdk,
+          baseRequest,
+          expectedHost
+        );
+        const application = fixture.build('contxtApplication');
+        const promise = applications.removeFavorite(undefined, application.id);
+
+        return expect(promise).to.be.rejectedWith(
+          'An organization ID is required for deleting a favorite application'
+        );
+      });
+    });
+
+    context('when the application ID is not provided', function() {
+      it('throws an error', function() {
+        const applications = new Applications(
+          baseSdk,
+          baseRequest,
+          expectedHost
+        );
+        const organization = fixture.build('organization');
+        const promise = applications.removeFavorite(organization.id);
 
         return expect(promise).to.be.rejectedWith(
           'An application ID is required for deleting a favorite application'

--- a/src/coordinator/applications.spec.js
+++ b/src/coordinator/applications.spec.js
@@ -28,7 +28,7 @@ describe('Coordinator/Applications', function() {
   });
 
   describe('constructor', function() {
-    context('when organization ID is provided', function() {
+    context('when an organization ID is provided', function() {
       let applications;
       let organizationId;
 
@@ -60,7 +60,7 @@ describe('Coordinator/Applications', function() {
       });
     });
 
-    context('when organization ID is not provided', function() {
+    context('when an organization ID is not provided', function() {
       let applications;
 
       beforeEach(function() {
@@ -79,7 +79,7 @@ describe('Coordinator/Applications', function() {
         expect(applications._sdk).to.deep.equal(baseSdk);
       });
 
-      it('sets the organization ID for the class instance', function() {
+      it('sets the organization ID for the class instance to null', function() {
         expect(applications._organizationId).to.equal(null);
       });
     });
@@ -389,47 +389,51 @@ describe('Coordinator/Applications', function() {
     });
 
     context('tenant API', function() {
+      let applications;
+      let expectedFeaturedApplications;
+      let featuredApplicationsFromServer;
+      let expectedOrganizationId;
+      let promise;
+      let request;
+      let toCamelCase;
+
+      beforeEach(function() {
+        expectedOrganizationId = fixture.build('organization').id;
+        expectedFeaturedApplications = fixture.buildList(
+          'contxtOrganizationFeaturedApplication',
+          faker.random.number({
+            min: 1,
+            max: 10
+          }),
+          {
+            organizationId: expectedOrganizationId
+          }
+        );
+        featuredApplicationsFromServer = expectedFeaturedApplications.map(
+          (app) =>
+            fixture.build('contxtOrganizationFeaturedApplication', app, {
+              fromServer: true
+            })
+        );
+
+        request = {
+          ...baseRequest,
+          get: sinon.stub().resolves(featuredApplicationsFromServer)
+        };
+        toCamelCase = sinon
+          .stub(objectUtils, 'toCamelCase')
+          .returns(expectedFeaturedApplications);
+
+        applications = new Applications(
+          baseSdk,
+          request,
+          expectedHost,
+          expectedOrganizationId
+        );
+      });
+
       context('when the organization ID is provided', function() {
-        let expectedFeaturedApplications;
-        let featuredApplicationsFromServer;
-        let expectedOrganizationId;
-        let promise;
-        let request;
-        let toCamelCase;
-
         beforeEach(function() {
-          expectedOrganizationId = faker.random.uuid();
-          expectedFeaturedApplications = fixture.buildList(
-            'contxtOrganizationFeaturedApplication',
-            faker.random.number({
-              min: 1,
-              max: 10
-            }),
-            {
-              organizationId: expectedOrganizationId
-            }
-          );
-          featuredApplicationsFromServer = expectedFeaturedApplications.map(
-            (app) =>
-              fixture.build('contxtOrganizationFeaturedApplication', app, {
-                fromServer: true
-              })
-          );
-
-          request = {
-            ...baseRequest,
-            get: sinon.stub().resolves(featuredApplicationsFromServer)
-          };
-          toCamelCase = sinon
-            .stub(objectUtils, 'toCamelCase')
-            .returns(expectedFeaturedApplications);
-
-          const applications = new Applications(
-            baseSdk,
-            request,
-            expectedHost,
-            expectedOrganizationId
-          );
           promise = applications.getFeatured(expectedOrganizationId);
         });
 
@@ -455,50 +459,11 @@ describe('Coordinator/Applications', function() {
       });
 
       context('when the organization ID is not provided', function() {
-        let expectedFeaturedApplications;
-        let featuredApplicationsFromServer;
-        let expectedOrganizationId;
-        let promise;
-        let request;
-        let toCamelCase;
-
         beforeEach(function() {
-          expectedOrganizationId = faker.random.uuid();
-          expectedFeaturedApplications = fixture.buildList(
-            'contxtOrganizationFeaturedApplication',
-            faker.random.number({
-              min: 1,
-              max: 10
-            }),
-            {
-              organizationId: expectedOrganizationId
-            }
-          );
-          featuredApplicationsFromServer = expectedFeaturedApplications.map(
-            (app) =>
-              fixture.build('contxtOrganizationFeaturedApplication', app, {
-                fromServer: true
-              })
-          );
-
-          request = {
-            ...baseRequest,
-            get: sinon.stub().resolves(featuredApplicationsFromServer)
-          };
-          toCamelCase = sinon
-            .stub(objectUtils, 'toCamelCase')
-            .returns(expectedFeaturedApplications);
-
-          const applications = new Applications(
-            baseSdk,
-            request,
-            expectedHost,
-            expectedOrganizationId
-          );
-          promise = applications.getFeatured(expectedOrganizationId);
+          promise = applications.getFeatured();
         });
 
-        it('gets the list of featured applications from the server and does not use the organization ID provided', function() {
+        it('gets the list of featured applications from the server', function() {
           expect(request.get).to.be.calledWith(
             `${expectedHost}/applications/featured`
           );

--- a/src/coordinator/consent.js
+++ b/src/coordinator/consent.js
@@ -56,11 +56,13 @@ class Consent {
    * @param {Object} sdk An instance of the SDK so the module can communicate with other modules
    * @param {Object} request An instance of the request module tied to this module's audience.
    * @param {string} baseUrl The base URL provided by the parent module
+   * @param {string} [organizationId] The organization ID to be used in tenant url requests
    */
-  constructor(sdk, request, baseUrl) {
+  constructor(sdk, request, baseUrl, organizationId = null) {
     this._baseUrl = baseUrl;
     this._request = request;
     this._sdk = sdk;
+    this._organizationId = organizationId;
   }
 
   /**

--- a/src/coordinator/consent.spec.js
+++ b/src/coordinator/consent.spec.js
@@ -33,22 +33,60 @@ describe('Coordinator/Consent', function() {
   });
 
   describe('constructor', function() {
-    let consent;
+    context('when organization ID is provided', function() {
+      let consent;
+      let organizationId;
 
-    beforeEach(function() {
-      consent = new Consent(baseSdk, baseRequest, expectedHost);
+      beforeEach(function() {
+        organizationId = fixture.build('organization').id;
+
+        consent = new Consent(
+          baseSdk,
+          baseRequest,
+          expectedHost,
+          organizationId
+        );
+      });
+
+      it('sets a base url for the class instance', function() {
+        expect(consent._baseUrl).to.equal(expectedHost);
+      });
+
+      it('appends the supplied request module to the class instance', function() {
+        expect(consent._request).to.deep.equal(baseRequest);
+      });
+
+      it('appends the supplied sdk to the class instance', function() {
+        expect(consent._sdk).to.deep.equal(baseSdk);
+      });
+
+      it('sets the organization ID for the class instance', function() {
+        expect(consent._organizationId).to.equal(organizationId);
+      });
     });
 
-    it('sets a base url for the class instance', function() {
-      expect(consent._baseUrl).to.equal(expectedHost);
-    });
+    context('when organization ID is not provided', function() {
+      let consent;
 
-    it('appends the supplied request module to the class instance', function() {
-      expect(consent._request).to.deep.equal(baseRequest);
-    });
+      beforeEach(function() {
+        consent = new Consent(baseSdk, baseRequest, expectedHost);
+      });
 
-    it('appends the supplied sdk to the class instance', function() {
-      expect(consent._sdk).to.deep.equal(baseSdk);
+      it('sets a base url for the class instance', function() {
+        expect(consent._baseUrl).to.equal(expectedHost);
+      });
+
+      it('appends the supplied request module to the class instance', function() {
+        expect(consent._request).to.deep.equal(baseRequest);
+      });
+
+      it('appends the supplied sdk to the class instance', function() {
+        expect(consent._sdk).to.deep.equal(baseSdk);
+      });
+
+      it('sets the organization ID for the class instance', function() {
+        expect(consent._organizationId).to.equal(null);
+      });
     });
   });
 

--- a/src/coordinator/consent.spec.js
+++ b/src/coordinator/consent.spec.js
@@ -33,7 +33,7 @@ describe('Coordinator/Consent', function() {
   });
 
   describe('constructor', function() {
-    context('when organization ID is provided', function() {
+    context('when an organization ID is provided', function() {
       let consent;
       let organizationId;
 
@@ -65,7 +65,7 @@ describe('Coordinator/Consent', function() {
       });
     });
 
-    context('when organization ID is not provided', function() {
+    context('when an organization ID is not provided', function() {
       let consent;
 
       beforeEach(function() {
@@ -84,7 +84,7 @@ describe('Coordinator/Consent', function() {
         expect(consent._sdk).to.deep.equal(baseSdk);
       });
 
-      it('sets the organization ID for the class instance', function() {
+      it('sets the organization ID for the class instance to null', function() {
         expect(consent._organizationId).to.equal(null);
       });
     });

--- a/src/coordinator/edgeNodes.js
+++ b/src/coordinator/edgeNodes.js
@@ -21,20 +21,23 @@ class EdgeNodes {
    * @param {Object} sdk An instance of the SDK so the module can communicate with other modules
    * @param {Object} request An instance of the request module tied to this module's audience.
    * @param {string} baseUrl The base URL provided by the parent module
+   * @param {string} [organizationId] The organization ID to be used in tenant url requests
    */
-  constructor(sdk, request, baseUrl) {
+  constructor(sdk, request, baseUrl, organizationId = null) {
     this._baseUrl = baseUrl;
     this._request = request;
     this._sdk = sdk;
+    this._organizationId = organizationId;
   }
 
   /**
    * Get an edge node
    *
-   * API Endpoint: '/organizations/:organizationId/edgenodes/:edgeNodeClientId'
+   * Legacy API Endpoint: '/organizations/:organizationId/edgenodes/:edgeNodeClientId'
+   * API Endpoint: 'edgenodes/:edgeNodeClientId'
    * METHOD: GET
    *
-   * @param {string} organizationId UUID
+   * @param {string} [organizationId] UUID Required when using the legacy API
    * @param {string} edgeNodeClientId
    *
    * @returns {Promise}
@@ -48,6 +51,18 @@ class EdgeNodes {
    *   .catch((err) => console.log(err));
    */
   get(organizationId, edgeNodeClientId) {
+    if (this._organizationId) {
+      if (!edgeNodeClientId) {
+        return Promise.reject(
+          new Error('An edgeNodeClientId is required for getting an edge node.')
+        );
+      }
+
+      return this._request
+        .get(`${this._baseUrl}/edgenodes/${edgeNodeClientId}`)
+        .then((edgeNode) => toCamelCase(edgeNode));
+    }
+
     if (!organizationId) {
       return Promise.reject(
         new Error('An organizationId is required for getting an edge node.')

--- a/src/coordinator/edgeNodes.js
+++ b/src/coordinator/edgeNodes.js
@@ -51,13 +51,13 @@ class EdgeNodes {
    *   .catch((err) => console.log(err));
    */
   get(organizationId, edgeNodeClientId) {
-    if (!edgeNodeClientId) {
-      return Promise.reject(
-        new Error('An edgeNodeClientId is required for getting an edge node.')
-      );
-    }
-
     if (this._organizationId) {
+      if (!edgeNodeClientId) {
+        return Promise.reject(
+          new Error('An edgeNodeClientId is required for getting an edge node.')
+        );
+      }
+
       return this._request
         .get(`${this._baseUrl}/edgenodes/${edgeNodeClientId}`)
         .then((edgeNode) => toCamelCase(edgeNode));
@@ -66,6 +66,12 @@ class EdgeNodes {
     if (!organizationId) {
       return Promise.reject(
         new Error('An organizationId is required for getting an edge node.')
+      );
+    }
+
+    if (!edgeNodeClientId) {
+      return Promise.reject(
+        new Error('An edgeNodeClientId is required for getting an edge node.')
       );
     }
 

--- a/src/coordinator/edgeNodes.js
+++ b/src/coordinator/edgeNodes.js
@@ -37,7 +37,7 @@ class EdgeNodes {
    * API Endpoint: 'edgenodes/:edgeNodeClientId'
    * METHOD: GET
    *
-   * @param {string} [organizationId] UUID Required when using the legacy API
+   * @param {string} organizationId The ID of the organization, optional when using the tenant API and an organization ID has been set
    * @param {string} edgeNodeClientId
    *
    * @returns {Promise}
@@ -51,13 +51,13 @@ class EdgeNodes {
    *   .catch((err) => console.log(err));
    */
   get(organizationId, edgeNodeClientId) {
-    if (this._organizationId) {
-      if (!edgeNodeClientId) {
-        return Promise.reject(
-          new Error('An edgeNodeClientId is required for getting an edge node.')
-        );
-      }
+    if (!edgeNodeClientId) {
+      return Promise.reject(
+        new Error('An edgeNodeClientId is required for getting an edge node.')
+      );
+    }
 
+    if (this._organizationId) {
       return this._request
         .get(`${this._baseUrl}/edgenodes/${edgeNodeClientId}`)
         .then((edgeNode) => toCamelCase(edgeNode));
@@ -66,12 +66,6 @@ class EdgeNodes {
     if (!organizationId) {
       return Promise.reject(
         new Error('An organizationId is required for getting an edge node.')
-      );
-    }
-
-    if (!edgeNodeClientId) {
-      return Promise.reject(
-        new Error('An edgeNodeClientId is required for getting an edge node.')
       );
     }
 

--- a/src/coordinator/edgeNodes.spec.js
+++ b/src/coordinator/edgeNodes.spec.js
@@ -28,96 +28,273 @@ describe('edgeNodes', function() {
   });
 
   describe('constructor', function() {
-    let edgeNodes;
+    context('when organization ID is provided', function() {
+      let edgeNodes;
+      let organizationId;
 
-    beforeEach(function() {
-      edgeNodes = new EdgeNodes(baseSdk, baseRequest, expectedHost);
+      beforeEach(function() {
+        organizationId = fixture.build('organization').id;
+
+        edgeNodes = new EdgeNodes(
+          baseSdk,
+          baseRequest,
+          expectedHost,
+          organizationId
+        );
+      });
+
+      it('sets a base url for the class instance', function() {
+        expect(edgeNodes._baseUrl).to.equal(expectedHost);
+      });
+
+      it('appends the supplied request module to the class instance', function() {
+        expect(edgeNodes._request).to.deep.equal(baseRequest);
+      });
+
+      it('appends the supplied sdk to the class instance', function() {
+        expect(edgeNodes._sdk).to.deep.equal(baseSdk);
+      });
+
+      it('sets the organization ID for the class instance', function() {
+        expect(edgeNodes._organizationId).to.equal(organizationId);
+      });
     });
 
-    it('sets a base url for the class instance', function() {
-      expect(edgeNodes._baseUrl).to.equal(expectedHost);
-    });
+    context('when organization ID is not provided', function() {
+      let edgeNodes;
 
-    it('appends the supplied request module to the class instance', function() {
-      expect(edgeNodes._request).to.deep.equal(baseRequest);
-    });
+      beforeEach(function() {
+        edgeNodes = new EdgeNodes(baseSdk, baseRequest, expectedHost);
+      });
 
-    it('appends the supplied sdk to the class instance', function() {
-      expect(edgeNodes._sdk).to.deep.equal(baseSdk);
+      it('sets a base url for the class instance', function() {
+        expect(edgeNodes._baseUrl).to.equal(expectedHost);
+      });
+
+      it('appends the supplied request module to the class instance', function() {
+        expect(edgeNodes._request).to.deep.equal(baseRequest);
+      });
+
+      it('appends the supplied sdk to the class instance', function() {
+        expect(edgeNodes._sdk).to.deep.equal(baseSdk);
+      });
+
+      it('sets the organization ID for the class instance', function() {
+        expect(edgeNodes._organizationId).to.equal(null);
+      });
     });
   });
 
   describe('get', function() {
-    context('all required params are provided', function() {
-      let edgeNodeFromServerAfterFormat;
-      let edgeNodeFromServerBeforeFormat;
-      let expectedEdgeNodeId;
-      let expectedOrganizationId;
-      let promise;
-      let request;
-      let toCamelCase;
+    context('legacy API', function() {
+      context('all required params are provided', function() {
+        let edgeNodeFromServerAfterFormat;
+        let edgeNodeFromServerBeforeFormat;
+        let expectedEdgeNodeId;
+        let expectedOrganizationId;
+        let promise;
+        let request;
+        let toCamelCase;
 
-      beforeEach(function() {
-        edgeNodeFromServerAfterFormat = fixture.build('edgeNode');
-        expectedEdgeNodeId = edgeNodeFromServerAfterFormat.id;
-        expectedOrganizationId = edgeNodeFromServerAfterFormat.organizationId;
-        edgeNodeFromServerBeforeFormat = fixture.build(
-          'edgeNode',
-          edgeNodeFromServerAfterFormat,
-          { fromServer: true }
-        );
+        beforeEach(function() {
+          edgeNodeFromServerAfterFormat = fixture.build('edgeNode');
+          expectedEdgeNodeId = edgeNodeFromServerAfterFormat.id;
+          expectedOrganizationId = edgeNodeFromServerAfterFormat.organizationId;
+          edgeNodeFromServerBeforeFormat = fixture.build(
+            'edgeNode',
+            edgeNodeFromServerAfterFormat,
+            { fromServer: true }
+          );
 
-        request = {
-          ...baseRequest,
-          get: sinon.stub().resolves(edgeNodeFromServerBeforeFormat)
-        };
-        toCamelCase = sinon
-          .stub(objectUtils, 'toCamelCase')
-          .returns(edgeNodeFromServerAfterFormat);
+          request = {
+            ...baseRequest,
+            get: sinon.stub().resolves(edgeNodeFromServerBeforeFormat)
+          };
+          toCamelCase = sinon
+            .stub(objectUtils, 'toCamelCase')
+            .returns(edgeNodeFromServerAfterFormat);
 
-        const edgeNodes = new EdgeNodes(baseSdk, request);
-        edgeNodes._baseUrl = expectedHost;
-        promise = edgeNodes.get(expectedOrganizationId, expectedEdgeNodeId);
-      });
+          const edgeNodes = new EdgeNodes(baseSdk, request);
+          edgeNodes._baseUrl = expectedHost;
+          promise = edgeNodes.get(expectedOrganizationId, expectedEdgeNodeId);
+        });
 
-      it('gets the edge node from the server', function() {
-        expect(request.get).to.be.calledWith(
-          `${expectedHost}/organizations/${expectedOrganizationId}/edgenodes/${expectedEdgeNodeId}`
-        );
-      });
+        it('gets the edge node from the server', function() {
+          expect(request.get).to.be.calledWith(
+            `${expectedHost}/organizations/${expectedOrganizationId}/edgenodes/${expectedEdgeNodeId}`
+          );
+        });
 
-      it('formats the edge node object', function() {
-        return promise.then(() => {
-          expect(toCamelCase).to.be.calledWith(edgeNodeFromServerBeforeFormat);
+        it('formats the edge node object', function() {
+          return promise.then(() => {
+            expect(toCamelCase).to.be.calledWith(
+              edgeNodeFromServerBeforeFormat
+            );
+          });
+        });
+
+        it('returns the requested edge node', function() {
+          return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
+            edgeNodeFromServerAfterFormat
+          );
         });
       });
 
-      it('returns the requested edge node', function() {
-        return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
-          edgeNodeFromServerAfterFormat
-        );
+      context('the organization ID is not provided', function() {
+        it('throws an error', function() {
+          const edgeNodes = new EdgeNodes(baseSdk, baseRequest);
+          const promise = edgeNodes.get();
+
+          return expect(promise).to.be.rejectedWith(
+            'An organizationId is required for getting an edge node.'
+          );
+        });
+      });
+
+      context('the edge node client ID is not provided', function() {
+        it('throws an error', function() {
+          const edgeNodes = new EdgeNodes(baseSdk, baseRequest);
+          const promise = edgeNodes.get('1');
+
+          return expect(promise).to.be.rejectedWith(
+            'An edgeNodeClientId is required for getting an edge node.'
+          );
+        });
       });
     });
 
-    context('the organization ID is not provided', function() {
-      it('throws an error', function() {
-        const edgeNodes = new EdgeNodes(baseSdk, baseRequest);
-        const promise = edgeNodes.get();
+    context('tenant API', function() {
+      context('all params are provided', function() {
+        let edgeNodeFromServerAfterFormat;
+        let edgeNodeFromServerBeforeFormat;
+        let expectedEdgeNodeId;
+        let expectedOrganizationId;
+        let promise;
+        let request;
+        let toCamelCase;
 
-        return expect(promise).to.be.rejectedWith(
-          'An organizationId is required for getting an edge node.'
-        );
+        beforeEach(function() {
+          edgeNodeFromServerAfterFormat = fixture.build('edgeNode');
+          expectedEdgeNodeId = edgeNodeFromServerAfterFormat.id;
+          expectedOrganizationId = edgeNodeFromServerAfterFormat.organizationId;
+          edgeNodeFromServerBeforeFormat = fixture.build(
+            'edgeNode',
+            edgeNodeFromServerAfterFormat,
+            { fromServer: true }
+          );
+
+          request = {
+            ...baseRequest,
+            get: sinon.stub().resolves(edgeNodeFromServerBeforeFormat)
+          };
+          toCamelCase = sinon
+            .stub(objectUtils, 'toCamelCase')
+            .returns(edgeNodeFromServerAfterFormat);
+
+          const edgeNodes = new EdgeNodes(
+            baseSdk,
+            request,
+            null,
+            expectedOrganizationId
+          );
+          edgeNodes._baseUrl = expectedHost;
+          promise = edgeNodes.get(expectedOrganizationId, expectedEdgeNodeId);
+        });
+
+        it('gets the edge node from the server and does not use the organization ID provided', function() {
+          expect(request.get).to.be.calledWith(
+            `${expectedHost}/edgenodes/${expectedEdgeNodeId}`
+          );
+        });
+
+        it('formats the edge node object', function() {
+          return promise.then(() => {
+            expect(toCamelCase).to.be.calledWith(
+              edgeNodeFromServerBeforeFormat
+            );
+          });
+        });
+
+        it('returns the requested edge node', function() {
+          return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
+            edgeNodeFromServerAfterFormat
+          );
+        });
       });
-    });
 
-    context('the edge node client ID is not provided', function() {
-      it('throws an error', function() {
-        const edgeNodes = new EdgeNodes(baseSdk, baseRequest);
-        const promise = edgeNodes.get('1');
+      context('the organization ID is not provided', function() {
+        let edgeNodeFromServerAfterFormat;
+        let edgeNodeFromServerBeforeFormat;
+        let expectedEdgeNodeId;
+        let expectedOrganizationId;
+        let promise;
+        let request;
+        let toCamelCase;
 
-        return expect(promise).to.be.rejectedWith(
-          'An edgeNodeClientId is required for getting an edge node.'
-        );
+        beforeEach(function() {
+          edgeNodeFromServerAfterFormat = fixture.build('edgeNode');
+          expectedEdgeNodeId = edgeNodeFromServerAfterFormat.id;
+          expectedOrganizationId = edgeNodeFromServerAfterFormat.organizationId;
+          edgeNodeFromServerBeforeFormat = fixture.build(
+            'edgeNode',
+            edgeNodeFromServerAfterFormat,
+            { fromServer: true }
+          );
+
+          request = {
+            ...baseRequest,
+            get: sinon.stub().resolves(edgeNodeFromServerBeforeFormat)
+          };
+          toCamelCase = sinon
+            .stub(objectUtils, 'toCamelCase')
+            .returns(edgeNodeFromServerAfterFormat);
+
+          const edgeNodes = new EdgeNodes(
+            baseSdk,
+            request,
+            null,
+            expectedOrganizationId
+          );
+          edgeNodes._baseUrl = expectedHost;
+          promise = edgeNodes.get(expectedOrganizationId, expectedEdgeNodeId);
+        });
+
+        it('gets the edge node from the server', function() {
+          expect(request.get).to.be.calledWith(
+            `${expectedHost}/edgenodes/${expectedEdgeNodeId}`
+          );
+        });
+
+        it('formats the edge node object', function() {
+          return promise.then(() => {
+            expect(toCamelCase).to.be.calledWith(
+              edgeNodeFromServerBeforeFormat
+            );
+          });
+        });
+
+        it('returns the requested edge node', function() {
+          return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
+            edgeNodeFromServerAfterFormat
+          );
+        });
+      });
+
+      context('the edge node client ID is not provided', function() {
+        it('throws an error', function() {
+          const organizationId = fixture.build('organization').id;
+          const edgeNodes = new EdgeNodes(
+            baseSdk,
+            baseRequest,
+            null,
+            organizationId
+          );
+          const promise = edgeNodes.get('1');
+
+          return expect(promise).to.be.rejectedWith(
+            'An edgeNodeClientId is required for getting an edge node.'
+          );
+        });
       });
     });
   });

--- a/src/coordinator/edgeNodes.spec.js
+++ b/src/coordinator/edgeNodes.spec.js
@@ -28,7 +28,7 @@ describe('edgeNodes', function() {
   });
 
   describe('constructor', function() {
-    context('when organization ID is provided', function() {
+    context('when an organization ID is provided', function() {
       let edgeNodes;
       let organizationId;
 
@@ -60,7 +60,7 @@ describe('edgeNodes', function() {
       });
     });
 
-    context('when organization ID is not provided', function() {
+    context('when an organization ID is not provided', function() {
       let edgeNodes;
 
       beforeEach(function() {
@@ -79,7 +79,7 @@ describe('edgeNodes', function() {
         expect(edgeNodes._sdk).to.deep.equal(baseSdk);
       });
 
-      it('sets the organization ID for the class instance', function() {
+      it('sets the organization ID for the class instance to null', function() {
         expect(edgeNodes._organizationId).to.equal(null);
       });
     });
@@ -143,7 +143,7 @@ describe('edgeNodes', function() {
       context('the organization ID is not provided', function() {
         it('throws an error', function() {
           const edgeNodes = new EdgeNodes(baseSdk, baseRequest);
-          const promise = edgeNodes.get();
+          const promise = edgeNodes.get(null, faker.random.uuid());
 
           return expect(promise).to.be.rejectedWith(
             'An organizationId is required for getting an edge node.'
@@ -154,7 +154,7 @@ describe('edgeNodes', function() {
       context('the edge node client ID is not provided', function() {
         it('throws an error', function() {
           const edgeNodes = new EdgeNodes(baseSdk, baseRequest);
-          const promise = edgeNodes.get('1');
+          const promise = edgeNodes.get(faker.random.uuid());
 
           return expect(promise).to.be.rejectedWith(
             'An edgeNodeClientId is required for getting an edge node.'
@@ -256,7 +256,8 @@ describe('edgeNodes', function() {
             expectedOrganizationId
           );
           edgeNodes._baseUrl = expectedHost;
-          promise = edgeNodes.get(expectedOrganizationId, expectedEdgeNodeId);
+
+          promise = edgeNodes.get(null, expectedEdgeNodeId);
         });
 
         it('gets the edge node from the server', function() {
@@ -289,7 +290,7 @@ describe('edgeNodes', function() {
             null,
             organizationId
           );
-          const promise = edgeNodes.get('1');
+          const promise = edgeNodes.get(organizationId);
 
           return expect(promise).to.be.rejectedWith(
             'An edgeNodeClientId is required for getting an edge node.'

--- a/src/coordinator/index.js
+++ b/src/coordinator/index.js
@@ -17,11 +17,13 @@ class Coordinator {
    * @param {Object} request An instance of the request module tied to this module's audience.
    */
   constructor(sdk, request) {
-    const baseUrl = `${sdk.config.audiences.coordinator.host}/contxt/v1`;
+    const baseUrl = `${sdk.config.audiences.coordinator.host}/v1`;
 
     this._baseUrl = baseUrl;
     this._request = request;
     this._sdk = sdk;
+
+    this._organizationId = null;
 
     this.applications = new Applications(sdk, request, baseUrl);
     this.consent = new Consent(sdk, request, baseUrl);
@@ -30,6 +32,33 @@ class Coordinator {
     this.permissions = new Permissions(sdk, request, baseUrl);
     this.roles = new Roles(sdk, request, baseUrl);
     this.users = new Users(sdk, request, baseUrl);
+  }
+
+  /**
+   * Sets a selected oranization ID to be used in tenant based requests
+   *
+   * @param {string} organizationId the ID of the organization
+   *
+   * @example
+   * contxtSdk.coordinator
+   *   .setOrganizationId('36b8421a-cc4a-4204-b839-1397374fb16b');
+   */
+  setOrganizationId(organizationId) {
+    this._organizationId = organizationId;
+
+    const url = organizationId
+      ? `${
+          this._sdk.config.audiences.coordinator.host
+        }/contxt/v1/${organizationId}`
+      : `${this._sdk.config.audiences.coordinator.host}/v1`;
+
+    this._baseUrl = url;
+
+    this.applications = new Applications(
+      this._sdk,
+      this._request,
+      this._baseUrl
+    );
   }
 }
 

--- a/src/coordinator/index.js
+++ b/src/coordinator/index.js
@@ -47,7 +47,7 @@ class Coordinator {
     this._organizationId = organizationId;
 
     const url = this._organizationId
-      ? `${this._sdk.config.audiences.coordinator.host}/contxt/v1/${
+      ? `${this._sdk.config.audiences.coordinator.host}/deploy/v1/${
           this._organizationId
         }`
       : `${this._sdk.config.audiences.coordinator.host}/v1`;

--- a/src/coordinator/index.js
+++ b/src/coordinator/index.js
@@ -46,10 +46,10 @@ class Coordinator {
   setOrganizationId(organizationId) {
     this._organizationId = organizationId;
 
-    const url = organizationId
-      ? `${
-          this._sdk.config.audiences.coordinator.host
-        }/contxt/v1/${organizationId}`
+    const url = this._organizationId
+      ? `${this._sdk.config.audiences.coordinator.host}/contxt/v1/${
+          this._organizationId
+        }`
       : `${this._sdk.config.audiences.coordinator.host}/v1`;
 
     this._baseUrl = url;
@@ -57,7 +57,44 @@ class Coordinator {
     this.applications = new Applications(
       this._sdk,
       this._request,
-      this._baseUrl
+      this._baseUrl,
+      this._organizationId
+    );
+    this.consent = new Consent(
+      this._sdk,
+      this._request,
+      this._baseUrl,
+      this._organizationId
+    );
+    this.edgeNodes = new EdgeNodes(
+      this._sdk,
+      this._request,
+      this._baseUrl,
+      this._organizationId
+    );
+    this.organizations = new Organizations(
+      this._sdk,
+      this._request,
+      this._baseUrl,
+      this._organizationId
+    );
+    this.permissions = new Permissions(
+      this._sdk,
+      this._request,
+      this._baseUrl,
+      this._organizationId
+    );
+    this.roles = new Roles(
+      this._sdk,
+      this._request,
+      this._baseUrl,
+      this._organizationId
+    );
+    this.users = new Users(
+      this._sdk,
+      this._request,
+      this._baseUrl,
+      this._organizationId
     );
   }
 }

--- a/src/coordinator/index.js
+++ b/src/coordinator/index.js
@@ -23,6 +23,8 @@ class Coordinator {
     this._request = request;
     this._sdk = sdk;
 
+    this._accessBaseUrl = null;
+    this._deployBaseUrl = null;
     this._organizationId = null;
 
     this.applications = new Applications(sdk, request, baseUrl);
@@ -46,54 +48,58 @@ class Coordinator {
   setOrganizationId(organizationId) {
     this._organizationId = organizationId;
 
-    const url = this._organizationId
+    this._accessBaseUrl = this._organizationId
+      ? `${this._sdk.config.audiences.coordinator.host}/access/v1/${
+          this._organizationId
+        }`
+      : null;
+
+    this._deployBaseUrl = this._organizationId
       ? `${this._sdk.config.audiences.coordinator.host}/deploy/v1/${
           this._organizationId
         }`
-      : `${this._sdk.config.audiences.coordinator.host}/v1`;
-
-    this._baseUrl = url;
+      : null;
 
     this.applications = new Applications(
       this._sdk,
       this._request,
-      this._baseUrl,
+      this._deployBaseUrl || this._baseUrl,
       this._organizationId
     );
     this.consent = new Consent(
       this._sdk,
       this._request,
-      this._baseUrl,
+      this._deployBaseUrl || this._baseUrl,
       this._organizationId
     );
     this.edgeNodes = new EdgeNodes(
       this._sdk,
       this._request,
-      this._baseUrl,
+      this._deployBaseUrl || this._baseUrl,
       this._organizationId
     );
     this.organizations = new Organizations(
       this._sdk,
       this._request,
-      this._baseUrl,
+      this._accessBaseUrl || this._baseUrl,
       this._organizationId
     );
     this.permissions = new Permissions(
       this._sdk,
       this._request,
-      this._baseUrl,
+      this._accessBaseUrl || this._baseUrl,
       this._organizationId
     );
     this.roles = new Roles(
       this._sdk,
       this._request,
-      this._baseUrl,
+      this._accessBaseUrl || this._baseUrl,
       this._organizationId
     );
     this.users = new Users(
       this._sdk,
       this._request,
-      this._baseUrl,
+      this._accessBaseUrl || this._baseUrl,
       this._organizationId
     );
   }

--- a/src/coordinator/index.js
+++ b/src/coordinator/index.js
@@ -17,7 +17,7 @@ class Coordinator {
    * @param {Object} request An instance of the request module tied to this module's audience.
    */
   constructor(sdk, request) {
-    const baseUrl = `${sdk.config.audiences.coordinator.host}/v1`;
+    const baseUrl = `${sdk.config.audiences.coordinator.host}/contxt/v1`;
 
     this._baseUrl = baseUrl;
     this._request = request;

--- a/src/coordinator/index.spec.js
+++ b/src/coordinator/index.spec.js
@@ -105,7 +105,7 @@ describe('Coordinator', function() {
 
       it('sets the base url to be the new tenant url', function() {
         expect(coordinator._baseUrl).to.equal(
-          `${baseSdk.config.audiences.coordinator.host}/contxt/v1/${
+          `${baseSdk.config.audiences.coordinator.host}/deploy/v1/${
             organization.id
           }`
         );
@@ -114,7 +114,7 @@ describe('Coordinator', function() {
       it('appends a new instance of Application to the class instance with the tenant base url', function() {
         expect(coordinator.applications).to.be.an.instanceof(Applications);
         expect(coordinator.applications._baseUrl).to.equal(
-          `${baseSdk.config.audiences.coordinator.host}/contxt/v1/${
+          `${baseSdk.config.audiences.coordinator.host}/deploy/v1/${
             organization.id
           }`
         );
@@ -126,7 +126,7 @@ describe('Coordinator', function() {
       it('appends a new instance of Consent to the class instance with the tenant base url', function() {
         expect(coordinator.consent).to.be.an.instanceof(Consent);
         expect(coordinator.consent._baseUrl).to.equal(
-          `${baseSdk.config.audiences.coordinator.host}/contxt/v1/${
+          `${baseSdk.config.audiences.coordinator.host}/deploy/v1/${
             organization.id
           }`
         );
@@ -136,7 +136,7 @@ describe('Coordinator', function() {
       it('appends a new instance of EdgeNodes to the class instance with the tenant base url', function() {
         expect(coordinator.edgeNodes).to.be.an.instanceof(EdgeNodes);
         expect(coordinator.edgeNodes._baseUrl).to.equal(
-          `${baseSdk.config.audiences.coordinator.host}/contxt/v1/${
+          `${baseSdk.config.audiences.coordinator.host}/deploy/v1/${
             organization.id
           }`
         );
@@ -146,7 +146,7 @@ describe('Coordinator', function() {
       it('appends a new instance of Organizations to the class instance with the tenant base url', function() {
         expect(coordinator.organizations).to.be.an.instanceof(Organizations);
         expect(coordinator.organizations._baseUrl).to.equal(
-          `${baseSdk.config.audiences.coordinator.host}/contxt/v1/${
+          `${baseSdk.config.audiences.coordinator.host}/deploy/v1/${
             organization.id
           }`
         );
@@ -158,7 +158,7 @@ describe('Coordinator', function() {
       it('appends a new instance of Permissions to the class instance with the tenant base url', function() {
         expect(coordinator.permissions).to.be.an.instanceof(Permissions);
         expect(coordinator.permissions._baseUrl).to.equal(
-          `${baseSdk.config.audiences.coordinator.host}/contxt/v1/${
+          `${baseSdk.config.audiences.coordinator.host}/deploy/v1/${
             organization.id
           }`
         );
@@ -170,7 +170,7 @@ describe('Coordinator', function() {
       it('appends a new instance of Roles to the class instance with the tenant base url', function() {
         expect(coordinator.roles).to.be.an.instanceof(Roles);
         expect(coordinator.roles._baseUrl).to.equal(
-          `${baseSdk.config.audiences.coordinator.host}/contxt/v1/${
+          `${baseSdk.config.audiences.coordinator.host}/deploy/v1/${
             organization.id
           }`
         );
@@ -180,7 +180,7 @@ describe('Coordinator', function() {
       it('appends a new instance of Users to the class instance with the tenant base url', function() {
         expect(coordinator.users).to.be.an.instanceof(Users);
         expect(coordinator.users._baseUrl).to.equal(
-          `${baseSdk.config.audiences.coordinator.host}/contxt/v1/${
+          `${baseSdk.config.audiences.coordinator.host}/deploy/v1/${
             organization.id
           }`
         );

--- a/src/coordinator/index.spec.js
+++ b/src/coordinator/index.spec.js
@@ -44,7 +44,7 @@ describe('Coordinator', function() {
       );
     });
 
-    it('sets the organization ID to null', function() {
+    it('sets the organization ID to null for the class instance', function() {
       expect(coordinator._organizationId).to.equal(null);
     });
 
@@ -118,6 +118,9 @@ describe('Coordinator', function() {
             organization.id
           }`
         );
+        expect(coordinator.applications._organizationId).to.equal(
+          organization.id
+        );
       });
 
       it('appends a new instance of Consent to the class instance with the tenant base url', function() {
@@ -127,6 +130,7 @@ describe('Coordinator', function() {
             organization.id
           }`
         );
+        expect(coordinator.consent._organizationId).to.equal(organization.id);
       });
 
       it('appends a new instance of EdgeNodes to the class instance with the tenant base url', function() {
@@ -136,6 +140,7 @@ describe('Coordinator', function() {
             organization.id
           }`
         );
+        expect(coordinator.edgeNodes._organizationId).to.equal(organization.id);
       });
 
       it('appends a new instance of Organizations to the class instance with the tenant base url', function() {
@@ -144,6 +149,9 @@ describe('Coordinator', function() {
           `${baseSdk.config.audiences.coordinator.host}/contxt/v1/${
             organization.id
           }`
+        );
+        expect(coordinator.organizations._organizationId).to.equal(
+          organization.id
         );
       });
 
@@ -154,6 +162,9 @@ describe('Coordinator', function() {
             organization.id
           }`
         );
+        expect(coordinator.permissions._organizationId).to.equal(
+          organization.id
+        );
       });
 
       it('appends a new instance of Roles to the class instance with the tenant base url', function() {
@@ -163,6 +174,7 @@ describe('Coordinator', function() {
             organization.id
           }`
         );
+        expect(coordinator.roles._organizationId).to.equal(organization.id);
       });
 
       it('appends a new instance of Users to the class instance with the tenant base url', function() {
@@ -172,6 +184,7 @@ describe('Coordinator', function() {
             organization.id
           }`
         );
+        expect(coordinator.users._organizationId).to.equal(organization.id);
       });
     });
 
@@ -195,6 +208,7 @@ describe('Coordinator', function() {
         expect(coordinator.applications._baseUrl).to.equal(
           `${baseSdk.config.audiences.coordinator.host}/v1`
         );
+        expect(coordinator.applications._organizationId).to.equal(null);
       });
 
       it('appends a new instance of Consent to the class instance with the legacy base url', function() {
@@ -202,6 +216,7 @@ describe('Coordinator', function() {
         expect(coordinator.consent._baseUrl).to.equal(
           `${baseSdk.config.audiences.coordinator.host}/v1`
         );
+        expect(coordinator.consent._organizationId).to.equal(null);
       });
 
       it('appends a new instance of EdgeNodes to the class instance with the legacy base url', function() {
@@ -209,6 +224,7 @@ describe('Coordinator', function() {
         expect(coordinator.edgeNodes._baseUrl).to.equal(
           `${baseSdk.config.audiences.coordinator.host}/v1`
         );
+        expect(coordinator.edgeNodes._organizationId).to.equal(null);
       });
 
       it('appends a new instance of Organizations to the class instance with the legacy base url', function() {
@@ -216,6 +232,7 @@ describe('Coordinator', function() {
         expect(coordinator.organizations._baseUrl).to.equal(
           `${baseSdk.config.audiences.coordinator.host}/v1`
         );
+        expect(coordinator.organizations._organizationId).to.equal(null);
       });
 
       it('appends a new instance of Permissions to the class instance with the legacy base url', function() {
@@ -223,6 +240,7 @@ describe('Coordinator', function() {
         expect(coordinator.permissions._baseUrl).to.equal(
           `${baseSdk.config.audiences.coordinator.host}/v1`
         );
+        expect(coordinator.permissions._organizationId).to.equal(null);
       });
 
       it('appends a new instance of Roles to the class instance with the legacy base url', function() {
@@ -230,6 +248,7 @@ describe('Coordinator', function() {
         expect(coordinator.roles._baseUrl).to.equal(
           `${baseSdk.config.audiences.coordinator.host}/v1`
         );
+        expect(coordinator.roles._organizationId).to.equal(null);
       });
 
       it('appends a new instance of Users to the class instance with the legacy base url', function() {
@@ -237,6 +256,7 @@ describe('Coordinator', function() {
         expect(coordinator.users._baseUrl).to.equal(
           `${baseSdk.config.audiences.coordinator.host}/v1`
         );
+        expect(coordinator.users._organizationId).to.equal(null);
       });
     });
   });

--- a/src/coordinator/index.spec.js
+++ b/src/coordinator/index.spec.js
@@ -40,7 +40,7 @@ describe('Coordinator', function() {
 
     it('sets a base url for the class instance', function() {
       expect(coordinator._baseUrl).to.equal(
-        `${baseSdk.config.audiences.coordinator.host}/v1`
+        `${baseSdk.config.audiences.coordinator.host}/contxt/v1`
       );
     });
 

--- a/src/coordinator/index.spec.js
+++ b/src/coordinator/index.spec.js
@@ -44,8 +44,16 @@ describe('Coordinator', function() {
       );
     });
 
-    it('sets the organization ID to null for the class instance', function() {
+    it('sets the organization ID to null for the class instance to null', function() {
       expect(coordinator._organizationId).to.equal(null);
+    });
+
+    it('sets the access base url to null', function() {
+      expect(coordinator._accessBaseUrl).to.equal(null);
+    });
+
+    it('sets the deploy base url to null', function() {
+      expect(coordinator._deployBaseUrl).to.equal(null);
     });
 
     it('appends the supplied request module to the class instance', function() {
@@ -56,32 +64,53 @@ describe('Coordinator', function() {
       expect(coordinator._sdk).to.deep.equal(baseSdk);
     });
 
-    it('appends an instance of Applications to the class instance', function() {
+    it('appends an instance of Applications to the class instance with the legacy API base url', function() {
       expect(coordinator.applications).to.be.an.instanceof(Applications);
+      expect(coordinator.applications._baseUrl).to.equal(
+        `${baseSdk.config.audiences.coordinator.host}/v1`
+      );
     });
 
-    it('appends an instance of Consent to the class instance', function() {
+    it('appends an instance of Consent to the class instance with the legacy API base url', function() {
       expect(coordinator.consent).to.be.an.instanceof(Consent);
+      expect(coordinator.consent._baseUrl).to.equal(
+        `${baseSdk.config.audiences.coordinator.host}/v1`
+      );
     });
 
-    it('appends an instance of EdgeNodes to the class instance', function() {
+    it('appends an instance of EdgeNodes to the class instance with the legacy API base url', function() {
       expect(coordinator.edgeNodes).to.be.an.instanceof(EdgeNodes);
+      expect(coordinator.edgeNodes._baseUrl).to.equal(
+        `${baseSdk.config.audiences.coordinator.host}/v1`
+      );
     });
 
-    it('appends an instance of Organizations to the class instance', function() {
+    it('appends an instance of Organizations to the class instance with the legacy API base url', function() {
       expect(coordinator.organizations).to.be.an.instanceof(Organizations);
+      expect(coordinator.organizations._baseUrl).to.equal(
+        `${baseSdk.config.audiences.coordinator.host}/v1`
+      );
     });
 
-    it('appends an instance of Permissions to the class instance', function() {
+    it('appends an instance of Permissions to the class instance with the legacy API base url', function() {
       expect(coordinator.permissions).to.be.an.instanceof(Permissions);
+      expect(coordinator.permissions._baseUrl).to.equal(
+        `${baseSdk.config.audiences.coordinator.host}/v1`
+      );
     });
 
-    it('appends an instance of Roles to the class instance', function() {
+    it('appends an instance of Roles to the class instance with the legacy API base url', function() {
       expect(coordinator.roles).to.be.an.instanceof(Roles);
+      expect(coordinator.roles._baseUrl).to.equal(
+        `${baseSdk.config.audiences.coordinator.host}/v1`
+      );
     });
 
-    it('appends an instance of Users to the class instance', function() {
+    it('appends an instance of Users to the class instance with the legacy API base url', function() {
       expect(coordinator.users).to.be.an.instanceof(Users);
+      expect(coordinator.users._baseUrl).to.equal(
+        `${baseSdk.config.audiences.coordinator.host}/v1`
+      );
     });
   });
 
@@ -103,15 +132,20 @@ describe('Coordinator', function() {
         expect(coordinator._organizationId).to.equal(organization.id);
       });
 
-      it('sets the base url to be the new tenant url', function() {
-        expect(coordinator._baseUrl).to.equal(
+      it('sets the access and deploy base urls to the class instance', function() {
+        expect(coordinator._accessBaseUrl).to.equal(
+          `${baseSdk.config.audiences.coordinator.host}/access/v1/${
+            organization.id
+          }`
+        );
+        expect(coordinator._deployBaseUrl).to.equal(
           `${baseSdk.config.audiences.coordinator.host}/deploy/v1/${
             organization.id
           }`
         );
       });
 
-      it('appends a new instance of Application to the class instance with the tenant base url', function() {
+      it('appends a new instance of Application to the class instance with the correct tenant base url', function() {
         expect(coordinator.applications).to.be.an.instanceof(Applications);
         expect(coordinator.applications._baseUrl).to.equal(
           `${baseSdk.config.audiences.coordinator.host}/deploy/v1/${
@@ -123,7 +157,7 @@ describe('Coordinator', function() {
         );
       });
 
-      it('appends a new instance of Consent to the class instance with the tenant base url', function() {
+      it('appends a new instance of Consent to the class instance with the correct tenant base url', function() {
         expect(coordinator.consent).to.be.an.instanceof(Consent);
         expect(coordinator.consent._baseUrl).to.equal(
           `${baseSdk.config.audiences.coordinator.host}/deploy/v1/${
@@ -133,7 +167,7 @@ describe('Coordinator', function() {
         expect(coordinator.consent._organizationId).to.equal(organization.id);
       });
 
-      it('appends a new instance of EdgeNodes to the class instance with the tenant base url', function() {
+      it('appends a new instance of EdgeNodes to the class instance with the correct tenant base url', function() {
         expect(coordinator.edgeNodes).to.be.an.instanceof(EdgeNodes);
         expect(coordinator.edgeNodes._baseUrl).to.equal(
           `${baseSdk.config.audiences.coordinator.host}/deploy/v1/${
@@ -143,10 +177,10 @@ describe('Coordinator', function() {
         expect(coordinator.edgeNodes._organizationId).to.equal(organization.id);
       });
 
-      it('appends a new instance of Organizations to the class instance with the tenant base url', function() {
+      it('appends a new instance of Organizations to the class instance with the correct tenant base url', function() {
         expect(coordinator.organizations).to.be.an.instanceof(Organizations);
         expect(coordinator.organizations._baseUrl).to.equal(
-          `${baseSdk.config.audiences.coordinator.host}/deploy/v1/${
+          `${baseSdk.config.audiences.coordinator.host}/access/v1/${
             organization.id
           }`
         );
@@ -155,10 +189,10 @@ describe('Coordinator', function() {
         );
       });
 
-      it('appends a new instance of Permissions to the class instance with the tenant base url', function() {
+      it('appends a new instance of Permissions to the class instance with the correct tenant base url', function() {
         expect(coordinator.permissions).to.be.an.instanceof(Permissions);
         expect(coordinator.permissions._baseUrl).to.equal(
-          `${baseSdk.config.audiences.coordinator.host}/deploy/v1/${
+          `${baseSdk.config.audiences.coordinator.host}/access/v1/${
             organization.id
           }`
         );
@@ -167,20 +201,20 @@ describe('Coordinator', function() {
         );
       });
 
-      it('appends a new instance of Roles to the class instance with the tenant base url', function() {
+      it('appends a new instance of Roles to the class instance with the correct tenant base url', function() {
         expect(coordinator.roles).to.be.an.instanceof(Roles);
         expect(coordinator.roles._baseUrl).to.equal(
-          `${baseSdk.config.audiences.coordinator.host}/deploy/v1/${
+          `${baseSdk.config.audiences.coordinator.host}/access/v1/${
             organization.id
           }`
         );
         expect(coordinator.roles._organizationId).to.equal(organization.id);
       });
 
-      it('appends a new instance of Users to the class instance with the tenant base url', function() {
+      it('appends a new instance of Users to the class instance with the correct tenant base url', function() {
         expect(coordinator.users).to.be.an.instanceof(Users);
         expect(coordinator.users._baseUrl).to.equal(
-          `${baseSdk.config.audiences.coordinator.host}/deploy/v1/${
+          `${baseSdk.config.audiences.coordinator.host}/access/v1/${
             organization.id
           }`
         );
@@ -197,10 +231,9 @@ describe('Coordinator', function() {
         expect(coordinator._organizationId).to.equal(null);
       });
 
-      it('sets the base url to be the legacy url', function() {
-        expect(coordinator._baseUrl).to.equal(
-          `${baseSdk.config.audiences.coordinator.host}/v1`
-        );
+      it('sets the access and deploy base urls on the class instance to null', function() {
+        expect(coordinator._accessBaseUrl).to.equal(null);
+        expect(coordinator._deployBaseUrl).to.equal(null);
       });
 
       it('appends a new instance of Application to the class instance with the legacy base url', function() {

--- a/src/coordinator/index.spec.js
+++ b/src/coordinator/index.spec.js
@@ -40,8 +40,12 @@ describe('Coordinator', function() {
 
     it('sets a base url for the class instance', function() {
       expect(coordinator._baseUrl).to.equal(
-        `${baseSdk.config.audiences.coordinator.host}/contxt/v1`
+        `${baseSdk.config.audiences.coordinator.host}/v1`
       );
+    });
+
+    it('sets the organization ID to null', function() {
+      expect(coordinator._organizationId).to.equal(null);
     });
 
     it('appends the supplied request module to the class instance', function() {
@@ -78,6 +82,66 @@ describe('Coordinator', function() {
 
     it('appends an instance of Users to the class instance', function() {
       expect(coordinator.users).to.be.an.instanceof(Users);
+    });
+  });
+
+  describe('setOrganizationId', function() {
+    let coordinator;
+    let organization;
+
+    beforeEach(function() {
+      coordinator = new Coordinator(baseSdk, baseRequest);
+      organization = fixture.build('organization');
+    });
+
+    context('when an organization ID is provided', function() {
+      beforeEach(function() {
+        coordinator.setOrganizationId(organization.id);
+      });
+
+      it('sets the organization ID for the class instance', function() {
+        expect(coordinator._organizationId).to.equal(organization.id);
+      });
+
+      it('sets the base url to be the new tenant url', function() {
+        expect(coordinator._baseUrl).to.equal(
+          `${baseSdk.config.audiences.coordinator.host}/contxt/v1/${
+            organization.id
+          }`
+        );
+      });
+
+      it('appends a new instance of Application to the class instance with the tenant base url', function() {
+        expect(coordinator.applications).to.be.an.instanceof(Applications);
+        expect(coordinator.applications._baseUrl).to.equal(
+          `${baseSdk.config.audiences.coordinator.host}/contxt/v1/${
+            organization.id
+          }`
+        );
+      });
+    });
+
+    context('when an organization ID provided is null', function() {
+      beforeEach(function() {
+        coordinator.setOrganizationId(null);
+      });
+
+      it('sets the organization ID for the class instance to null', function() {
+        expect(coordinator._organizationId).to.equal(null);
+      });
+
+      it('sets the base url to be the legacy url', function() {
+        expect(coordinator._baseUrl).to.equal(
+          `${baseSdk.config.audiences.coordinator.host}/v1`
+        );
+      });
+
+      it('appends a new instance of Application to the class instance with the legacy base url', function() {
+        expect(coordinator.applications).to.be.an.instanceof(Applications);
+        expect(coordinator.applications._baseUrl).to.equal(
+          `${baseSdk.config.audiences.coordinator.host}/v1`
+        );
+      });
     });
   });
 });

--- a/src/coordinator/index.spec.js
+++ b/src/coordinator/index.spec.js
@@ -119,6 +119,60 @@ describe('Coordinator', function() {
           }`
         );
       });
+
+      it('appends a new instance of Consent to the class instance with the tenant base url', function() {
+        expect(coordinator.consent).to.be.an.instanceof(Consent);
+        expect(coordinator.consent._baseUrl).to.equal(
+          `${baseSdk.config.audiences.coordinator.host}/contxt/v1/${
+            organization.id
+          }`
+        );
+      });
+
+      it('appends a new instance of EdgeNodes to the class instance with the tenant base url', function() {
+        expect(coordinator.edgeNodes).to.be.an.instanceof(EdgeNodes);
+        expect(coordinator.edgeNodes._baseUrl).to.equal(
+          `${baseSdk.config.audiences.coordinator.host}/contxt/v1/${
+            organization.id
+          }`
+        );
+      });
+
+      it('appends a new instance of Organizations to the class instance with the tenant base url', function() {
+        expect(coordinator.organizations).to.be.an.instanceof(Organizations);
+        expect(coordinator.organizations._baseUrl).to.equal(
+          `${baseSdk.config.audiences.coordinator.host}/contxt/v1/${
+            organization.id
+          }`
+        );
+      });
+
+      it('appends a new instance of Permissions to the class instance with the tenant base url', function() {
+        expect(coordinator.permissions).to.be.an.instanceof(Permissions);
+        expect(coordinator.permissions._baseUrl).to.equal(
+          `${baseSdk.config.audiences.coordinator.host}/contxt/v1/${
+            organization.id
+          }`
+        );
+      });
+
+      it('appends a new instance of Roles to the class instance with the tenant base url', function() {
+        expect(coordinator.roles).to.be.an.instanceof(Roles);
+        expect(coordinator.roles._baseUrl).to.equal(
+          `${baseSdk.config.audiences.coordinator.host}/contxt/v1/${
+            organization.id
+          }`
+        );
+      });
+
+      it('appends a new instance of Users to the class instance with the tenant base url', function() {
+        expect(coordinator.users).to.be.an.instanceof(Users);
+        expect(coordinator.users._baseUrl).to.equal(
+          `${baseSdk.config.audiences.coordinator.host}/contxt/v1/${
+            organization.id
+          }`
+        );
+      });
     });
 
     context('when an organization ID provided is null', function() {
@@ -139,6 +193,48 @@ describe('Coordinator', function() {
       it('appends a new instance of Application to the class instance with the legacy base url', function() {
         expect(coordinator.applications).to.be.an.instanceof(Applications);
         expect(coordinator.applications._baseUrl).to.equal(
+          `${baseSdk.config.audiences.coordinator.host}/v1`
+        );
+      });
+
+      it('appends a new instance of Consent to the class instance with the legacy base url', function() {
+        expect(coordinator.consent).to.be.an.instanceof(Consent);
+        expect(coordinator.consent._baseUrl).to.equal(
+          `${baseSdk.config.audiences.coordinator.host}/v1`
+        );
+      });
+
+      it('appends a new instance of EdgeNodes to the class instance with the legacy base url', function() {
+        expect(coordinator.edgeNodes).to.be.an.instanceof(EdgeNodes);
+        expect(coordinator.edgeNodes._baseUrl).to.equal(
+          `${baseSdk.config.audiences.coordinator.host}/v1`
+        );
+      });
+
+      it('appends a new instance of Organizations to the class instance with the legacy base url', function() {
+        expect(coordinator.organizations).to.be.an.instanceof(Organizations);
+        expect(coordinator.organizations._baseUrl).to.equal(
+          `${baseSdk.config.audiences.coordinator.host}/v1`
+        );
+      });
+
+      it('appends a new instance of Permissions to the class instance with the legacy base url', function() {
+        expect(coordinator.permissions).to.be.an.instanceof(Permissions);
+        expect(coordinator.permissions._baseUrl).to.equal(
+          `${baseSdk.config.audiences.coordinator.host}/v1`
+        );
+      });
+
+      it('appends a new instance of Roles to the class instance with the legacy base url', function() {
+        expect(coordinator.roles).to.be.an.instanceof(Roles);
+        expect(coordinator.roles._baseUrl).to.equal(
+          `${baseSdk.config.audiences.coordinator.host}/v1`
+        );
+      });
+
+      it('appends a new instance of Users to the class instance with the legacy base url', function() {
+        expect(coordinator.users).to.be.an.instanceof(Users);
+        expect(coordinator.users._baseUrl).to.equal(
           `${baseSdk.config.audiences.coordinator.host}/v1`
         );
       });

--- a/src/coordinator/organizations.js
+++ b/src/coordinator/organizations.js
@@ -19,17 +19,20 @@ class Organizations {
    * @param {Object} sdk An instance of the SDK so the module can communicate with other modules
    * @param {Object} request An instance of the request module tied to this module's audience.
    * @param {string} baseUrl The base URL provided by the parent module
+   * @param {string} [organizationId] The organization ID to be used in tenant url requests
    */
-  constructor(sdk, request, baseUrl) {
+  constructor(sdk, request, baseUrl, organizationId = null) {
     this._baseUrl = baseUrl;
     this._request = request;
     this._sdk = sdk;
+    this._organizationId = organizationId;
   }
 
   /**
    * Gets information about a contxt organization
    *
-   * API Endpoint: '/organizations/:organizationId'
+   * Legacy API Endpoint: '/organizations/:organizationId'
+   * API Endpoint: '/'
    * Method: GET
    *
    * @param {string} organizationId The ID of the organization
@@ -45,6 +48,12 @@ class Organizations {
    *   .catch((err) => console.log(err));
    */
   get(organizationId) {
+    if (this._organizationId) {
+      return this._request
+        .get(`${this._baseUrl}`)
+        .then((org) => toCamelCase(org));
+    }
+
     if (!organizationId) {
       return Promise.reject(
         new Error(

--- a/src/coordinator/organizations.js
+++ b/src/coordinator/organizations.js
@@ -35,7 +35,7 @@ class Organizations {
    * API Endpoint: '/'
    * Method: GET
    *
-   * @param {string} organizationId The ID of the organization
+   * @param {string} organizationId The ID of the organization, optional when using the tenant API and an organization ID has been set
    *
    * @returns {Promise}
    * @fulfill {ContxtOrganization} Information about a contxt organization

--- a/src/coordinator/organizations.spec.js
+++ b/src/coordinator/organizations.spec.js
@@ -1,7 +1,7 @@
 import Organizations from './organizations';
 import * as objectUtils from '../utils/objects';
 
-describe('Coordinator/Organizations', function() {
+describe.only('Coordinator/Organizations', function() {
   let baseRequest;
   let baseSdk;
   let expectedHost;
@@ -28,7 +28,7 @@ describe('Coordinator/Organizations', function() {
   });
 
   describe('constructor', function() {
-    context('when organization ID is provided', function() {
+    context('when an organization ID is provided', function() {
       let organizationId;
       let organizations;
 
@@ -60,7 +60,7 @@ describe('Coordinator/Organizations', function() {
       });
     });
 
-    context('when organization ID is not provided', function() {
+    context('when an organization ID is not provided', function() {
       let organizations;
 
       beforeEach(function() {
@@ -79,7 +79,7 @@ describe('Coordinator/Organizations', function() {
         expect(organizations._sdk).to.deep.equal(baseSdk);
       });
 
-      it('sets the organization ID for the class instance', function() {
+      it('sets the organization ID for the class instance to null', function() {
         expect(organizations._organizationId).to.equal(null);
       });
     });
@@ -163,42 +163,46 @@ describe('Coordinator/Organizations', function() {
     });
 
     context('tenant API', function() {
+      let organizationFromServerAfterFormat;
+      let organizationFromServerBeforeFormat;
+      let expectedOrganizationId;
+      let organizations;
+      let promise;
+      let request;
+      let toCamelCase;
+
+      beforeEach(function() {
+        expectedOrganizationId = faker.random.uuid();
+        organizationFromServerAfterFormat = fixture.build(
+          'contxtOrganization',
+          {
+            id: expectedOrganizationId
+          }
+        );
+        organizationFromServerBeforeFormat = fixture.build(
+          'event',
+          { id: expectedOrganizationId },
+          { fromServer: true }
+        );
+
+        request = {
+          ...baseRequest,
+          get: sinon.stub().resolves(organizationFromServerBeforeFormat)
+        };
+        toCamelCase = sinon
+          .stub(objectUtils, 'toCamelCase')
+          .returns(organizationFromServerAfterFormat);
+
+        organizations = new Organizations(
+          baseSdk,
+          request,
+          expectedHost,
+          expectedOrganizationId
+        );
+      });
+
       context('the organization ID is provided', function() {
-        let organizationFromServerAfterFormat;
-        let organizationFromServerBeforeFormat;
-        let expectedOrganizationId;
-        let promise;
-        let request;
-        let toCamelCase;
-
         beforeEach(function() {
-          expectedOrganizationId = faker.random.uuid();
-          organizationFromServerAfterFormat = fixture.build(
-            'contxtOrganization',
-            {
-              id: expectedOrganizationId
-            }
-          );
-          organizationFromServerBeforeFormat = fixture.build(
-            'event',
-            { id: expectedOrganizationId },
-            { fromServer: true }
-          );
-
-          request = {
-            ...baseRequest,
-            get: sinon.stub().resolves(organizationFromServerBeforeFormat)
-          };
-          toCamelCase = sinon
-            .stub(objectUtils, 'toCamelCase')
-            .returns(organizationFromServerAfterFormat);
-
-          const organizations = new Organizations(
-            baseSdk,
-            request,
-            expectedHost,
-            expectedOrganizationId
-          );
           promise = organizations.get(expectedOrganizationId);
         });
 
@@ -222,41 +226,7 @@ describe('Coordinator/Organizations', function() {
       });
 
       context('the organization ID is not provided', function() {
-        let organizationFromServerAfterFormat;
-        let organizationFromServerBeforeFormat;
-        let expectedOrganizationId;
-        let promise;
-        let request;
-        let toCamelCase;
-
         beforeEach(function() {
-          expectedOrganizationId = faker.random.uuid();
-          organizationFromServerAfterFormat = fixture.build(
-            'contxtOrganization',
-            {
-              id: expectedOrganizationId
-            }
-          );
-          organizationFromServerBeforeFormat = fixture.build(
-            'event',
-            { id: expectedOrganizationId },
-            { fromServer: true }
-          );
-
-          request = {
-            ...baseRequest,
-            get: sinon.stub().resolves(organizationFromServerBeforeFormat)
-          };
-          toCamelCase = sinon
-            .stub(objectUtils, 'toCamelCase')
-            .returns(organizationFromServerAfterFormat);
-
-          const organizations = new Organizations(
-            baseSdk,
-            request,
-            expectedHost,
-            expectedOrganizationId
-          );
           promise = organizations.get();
         });
 

--- a/src/coordinator/organizations.spec.js
+++ b/src/coordinator/organizations.spec.js
@@ -1,7 +1,7 @@
 import Organizations from './organizations';
 import * as objectUtils from '../utils/objects';
 
-describe.only('Coordinator/Organizations', function() {
+describe('Coordinator/Organizations', function() {
   let baseRequest;
   let baseSdk;
   let expectedHost;
@@ -206,7 +206,7 @@ describe.only('Coordinator/Organizations', function() {
           promise = organizations.get(expectedOrganizationId);
         });
 
-        it('gets the organization from the server', function() {
+        it('gets the organization from the server and does not use the organization ID provided', function() {
           expect(request.get).to.be.calledWith(`${expectedHost}`);
         });
 

--- a/src/coordinator/permissions.js
+++ b/src/coordinator/permissions.js
@@ -36,7 +36,7 @@ class Permissions {
    * API Endpoint: '/users/permissions/'
    * Method: GET
    *
-   * @param {string} [organizationId] The ID of the organization. Required when using the legacy API
+   * @param {string} organizationId The ID of the organization, optional when using the tenant API and an organization ID has been set
    *
    * @returns {Promise}
    * @fulfill {ContxtUserPermissions[]} A collection of user permissions
@@ -75,7 +75,7 @@ class Permissions {
    * API Endpoint: '/users/:userId/permissions'
    * Method: GET
    *
-   * @param {string} [organizationId] The ID of the organization. Required when using the legacy API
+   * @param {string} organizationId The ID of the organization, optional when using the tenant API and an organization ID has been set
    * @param {string} userId The ID of the user
    *
    * @returns {Promise}

--- a/src/coordinator/permissions.js
+++ b/src/coordinator/permissions.js
@@ -20,20 +20,23 @@ class Permissions {
    * @param {Object} sdk An instance of the SDK so the module can communicate with other modules
    * @param {Object} request An instance of the request module tied to this module's audience.
    * @param {string} baseUrl The base URL provided by the parent module
+   * @param {string} [organizationId] The organization ID to be used in tenant url requests
    */
-  constructor(sdk, request, baseUrl) {
+  constructor(sdk, request, baseUrl, organizationId = null) {
     this._baseUrl = baseUrl;
     this._request = request;
     this._sdk = sdk;
+    this._organizationId = organizationId;
   }
 
   /**
    * Gets a list of user permissions for each user in an organization
    *
-   * API Endpoint: '/organizations/:organizationId/users/permissions'
+   * Legacy API Endpoint: '/organizations/:organizationId/users/permissions'
+   * API Endpoint: '/users/permissions/'
    * Method: GET
    *
-   * @param {string} organizationId The ID of the organization
+   * @param {string} [organizationId] The ID of the organization. Required when using the legacy API
    *
    * @returns {Promise}
    * @fulfill {ContxtUserPermissions[]} A collection of user permissions
@@ -46,6 +49,12 @@ class Permissions {
    *   .catch((err) => console.log(err));
    */
   getAllByOrganizationId(organizationId) {
+    if (this._organizationId) {
+      return this._request
+        .get(`${this._baseUrl}/users/permissions`)
+        .then((userPermissions) => toCamelCase(userPermissions));
+    }
+
     if (!organizationId) {
       return Promise.reject(
         new Error(
@@ -62,10 +71,11 @@ class Permissions {
   /**
    * Gets a single user's permissions within an organization
    *
-   * API Endpoint: '/organizations/:organizationId/users/:userId/permissions'
+   * Legacy API Endpoint: '/organizations/:organizationId/users/:userId/permissions'
+   * API Endpoint: '/users/:userId/permissions'
    * Method: GET
    *
-   * @param {string} organizationId The ID of the organization
+   * @param {string} [organizationId] The ID of the organization. Required when using the legacy API
    * @param {string} userId The ID of the user
    *
    * @returns {Promise}
@@ -79,6 +89,20 @@ class Permissions {
    *   .catch((err) => console.log(err));
    */
   getOneByOrganizationId(organizationId, userId) {
+    if (this._organizationId) {
+      if (!userId) {
+        return Promise.reject(
+          new Error(
+            "A user ID is required for getting a user's permissions for an organization"
+          )
+        );
+      }
+
+      return this._request
+        .get(`${this._baseUrl}/users/${userId}/permissions`)
+        .then((userPermissions) => toCamelCase(userPermissions));
+    }
+
     if (!organizationId) {
       return Promise.reject(
         new Error(

--- a/src/coordinator/permissions.spec.js
+++ b/src/coordinator/permissions.spec.js
@@ -28,30 +28,143 @@ describe('Coordinator/Permissions', function() {
   });
 
   describe('constructor', function() {
-    let permissions;
+    context('when organization ID is provided', function() {
+      let permissions;
+      let organizationId;
 
-    beforeEach(function() {
-      permissions = new Permissions(baseSdk, baseRequest, expectedHost);
+      beforeEach(function() {
+        organizationId = fixture.build('organization').id;
+
+        permissions = new Permissions(
+          baseSdk,
+          baseRequest,
+          expectedHost,
+          organizationId
+        );
+      });
+
+      it('sets a base url for the class instance', function() {
+        expect(permissions._baseUrl).to.equal(expectedHost);
+      });
+
+      it('appends the supplied request module to the class instance', function() {
+        expect(permissions._request).to.deep.equal(baseRequest);
+      });
+
+      it('appends the supplied sdk to the class instance', function() {
+        expect(permissions._sdk).to.deep.equal(baseSdk);
+      });
+
+      it('sets the organization ID for the class instance', function() {
+        expect(permissions._organizationId).to.equal(organizationId);
+      });
     });
 
-    it('sets a base url for the class instance', function() {
-      expect(permissions._baseUrl).to.equal(expectedHost);
-    });
+    context('when organization ID is not provided', function() {
+      let permissions;
 
-    it('appends the supplied request module to the class instance', function() {
-      expect(permissions._request).to.deep.equal(baseRequest);
-    });
+      beforeEach(function() {
+        permissions = new Permissions(baseSdk, baseRequest, expectedHost);
+      });
 
-    it('appends the supplied sdk to the class instance', function() {
-      expect(permissions._sdk).to.deep.equal(baseSdk);
+      it('sets a base url for the class instance', function() {
+        expect(permissions._baseUrl).to.equal(expectedHost);
+      });
+
+      it('appends the supplied request module to the class instance', function() {
+        expect(permissions._request).to.deep.equal(baseRequest);
+      });
+
+      it('appends the supplied sdk to the class instance', function() {
+        expect(permissions._sdk).to.deep.equal(baseSdk);
+      });
+
+      it('sets the organization ID for the class instance', function() {
+        expect(permissions._organizationId).to.equal(null);
+      });
     });
   });
 
   describe('getAllByOrganizationId', function() {
-    context('when the organization ID is provided', function() {
+    context('legacy API', function() {
+      context('when the organization ID is provided', function() {
+        let expectedUsersPermissions;
+        let userPermissionFromServer;
+        let expectedOrganizationId;
+        let promise;
+        let request;
+        let toCamelCase;
+
+        beforeEach(function() {
+          expectedOrganizationId = fixture.build('contxtOrganization').id;
+          expectedUsersPermissions = fixture.buildList(
+            'contxtUserPermissions',
+            faker.random.number({
+              min: 1,
+              max: 10
+            }),
+            {
+              organizationId: expectedOrganizationId
+            }
+          );
+          userPermissionFromServer = expectedUsersPermissions.map((app) =>
+            fixture.build('contxtUserPermissions', app, {
+              fromServer: true
+            })
+          );
+
+          request = {
+            ...baseRequest,
+            get: sinon.stub().resolves(userPermissionFromServer)
+          };
+          toCamelCase = sinon
+            .stub(objectUtils, 'toCamelCase')
+            .returns(expectedUsersPermissions);
+
+          const permissions = new Permissions(baseSdk, request, expectedHost);
+          promise = permissions.getAllByOrganizationId(expectedOrganizationId);
+        });
+
+        it('gets the list of users permissions from the server', function() {
+          expect(request.get).to.be.calledWith(
+            `${expectedHost}/organizations/${expectedOrganizationId}/users/permissions`
+          );
+        });
+
+        it('formats the list of users permissions', function() {
+          return promise.then(() => {
+            expect(toCamelCase).to.be.calledWith(userPermissionFromServer);
+          });
+        });
+
+        it('returns a fulfilled promise with the users permissions', function() {
+          return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
+            expectedUsersPermissions
+          );
+        });
+      });
+
+      context('when the organization ID is not provided', function() {
+        it('throws an error', function() {
+          const permissions = new Permissions(
+            baseSdk,
+            baseRequest,
+            expectedHost
+          );
+          const promise = permissions.getAllByOrganizationId();
+
+          return expect(promise).to.be.rejectedWith(
+            'An organization ID is required for getting users permissions for an organization'
+          );
+        });
+      });
+    });
+
+    context('tenant API', function() {
       let expectedUsersPermissions;
       let userPermissionFromServer;
       let expectedOrganizationId;
+      let permissions;
       let promise;
       let request;
       let toCamelCase;
@@ -82,127 +195,306 @@ describe('Coordinator/Permissions', function() {
           .stub(objectUtils, 'toCamelCase')
           .returns(expectedUsersPermissions);
 
-        const permissions = new Permissions(baseSdk, request, expectedHost);
-        promise = permissions.getAllByOrganizationId(expectedOrganizationId);
-      });
-
-      it('gets the list of users permissions from the server', function() {
-        expect(request.get).to.be.calledWith(
-          `${expectedHost}/organizations/${expectedOrganizationId}/users/permissions`
+        permissions = new Permissions(
+          baseSdk,
+          request,
+          expectedHost,
+          expectedOrganizationId
         );
       });
 
-      it('formats the list of users permissions', function() {
-        return promise.then(() => {
-          expect(toCamelCase).to.be.calledWith(userPermissionFromServer);
+      context('when the organization ID is provided', function() {
+        let differentOrganizationId;
+
+        beforeEach(function() {
+          differentOrganizationId = fixture.build('organization').id;
+
+          promise = permissions.getAllByOrganizationId(differentOrganizationId);
+        });
+
+        it('gets the list of users permissions from the server', function() {
+          expect(request.get).to.be.calledWith(
+            `${expectedHost}/users/permissions`
+          );
+        });
+
+        it('formats the list of users permissions', function() {
+          return promise.then(() => {
+            expect(toCamelCase).to.be.calledWith(userPermissionFromServer);
+          });
+        });
+
+        it('returns a fulfilled promise with the users permissions', function() {
+          return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
+            expectedUsersPermissions
+          );
         });
       });
 
-      it('returns a fulfilled promise with the users permissions', function() {
-        return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
-          expectedUsersPermissions
-        );
-      });
-    });
+      context('when the organization ID is not provided', function() {
+        beforeEach(function() {
+          promise = permissions.getAllByOrganizationId();
+        });
 
-    context('when the organization ID is not provided', function() {
-      it('throws an error', function() {
-        const permissions = new Permissions(baseSdk, baseRequest, expectedHost);
-        const promise = permissions.getAllByOrganizationId();
+        it('gets the list of users permissions from the server', function() {
+          expect(request.get).to.be.calledWith(
+            `${expectedHost}/users/permissions`
+          );
+        });
 
-        return expect(promise).to.be.rejectedWith(
-          'An organization ID is required for getting users permissions for an organization'
-        );
+        it('formats the list of users permissions', function() {
+          return promise.then(() => {
+            expect(toCamelCase).to.be.calledWith(userPermissionFromServer);
+          });
+        });
+
+        it('returns a fulfilled promise with the users permissions', function() {
+          return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
+            expectedUsersPermissions
+          );
+        });
       });
     });
   });
 
   describe('getOneByOrganizationId', function() {
-    context('when the organization ID is provided', function() {
-      let expectedUserPermissions;
-      let userPermissionFromServer;
-      let expectedOrganizationId;
-      let expectedUserId;
-      let promise;
-      let request;
-      let toCamelCase;
+    context('legacy API', function() {
+      context('when the organization ID is provided', function() {
+        let expectedUserPermissions;
+        let userPermissionFromServer;
+        let expectedOrganizationId;
+        let expectedUserId;
+        let promise;
+        let request;
+        let toCamelCase;
 
-      beforeEach(function() {
-        expectedOrganizationId = fixture.build('contxtOrganization').id;
-        expectedUserId = fixture.build('contxtUser').id;
-        expectedUserPermissions = fixture.build('contxtUserPermissions', {
-          organizationId: expectedOrganizationId
+        beforeEach(function() {
+          expectedOrganizationId = fixture.build('contxtOrganization').id;
+          expectedUserId = fixture.build('contxtUser').id;
+          expectedUserPermissions = fixture.build('contxtUserPermissions', {
+            organizationId: expectedOrganizationId
+          });
+
+          userPermissionFromServer = fixture.build(
+            'contxtUserPermissions',
+            expectedUserPermissions,
+            {
+              fromServer: true
+            }
+          );
+
+          request = {
+            ...baseRequest,
+            get: sinon.stub().resolves(userPermissionFromServer)
+          };
+          toCamelCase = sinon
+            .stub(objectUtils, 'toCamelCase')
+            .returns(expectedUserPermissions);
+
+          const permissions = new Permissions(baseSdk, request, expectedHost);
+          promise = permissions.getOneByOrganizationId(
+            expectedOrganizationId,
+            expectedUserId
+          );
         });
 
-        userPermissionFromServer = fixture.build(
-          'contxtUserPermissions',
-          expectedUserPermissions,
-          {
-            fromServer: true
-          }
-        );
+        it('gets the user permissions from the server', function() {
+          expect(request.get).to.be.calledWith(
+            `${expectedHost}/organizations/${expectedOrganizationId}/users/${expectedUserId}/permissions`
+          );
+        });
 
-        request = {
-          ...baseRequest,
-          get: sinon.stub().resolves(userPermissionFromServer)
-        };
-        toCamelCase = sinon
-          .stub(objectUtils, 'toCamelCase')
-          .returns(expectedUserPermissions);
+        it('formats the of user permissions', function() {
+          return promise.then(() => {
+            expect(toCamelCase).to.be.calledWith(userPermissionFromServer);
+          });
+        });
 
-        const permissions = new Permissions(baseSdk, request, expectedHost);
-        promise = permissions.getOneByOrganizationId(
-          expectedOrganizationId,
-          expectedUserId
-        );
-      });
-
-      it('gets the user permissions from the server', function() {
-        expect(request.get).to.be.calledWith(
-          `${expectedHost}/organizations/${expectedOrganizationId}/users/${expectedUserId}/permissions`
-        );
-      });
-
-      it('formats the of user permissions', function() {
-        return promise.then(() => {
-          expect(toCamelCase).to.be.calledWith(userPermissionFromServer);
+        it('returns a fulfilled promise with the users permissions', function() {
+          return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
+            expectedUserPermissions
+          );
         });
       });
 
-      it('returns a fulfilled promise with the users permissions', function() {
-        return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
-          expectedUserPermissions
-        );
+      context('when the organization ID is not provided', function() {
+        it('throws an error', function() {
+          const expectedUserId = fixture.build('contxtUser').id;
+          const permissions = new Permissions(
+            baseSdk,
+            baseRequest,
+            expectedHost
+          );
+          const promise = permissions.getOneByOrganizationId(
+            null,
+            expectedUserId
+          );
+
+          return expect(promise).to.be.rejectedWith(
+            "An organization ID is required for getting a user's permissions for an organization"
+          );
+        });
+      });
+
+      context('when the user ID is not provided', function() {
+        it('throws an error', function() {
+          const expectedOrganizationId = fixture.build('contxtOrganization').id;
+          const permissions = new Permissions(
+            baseSdk,
+            baseRequest,
+            expectedHost
+          );
+          const promise = permissions.getOneByOrganizationId(
+            expectedOrganizationId,
+            null
+          );
+
+          return expect(promise).to.be.rejectedWith(
+            "A user ID is required for getting a user's permissions for an organization"
+          );
+        });
       });
     });
 
-    context('when the organization ID is not provided', function() {
-      it('throws an error', function() {
-        const expectedUserId = fixture.build('contxtUser').id;
-        const permissions = new Permissions(baseSdk, baseRequest, expectedHost);
-        const promise = permissions.getOneByOrganizationId(
-          null,
-          expectedUserId
-        );
+    context('tenant API', function() {
+      context('when the organization ID is provided', function() {
+        let expectedUserPermissions;
+        let userPermissionFromServer;
+        let expectedOrganizationId;
+        let expectedUserId;
+        let promise;
+        let request;
+        let toCamelCase;
 
-        return expect(promise).to.be.rejectedWith(
-          "An organization ID is required for getting a user's permissions for an organization"
-        );
+        beforeEach(function() {
+          expectedOrganizationId = fixture.build('contxtOrganization').id;
+          expectedUserId = fixture.build('contxtUser').id;
+          expectedUserPermissions = fixture.build('contxtUserPermissions', {
+            organizationId: expectedOrganizationId
+          });
+
+          userPermissionFromServer = fixture.build(
+            'contxtUserPermissions',
+            expectedUserPermissions,
+            {
+              fromServer: true
+            }
+          );
+
+          request = {
+            ...baseRequest,
+            get: sinon.stub().resolves(userPermissionFromServer)
+          };
+          toCamelCase = sinon
+            .stub(objectUtils, 'toCamelCase')
+            .returns(expectedUserPermissions);
+
+          const permissions = new Permissions(
+            baseSdk,
+            request,
+            expectedHost,
+            expectedOrganizationId
+          );
+          promise = permissions.getOneByOrganizationId(
+            faker.random.uuid(),
+            expectedUserId
+          );
+        });
+
+        it('gets the user permissions from the server', function() {
+          expect(request.get).to.be.calledWith(
+            `${expectedHost}/users/${expectedUserId}/permissions`
+          );
+        });
+
+        it('formats the of user permissions', function() {
+          return promise.then(() => {
+            expect(toCamelCase).to.be.calledWith(userPermissionFromServer);
+          });
+        });
+
+        it('returns a fulfilled promise with the users permissions', function() {
+          return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
+            expectedUserPermissions
+          );
+        });
       });
-    });
 
-    context('when the user ID is not provided', function() {
-      it('throws an error', function() {
-        const expectedOrganizationId = fixture.build('contxtOrganization').id;
-        const permissions = new Permissions(baseSdk, baseRequest, expectedHost);
-        const promise = permissions.getOneByOrganizationId(
-          expectedOrganizationId,
-          null
-        );
+      context('when the organization ID is not provided', function() {
+        let expectedUserPermissions;
+        let userPermissionFromServer;
+        let expectedOrganizationId;
+        let expectedUserId;
+        let promise;
+        let request;
+        let toCamelCase;
 
-        return expect(promise).to.be.rejectedWith(
-          "A user ID is required for getting a user's permissions for an organization"
-        );
+        beforeEach(function() {
+          expectedOrganizationId = fixture.build('contxtOrganization').id;
+          expectedUserId = fixture.build('contxtUser').id;
+          expectedUserPermissions = fixture.build('contxtUserPermissions', {
+            organizationId: expectedOrganizationId
+          });
+
+          userPermissionFromServer = fixture.build(
+            'contxtUserPermissions',
+            expectedUserPermissions,
+            {
+              fromServer: true
+            }
+          );
+
+          request = {
+            ...baseRequest,
+            get: sinon.stub().resolves(userPermissionFromServer)
+          };
+          toCamelCase = sinon
+            .stub(objectUtils, 'toCamelCase')
+            .returns(expectedUserPermissions);
+
+          const permissions = new Permissions(
+            baseSdk,
+            request,
+            expectedHost,
+            expectedOrganizationId
+          );
+          promise = permissions.getOneByOrganizationId(null, expectedUserId);
+        });
+
+        it('gets the user permissions from the server', function() {
+          expect(request.get).to.be.calledWith(
+            `${expectedHost}/users/${expectedUserId}/permissions`
+          );
+        });
+
+        it('formats the of user permissions', function() {
+          return promise.then(() => {
+            expect(toCamelCase).to.be.calledWith(userPermissionFromServer);
+          });
+        });
+
+        it('returns a fulfilled promise with the users permissions', function() {
+          return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
+            expectedUserPermissions
+          );
+        });
+      });
+
+      context('when the user ID is not provided', function() {
+        it('throws an error', function() {
+          const expectedOrganizationId = fixture.build('contxtOrganization').id;
+          const permissions = new Permissions(
+            baseSdk,
+            baseRequest,
+            expectedHost,
+            expectedOrganizationId
+          );
+          const promise = permissions.getOneByOrganizationId(null, null);
+
+          return expect(promise).to.be.rejectedWith(
+            "A user ID is required for getting a user's permissions for an organization"
+          );
+        });
       });
     });
   });

--- a/src/coordinator/roles.js
+++ b/src/coordinator/roles.js
@@ -156,7 +156,7 @@ class Roles {
   /**
    * Create a new role for an organization
    *
-   * @param {string} [organizationId] The ID of the organization. Required when using the legacy API
+   * @param {string} organizationId The ID of the organization, optional when using the tenant API and an organization ID has been set
    * @param {Object} role
    * @param {string} role.name The name of the new role
    * @param {string} role.description Some text describing the purpose of the role
@@ -228,7 +228,7 @@ class Roles {
    * API Endpiont: '/roles/:roleId'
    * Method: DELETE
    *
-   * @param {string} [organizationId] The ID of the organization. Required when using the legacy API
+   * @param {string} organizationId The ID of the organization, optional when using the tenant API and an organization ID has been set
    * @param {string} roleId The UUID formatted ID of the role
    *
    * @returns {Promise}
@@ -273,7 +273,7 @@ class Roles {
    * API Endpoint: '/roles'
    * Method: GET
    *
-   * @param {string} [organizationId] The ID of the organization. Required when using the legacy API
+   * @param {string} organizationId The ID of the organization, optional when using the tenant API and an organization ID has been set
    *
    * @returns {Promise}
    * @fulfill {ContxtRole[]} A list of roles

--- a/src/coordinator/roles.js
+++ b/src/coordinator/roles.js
@@ -57,11 +57,13 @@ class Roles {
    * @param {Object} sdk An instance of the SDK so the module can communicate with other modules
    * @param {Object} request An instance of the request module tied to this module's audience.
    * @param {string} baseUrl The base URL provided by the parent module
+   * @param {string} [organizationId] The organization ID to be used in tenant url requests
    */
-  constructor(sdk, request, baseUrl) {
+  constructor(sdk, request, baseUrl, organizationId = null) {
     this._baseUrl = baseUrl;
     this._request = request;
     this._sdk = sdk;
+    this._organizationId = organizationId;
   }
 
   /**
@@ -154,7 +156,7 @@ class Roles {
   /**
    * Create a new role for an organization
    *
-   * @param {string} organizationId The ID of the organization
+   * @param {string} [organizationId] The ID of the organization. Required when using the legacy API
    * @param {Object} role
    * @param {string} role.name The name of the new role
    * @param {string} role.description Some text describing the purpose of the role
@@ -173,6 +175,24 @@ class Roles {
    *   .catch((err) => console.log(err));
    */
   create(organizationId, role = {}) {
+    if (this._organizationId) {
+      if (!role.name) {
+        return Promise.reject(
+          new Error(`A name is required to create a new role.`)
+        );
+      }
+
+      if (!role.description) {
+        return Promise.reject(
+          new Error(`A description is required to create a new role.`)
+        );
+      }
+
+      return this._request
+        .post(`${this._baseUrl}/roles`, toSnakeCase(role))
+        .then((response) => toCamelCase(response));
+    }
+
     if (!organizationId) {
       return Promise.reject(
         new Error(
@@ -204,10 +224,11 @@ class Roles {
   /**
    * Deletes a role from an organization
    *
-   * API Endpoint: '/organizations/:organizationId/roles/:roleId'
+   * Legacy API Endpoint: '/organizations/:organizationId/roles/:roleId'
+   * API Endpiont: '/roles/:roleId'
    * Method: DELETE
    *
-   * @param {string} organizationId The ID of the organization
+   * @param {string} [organizationId] The ID of the organization. Required when using the legacy API
    * @param {string} roleId The UUID formatted ID of the role
    *
    * @returns {Promise}
@@ -215,9 +236,19 @@ class Roles {
    * @reject {Error}
    *
    * @example
-   * contxtSdk.roles.delete('4f0e51c6-728b-4892-9863-6d002e61204d');
+   * contxtSdk.roles.delete('4f0e51c6-728b-4892-9863-6d002e61204d', '8b64fb12-e649-46be-b330-e672d28eed99s');
    */
   delete(organizationId, roleId) {
+    if (this._organizationId) {
+      if (!roleId) {
+        return Promise.reject(
+          new Error('A roleId is required for deleting a role.')
+        );
+      }
+
+      return this._request.delete(`${this._baseUrl}/roles/${roleId}`);
+    }
+
     if (!organizationId) {
       return Promise.reject(
         new Error('An organizationId is required for deleting a role.')
@@ -238,10 +269,11 @@ class Roles {
   /**
    * Gets an organization's list of roles
    *
-   * API Endpoint: '/organizations/:organizationId/roles'
+   * Legacy API Endpoint: '/organizations/:organizationId/roles'
+   * API Endpoint: '/roles'
    * Method: GET
    *
-   * @param {string} organizationId The ID of the organization
+   * @param {string} [organizationId] The ID of the organization. Required when using the legacy API
    *
    * @returns {Promise}
    * @fulfill {ContxtRole[]} A list of roles
@@ -254,6 +286,12 @@ class Roles {
    *   .catch((err) => console.log(err));
    */
   getByOrganizationId(organizationId) {
+    if (this._organizationId) {
+      return this._request
+        .get(`${this._baseUrl}/roles`)
+        .then((roles) => toCamelCase(roles));
+    }
+
     if (!organizationId) {
       return Promise.reject(
         new Error(

--- a/src/coordinator/roles.spec.js
+++ b/src/coordinator/roles.spec.js
@@ -28,7 +28,7 @@ describe('Coordinator/Roles', function() {
   });
 
   describe('constructor', function() {
-    context('when organization ID is provided', function() {
+    context('when an organization ID is provided', function() {
       let organizationId;
       let roles;
 
@@ -55,7 +55,7 @@ describe('Coordinator/Roles', function() {
       });
     });
 
-    context('when organization ID is not provided', function() {
+    context('when an organization ID is not provided', function() {
       let roles;
 
       beforeEach(function() {
@@ -74,7 +74,7 @@ describe('Coordinator/Roles', function() {
         expect(roles._sdk).to.deep.equal(baseSdk);
       });
 
-      it('sets the organization ID for the class instance', function() {
+      it('sets the organization ID for the class instance to null', function() {
         expect(roles._organizationId).to.equal(null);
       });
     });
@@ -390,49 +390,52 @@ describe('Coordinator/Roles', function() {
     });
 
     context('tenant API', function() {
+      let roles;
+      let organization;
+      let expectedRole;
+      let expectedRoleFromServer;
+      let newRolePayload;
+      let newRolePayloadToServer;
+      let promise;
+      let request;
+      let toCamelCase;
+      let toSnakeCase;
+
+      beforeEach(function() {
+        organization = fixture.build('contxtOrganization');
+        expectedRole = fixture.build('contxtRole');
+        expectedRoleFromServer = fixture.build('contxtRole', expectedRole, {
+          fromServer: true
+        });
+        newRolePayload = {
+          name: expectedRole.name,
+          description: expectedRole.description
+        };
+
+        newRolePayloadToServer = {
+          name: newRolePayload.name,
+          description: newRolePayload.description
+        };
+
+        request = {
+          ...baseRequest,
+          post: sinon.stub().resolves(expectedRoleFromServer)
+        };
+        toCamelCase = sinon
+          .stub(objectUtils, 'toCamelCase')
+          .callsFake(() => expectedRole);
+
+        toSnakeCase = sinon
+          .stub(objectUtils, 'toSnakeCase')
+          .callsFake(() => newRolePayloadToServer);
+
+        roles = new Roles(baseSdk, request, expectedHost, organization.id);
+      });
+
       context(
         'when an organization ID and role information are both provided',
         function() {
-          let roles;
-          let organization;
-          let expectedRole;
-          let expectedRoleFromServer;
-          let newRolePayload;
-          let newRolePayloadToServer;
-          let promise;
-          let request;
-          let toCamelCase;
-          let toSnakeCase;
-
           beforeEach(function() {
-            organization = fixture.build('contxtOrganization');
-            expectedRole = fixture.build('contxtRole');
-            expectedRoleFromServer = fixture.build('contxtRole', expectedRole, {
-              fromServer: true
-            });
-            newRolePayload = {
-              name: expectedRole.name,
-              description: expectedRole.description
-            };
-
-            newRolePayloadToServer = {
-              name: newRolePayload.name,
-              description: newRolePayload.description
-            };
-
-            request = {
-              ...baseRequest,
-              post: sinon.stub().resolves(expectedRoleFromServer)
-            };
-            toCamelCase = sinon
-              .stub(objectUtils, 'toCamelCase')
-              .callsFake(() => expectedRole);
-
-            toSnakeCase = sinon
-              .stub(objectUtils, 'toSnakeCase')
-              .callsFake(() => newRolePayloadToServer);
-
-            roles = new Roles(baseSdk, request, expectedHost, organization.id);
             promise = roles.create(organization.id, newRolePayload);
           });
 
@@ -465,47 +468,8 @@ describe('Coordinator/Roles', function() {
       );
 
       context('when the organization ID is not provided', function() {
-        let roles;
-        let organization;
-        let expectedRole;
-        let expectedRoleFromServer;
-        let newRolePayload;
-        let newRolePayloadToServer;
-        let promise;
-        let request;
-        let toCamelCase;
-        let toSnakeCase;
-
         beforeEach(function() {
-          organization = fixture.build('contxtOrganization');
-          expectedRole = fixture.build('contxtRole');
-          expectedRoleFromServer = fixture.build('contxtRole', expectedRole, {
-            fromServer: true
-          });
-          newRolePayload = {
-            name: expectedRole.name,
-            description: expectedRole.description
-          };
-
-          newRolePayloadToServer = {
-            name: newRolePayload.name,
-            description: newRolePayload.description
-          };
-
-          request = {
-            ...baseRequest,
-            post: sinon.stub().resolves(expectedRoleFromServer)
-          };
-          toCamelCase = sinon
-            .stub(objectUtils, 'toCamelCase')
-            .callsFake(() => expectedRole);
-
-          toSnakeCase = sinon
-            .stub(objectUtils, 'toSnakeCase')
-            .callsFake(() => newRolePayloadToServer);
-
-          roles = new Roles(baseSdk, request, expectedHost, organization.id);
-          promise = roles.create(organization.id, newRolePayload);
+          promise = roles.create(null, newRolePayload);
         });
 
         it('formats the role payload', function() {
@@ -622,23 +586,22 @@ describe('Coordinator/Roles', function() {
     });
 
     context('tenant API', function() {
+      let role;
+      let roles;
+      let organization;
+      let promise;
+
+      beforeEach(function() {
+        organization = fixture.build('organization');
+        role = fixture.build('contxtRole');
+
+        roles = new Roles(baseSdk, baseRequest, expectedHost, organization.id);
+      });
+
       context(
         'when the the organization ID and role ID are both provided',
         function() {
-          let role;
-          let organization;
-          let promise;
-
           beforeEach(function() {
-            organization = fixture.build('organization');
-            role = fixture.build('contxtRole');
-
-            const roles = new Roles(
-              baseSdk,
-              baseRequest,
-              expectedHost,
-              organization.id
-            );
             promise = roles.delete(organization.id, role.id);
           });
 
@@ -655,21 +618,8 @@ describe('Coordinator/Roles', function() {
       );
 
       context('when the organization ID is not provided', function() {
-        let role;
-        let organization;
-        let promise;
-
         beforeEach(function() {
-          organization = fixture.build('organization');
-          role = fixture.build('contxtRole');
-
-          const roles = new Roles(
-            baseSdk,
-            baseRequest,
-            expectedHost,
-            organization.id
-          );
-          promise = roles.delete(organization.id, role.id);
+          promise = roles.delete(null, role.id);
         });
 
         it('returns a fulfilled promise', function() {
@@ -816,7 +766,7 @@ describe('Coordinator/Roles', function() {
         );
       });
 
-      context('when the organizationId is provided', function() {
+      context('when the organization ID is provided', function() {
         beforeEach(function() {
           promise = roles.getByOrganizationId(expectedOrganizationId);
         });
@@ -838,7 +788,7 @@ describe('Coordinator/Roles', function() {
         });
       });
 
-      context('when the organizationId is not provided', function() {
+      context('when the organization ID is not provided', function() {
         beforeEach(function() {
           promise = roles.getByOrganizationId();
         });

--- a/src/coordinator/roles.spec.js
+++ b/src/coordinator/roles.spec.js
@@ -27,6 +27,59 @@ describe('Coordinator/Roles', function() {
     sinon.restore();
   });
 
+  describe('constructor', function() {
+    context('when organization ID is provided', function() {
+      let organizationId;
+      let roles;
+
+      beforeEach(function() {
+        organizationId = fixture.build('organization').id;
+
+        roles = new Roles(baseSdk, baseRequest, expectedHost, organizationId);
+      });
+
+      it('sets a base url for the class instance', function() {
+        expect(roles._baseUrl).to.equal(expectedHost);
+      });
+
+      it('appends the supplied request module to the class instance', function() {
+        expect(roles._request).to.deep.equal(baseRequest);
+      });
+
+      it('appends the supplied sdk to the class instance', function() {
+        expect(roles._sdk).to.deep.equal(baseSdk);
+      });
+
+      it('sets the organization ID for the class instance', function() {
+        expect(roles._organizationId).to.equal(organizationId);
+      });
+    });
+
+    context('when organization ID is not provided', function() {
+      let roles;
+
+      beforeEach(function() {
+        roles = new Roles(baseSdk, baseRequest, expectedHost);
+      });
+
+      it('sets a base url for the class instance', function() {
+        expect(roles._baseUrl).to.equal(expectedHost);
+      });
+
+      it('appends the supplied request module to the class instance', function() {
+        expect(roles._request).to.deep.equal(baseRequest);
+      });
+
+      it('appends the supplied sdk to the class instance', function() {
+        expect(roles._sdk).to.deep.equal(baseSdk);
+      });
+
+      it('sets the organization ID for the class instance', function() {
+        expect(roles._organizationId).to.equal(null);
+      });
+    });
+  });
+
   describe('addApplication', function() {
     context('when all the required parameters are provided', function() {
       let expectedRoleApplication;
@@ -228,193 +281,509 @@ describe('Coordinator/Roles', function() {
     });
   });
 
-  describe('constructor', function() {
-    let roles;
-
-    beforeEach(function() {
-      roles = new Roles(baseSdk, baseRequest, expectedHost);
-    });
-
-    it('sets a base url for the class instance', function() {
-      expect(roles._baseUrl).to.equal(expectedHost);
-    });
-
-    it('appends the supplied request module to the class instance', function() {
-      expect(roles._request).to.deep.equal(baseRequest);
-    });
-
-    it('appends the supplied sdk to the class instance', function() {
-      expect(roles._sdk).to.deep.equal(baseSdk);
-    });
-  });
-
   describe('create', function() {
-    context('when the required information is provided', function() {
-      let roles;
-      let organization;
-      let expectedRole;
-      let expectedRoleFromServer;
-      let newRolePayload;
-      let newRolePayloadToServer;
-      let promise;
-      let request;
-      let toCamelCase;
-      let toSnakeCase;
+    context('legacy API', function() {
+      context('when the required information is provided', function() {
+        let roles;
+        let organization;
+        let expectedRole;
+        let expectedRoleFromServer;
+        let newRolePayload;
+        let newRolePayloadToServer;
+        let promise;
+        let request;
+        let toCamelCase;
+        let toSnakeCase;
 
-      beforeEach(function() {
-        organization = fixture.build('contxtOrganization');
-        expectedRole = fixture.build('contxtRole');
-        expectedRoleFromServer = fixture.build('contxtRole', expectedRole, {
-          fromServer: true
+        beforeEach(function() {
+          organization = fixture.build('contxtOrganization');
+          expectedRole = fixture.build('contxtRole');
+          expectedRoleFromServer = fixture.build('contxtRole', expectedRole, {
+            fromServer: true
+          });
+          newRolePayload = {
+            name: expectedRole.name,
+            description: expectedRole.description
+          };
+
+          newRolePayloadToServer = {
+            name: newRolePayload.name,
+            description: newRolePayload.description
+          };
+
+          request = {
+            ...baseRequest,
+            post: sinon.stub().resolves(expectedRoleFromServer)
+          };
+          toCamelCase = sinon
+            .stub(objectUtils, 'toCamelCase')
+            .callsFake(() => expectedRole);
+
+          toSnakeCase = sinon
+            .stub(objectUtils, 'toSnakeCase')
+            .callsFake(() => newRolePayloadToServer);
+
+          roles = new Roles(baseSdk, request, expectedHost);
+          promise = roles.create(organization.id, newRolePayload);
         });
-        newRolePayload = {
-          name: expectedRole.name,
-          description: expectedRole.description
-        };
 
-        newRolePayloadToServer = {
-          name: newRolePayload.name,
-          description: newRolePayload.description
-        };
+        it('formats the role payload', function() {
+          return promise.then(() => {
+            expect(toSnakeCase).to.be.calledWith(newRolePayload);
+          });
+        });
 
-        request = {
-          ...baseRequest,
-          post: sinon.stub().resolves(expectedRoleFromServer)
-        };
-        toCamelCase = sinon
-          .stub(objectUtils, 'toCamelCase')
-          .callsFake(() => expectedRole);
+        it('posts the role to the server', function() {
+          expect(request.post).to.be.calledOnce;
+          expect(request.post).to.be.calledWith(
+            `${expectedHost}/organizations/${organization.id}/roles`,
+            newRolePayloadToServer
+          );
+        });
 
-        toSnakeCase = sinon
-          .stub(objectUtils, 'toSnakeCase')
-          .callsFake(() => newRolePayloadToServer);
+        it('returns a fulfilled promise', function() {
+          return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
+            expectedRole
+          );
+        });
 
-        roles = new Roles(baseSdk, request, expectedHost);
-        promise = roles.create(organization.id, newRolePayload);
-      });
-
-      it('formats the role payload', function() {
-        return promise.then(() => {
-          expect(toSnakeCase).to.be.calledWith(newRolePayload);
+        it('formats the role response', function() {
+          return promise.then(() => {
+            expect(toCamelCase).to.be.calledWith(expectedRoleFromServer);
+          });
         });
       });
 
-      it('posts the role to the server', function() {
-        expect(request.post).to.be.calledOnce;
-        expect(request.post).to.be.calledWith(
-          `${expectedHost}/organizations/${organization.id}/roles`,
-          newRolePayloadToServer
-        );
+      context('when the organizationId is not provided', function() {
+        it('returns a rejected promise', function() {
+          const roles = new Roles(baseSdk, baseRequest, expectedHost);
+          const promise = roles.create();
+
+          return expect(promise).to.be.rejectedWith(
+            'An organizationId is required for creating roles for an organization.'
+          );
+        });
       });
 
-      it('returns a fulfilled promise', function() {
-        return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
-          expectedRole
-        );
-      });
+      context('when the role does not have required properties', function() {
+        it('without name it returns a rejected promise', function() {
+          const roles = new Roles(baseSdk, baseRequest, expectedHost);
+          const organization = fixture.build('contxtOrganization');
+          const promise = roles.create(organization.id, {
+            description: 'winning'
+          });
 
-      it('formats the role response', function() {
-        return promise.then(() => {
-          expect(toCamelCase).to.be.calledWith(expectedRoleFromServer);
+          return expect(promise).to.be.rejectedWith(
+            `A name is required to create a new role.`
+          );
+        });
+        it('without description it returns a rejected promise', function() {
+          const roles = new Roles(baseSdk, baseRequest, expectedHost);
+          const organization = fixture.build('contxtOrganization');
+          const promise = roles.create(organization.id, { name: 'winning' });
+
+          return expect(promise).to.be.rejectedWith(
+            `A description is required to create a new role.`
+          );
         });
       });
     });
 
-    context('when the organizationId is not provided', function() {
-      it('returns a rejected promise', function() {
-        const roles = new Roles(baseSdk, baseRequest, expectedHost);
-        const promise = roles.create();
+    context('tenant API', function() {
+      context(
+        'when an organization ID and role information are both provided',
+        function() {
+          let roles;
+          let organization;
+          let expectedRole;
+          let expectedRoleFromServer;
+          let newRolePayload;
+          let newRolePayloadToServer;
+          let promise;
+          let request;
+          let toCamelCase;
+          let toSnakeCase;
 
-        return expect(promise).to.be.rejectedWith(
-          'An organizationId is required for creating roles for an organization.'
-        );
-      });
-    });
+          beforeEach(function() {
+            organization = fixture.build('contxtOrganization');
+            expectedRole = fixture.build('contxtRole');
+            expectedRoleFromServer = fixture.build('contxtRole', expectedRole, {
+              fromServer: true
+            });
+            newRolePayload = {
+              name: expectedRole.name,
+              description: expectedRole.description
+            };
 
-    context('when the role does not have required properties', function() {
-      it('without name it returns a rejected promise', function() {
-        const roles = new Roles(baseSdk, baseRequest, expectedHost);
-        const organization = fixture.build('contxtOrganization');
-        const promise = roles.create(organization.id, {
-          description: 'winning'
+            newRolePayloadToServer = {
+              name: newRolePayload.name,
+              description: newRolePayload.description
+            };
+
+            request = {
+              ...baseRequest,
+              post: sinon.stub().resolves(expectedRoleFromServer)
+            };
+            toCamelCase = sinon
+              .stub(objectUtils, 'toCamelCase')
+              .callsFake(() => expectedRole);
+
+            toSnakeCase = sinon
+              .stub(objectUtils, 'toSnakeCase')
+              .callsFake(() => newRolePayloadToServer);
+
+            roles = new Roles(baseSdk, request, expectedHost, organization.id);
+            promise = roles.create(organization.id, newRolePayload);
+          });
+
+          it('formats the role payload', function() {
+            return promise.then(() => {
+              expect(toSnakeCase).to.be.calledWith(newRolePayload);
+            });
+          });
+
+          it('posts the role to the server', function() {
+            expect(request.post).to.be.calledOnce;
+            expect(request.post).to.be.calledWith(
+              `${expectedHost}/roles`,
+              newRolePayloadToServer
+            );
+          });
+
+          it('returns a fulfilled promise', function() {
+            return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
+              expectedRole
+            );
+          });
+
+          it('formats the role response', function() {
+            return promise.then(() => {
+              expect(toCamelCase).to.be.calledWith(expectedRoleFromServer);
+            });
+          });
+        }
+      );
+
+      context('when the organization ID is not provided', function() {
+        let roles;
+        let organization;
+        let expectedRole;
+        let expectedRoleFromServer;
+        let newRolePayload;
+        let newRolePayloadToServer;
+        let promise;
+        let request;
+        let toCamelCase;
+        let toSnakeCase;
+
+        beforeEach(function() {
+          organization = fixture.build('contxtOrganization');
+          expectedRole = fixture.build('contxtRole');
+          expectedRoleFromServer = fixture.build('contxtRole', expectedRole, {
+            fromServer: true
+          });
+          newRolePayload = {
+            name: expectedRole.name,
+            description: expectedRole.description
+          };
+
+          newRolePayloadToServer = {
+            name: newRolePayload.name,
+            description: newRolePayload.description
+          };
+
+          request = {
+            ...baseRequest,
+            post: sinon.stub().resolves(expectedRoleFromServer)
+          };
+          toCamelCase = sinon
+            .stub(objectUtils, 'toCamelCase')
+            .callsFake(() => expectedRole);
+
+          toSnakeCase = sinon
+            .stub(objectUtils, 'toSnakeCase')
+            .callsFake(() => newRolePayloadToServer);
+
+          roles = new Roles(baseSdk, request, expectedHost, organization.id);
+          promise = roles.create(organization.id, newRolePayload);
         });
 
-        return expect(promise).to.be.rejectedWith(
-          `A name is required to create a new role.`
-        );
-      });
-      it('without description it returns a rejected promise', function() {
-        const roles = new Roles(baseSdk, baseRequest, expectedHost);
-        const organization = fixture.build('contxtOrganization');
-        const promise = roles.create(organization.id, { name: 'winning' });
+        it('formats the role payload', function() {
+          return promise.then(() => {
+            expect(toSnakeCase).to.be.calledWith(newRolePayload);
+          });
+        });
 
-        return expect(promise).to.be.rejectedWith(
-          `A description is required to create a new role.`
-        );
+        it('posts the role to the server', function() {
+          expect(request.post).to.be.calledOnce;
+          expect(request.post).to.be.calledWith(
+            `${expectedHost}/roles`,
+            newRolePayloadToServer
+          );
+        });
+
+        it('returns a fulfilled promise', function() {
+          return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
+            expectedRole
+          );
+        });
+
+        it('formats the role response', function() {
+          return promise.then(() => {
+            expect(toCamelCase).to.be.calledWith(expectedRoleFromServer);
+          });
+        });
+      });
+
+      context('when the role does not have required properties', function() {
+        it('without name it returns a rejected promise', function() {
+          const organization = fixture.build('organization');
+          const roles = new Roles(
+            baseSdk,
+            baseRequest,
+            expectedHost,
+            organization.id
+          );
+          const promise = roles.create(null, {
+            description: 'winning'
+          });
+
+          return expect(promise).to.be.rejectedWith(
+            `A name is required to create a new role.`
+          );
+        });
+
+        it('without description it returns a rejected promise', function() {
+          const organization = fixture.build('organization');
+          const roles = new Roles(
+            baseSdk,
+            baseRequest,
+            expectedHost,
+            organization.id
+          );
+          const promise = roles.create(null, { name: 'winning' });
+
+          return expect(promise).to.be.rejectedWith(
+            `A description is required to create a new role.`
+          );
+        });
       });
     });
   });
 
   describe('delete', function() {
-    context('when the required information is provided', function() {
-      let role;
-      let organization;
-      let promise;
+    context('legacy API', function() {
+      context('when the required information is provided', function() {
+        let role;
+        let organization;
+        let promise;
 
-      beforeEach(function() {
-        organization = fixture.build('contxtOrganization');
-        role = fixture.build('contxtRole');
+        beforeEach(function() {
+          organization = fixture.build('contxtOrganization');
+          role = fixture.build('contxtRole');
 
-        const roles = new Roles(baseSdk, baseRequest, expectedHost);
-        promise = roles.delete(organization.id, role.id);
+          const roles = new Roles(baseSdk, baseRequest, expectedHost);
+          promise = roles.delete(organization.id, role.id);
+        });
+
+        it('returns a fulfilled promise', function() {
+          return expect(promise).to.be.fulfilled;
+        });
+
+        it('sends a delete request to delete the role', function() {
+          expect(baseRequest.delete).to.be.calledWith(
+            `${expectedHost}/organizations/${organization.id}/roles/${role.id}`
+          );
+        });
       });
 
-      it('returns a fulfilled promise', function() {
-        return expect(promise).to.be.fulfilled;
+      context('when the roleId is not provided', function() {
+        it('returns rejected promise', function() {
+          const roles = new Roles(baseSdk, baseRequest, expectedHost);
+          const organization = fixture.build('contxtOrganization');
+          const promise = roles.delete(organization.id);
+
+          return expect(promise).to.be.rejectedWith(
+            'A roleId is required for deleting a role.'
+          );
+        });
       });
 
-      it('sends a delete request to delete the role', function() {
-        expect(baseRequest.delete).to.be.calledWith(
-          `${expectedHost}/organizations/${organization.id}/roles/${role.id}`
-        );
+      context('when the organizationId is not provided', function() {
+        it('returns rejected promise', function() {
+          const roles = new Roles(baseSdk, baseRequest, expectedHost);
+          const promise = roles.delete();
+
+          return expect(promise).to.be.rejectedWith(
+            'An organizationId is required for deleting a role'
+          );
+        });
       });
     });
 
-    context('when the roleId is not provided', function() {
-      it('returns rejected promise', function() {
-        const roles = new Roles(baseSdk, baseRequest, expectedHost);
-        const organization = fixture.build('contxtOrganization');
-        const promise = roles.delete(organization.id);
+    context('tenant API', function() {
+      context(
+        'when the the organization ID and role ID are both provided',
+        function() {
+          let role;
+          let organization;
+          let promise;
 
-        return expect(promise).to.be.rejectedWith(
-          'A roleId is required for deleting a role.'
-        );
+          beforeEach(function() {
+            organization = fixture.build('organization');
+            role = fixture.build('contxtRole');
+
+            const roles = new Roles(
+              baseSdk,
+              baseRequest,
+              expectedHost,
+              organization.id
+            );
+            promise = roles.delete(organization.id, role.id);
+          });
+
+          it('returns a fulfilled promise', function() {
+            return expect(promise).to.be.fulfilled;
+          });
+
+          it('sends a delete request to delete the role', function() {
+            expect(baseRequest.delete).to.be.calledWith(
+              `${expectedHost}/roles/${role.id}`
+            );
+          });
+        }
+      );
+
+      context('when the organization ID is not provided', function() {
+        let role;
+        let organization;
+        let promise;
+
+        beforeEach(function() {
+          organization = fixture.build('organization');
+          role = fixture.build('contxtRole');
+
+          const roles = new Roles(
+            baseSdk,
+            baseRequest,
+            expectedHost,
+            organization.id
+          );
+          promise = roles.delete(organization.id, role.id);
+        });
+
+        it('returns a fulfilled promise', function() {
+          return expect(promise).to.be.fulfilled;
+        });
+
+        it('sends a delete request to delete the role', function() {
+          expect(baseRequest.delete).to.be.calledWith(
+            `${expectedHost}/roles/${role.id}`
+          );
+        });
       });
-    });
 
-    context('when the organizationId is not provided', function() {
-      it('returns rejected promise', function() {
-        const roles = new Roles(baseSdk, baseRequest, expectedHost);
-        const promise = roles.delete();
+      context('when the roleId is not provided', function() {
+        it('returns rejected promise', function() {
+          const organization = fixture.build('organization');
+          const roles = new Roles(
+            baseSdk,
+            baseRequest,
+            expectedHost,
+            organization.id
+          );
+          const promise = roles.delete(organization.id);
 
-        return expect(promise).to.be.rejectedWith(
-          'An organizationId is required for deleting a role'
-        );
+          return expect(promise).to.be.rejectedWith(
+            'A roleId is required for deleting a role.'
+          );
+        });
       });
     });
   });
 
   describe('getByOrganizationId', function() {
-    context('when the organizationId is provided', function() {
+    context('legacy API', function() {
+      context('when the organizationId is provided', function() {
+        let expectedRoles;
+        let rolesFromTheServer;
+        let expectedOrganizationId;
+        let promise;
+        let request;
+        let toCamelCase;
+
+        beforeEach(function() {
+          expectedOrganizationId = fixture.build('contxtOrganization').id;
+          expectedRoles = fixture.buildList(
+            'contxtRole',
+            faker.random.number({
+              min: 1,
+              max: 10
+            }),
+            {
+              organizationId: expectedOrganizationId
+            }
+          );
+          rolesFromTheServer = expectedRoles.map((role) =>
+            fixture.build('contxtRole', role, {
+              fromServer: true
+            })
+          );
+
+          request = {
+            ...baseRequest,
+            get: sinon.stub().resolves(rolesFromTheServer)
+          };
+          toCamelCase = sinon
+            .stub(objectUtils, 'toCamelCase')
+            .returns(expectedRoles);
+
+          const roles = new Roles(baseSdk, request, expectedHost);
+          promise = roles.getByOrganizationId(expectedOrganizationId);
+        });
+
+        it('gets the list of roles from the server', function() {
+          expect(request.get).to.be.calledWith(
+            `${expectedHost}/organizations/${expectedOrganizationId}/roles`
+          );
+        });
+
+        it('formats the list of roles', function() {
+          return promise.then(() => {
+            expect(toCamelCase).to.be.calledWith(rolesFromTheServer);
+          });
+        });
+
+        it('returns a fulfilled promise with the roles', function() {
+          return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
+            expectedRoles
+          );
+        });
+      });
+
+      context('when the organizationId is not provided', function() {
+        it('returns a rejected promise', function() {
+          const roles = new Roles(baseSdk, baseRequest, expectedHost);
+          const promise = roles.getByOrganizationId();
+
+          return expect(promise).to.be.rejectedWith(
+            'An organizationId is required for getting roles for an organization.'
+          );
+        });
+      });
+    });
+
+    context('tenant API', function() {
       let expectedRoles;
       let rolesFromTheServer;
       let expectedOrganizationId;
       let promise;
       let request;
+      let roles;
       let toCamelCase;
 
       beforeEach(function() {
-        expectedOrganizationId = fixture.build('contxtOrganization').id;
+        expectedOrganizationId = fixture.build('organization').id;
         expectedRoles = fixture.buildList(
           'contxtRole',
           faker.random.number({
@@ -439,37 +808,56 @@ describe('Coordinator/Roles', function() {
           .stub(objectUtils, 'toCamelCase')
           .returns(expectedRoles);
 
-        const roles = new Roles(baseSdk, request, expectedHost);
-        promise = roles.getByOrganizationId(expectedOrganizationId);
-      });
-
-      it('gets the list of roles from the server', function() {
-        expect(request.get).to.be.calledWith(
-          `${expectedHost}/organizations/${expectedOrganizationId}/roles`
+        roles = new Roles(
+          baseSdk,
+          request,
+          expectedHost,
+          expectedOrganizationId
         );
       });
 
-      it('formats the list of roles', function() {
-        return promise.then(() => {
-          expect(toCamelCase).to.be.calledWith(rolesFromTheServer);
+      context('when the organizationId is provided', function() {
+        beforeEach(function() {
+          promise = roles.getByOrganizationId(expectedOrganizationId);
+        });
+
+        it('gets the list of roles from the server', function() {
+          expect(request.get).to.be.calledWith(`${expectedHost}/roles`);
+        });
+
+        it('formats the list of roles', function() {
+          return promise.then(() => {
+            expect(toCamelCase).to.be.calledWith(rolesFromTheServer);
+          });
+        });
+
+        it('returns a fulfilled promise with the roles', function() {
+          return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
+            expectedRoles
+          );
         });
       });
 
-      it('returns a fulfilled promise with the roles', function() {
-        return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
-          expectedRoles
-        );
-      });
-    });
+      context('when the organizationId is not provided', function() {
+        beforeEach(function() {
+          promise = roles.getByOrganizationId();
+        });
 
-    context('when the organizationId is not provided', function() {
-      it('returns a rejected promise', function() {
-        const roles = new Roles(baseSdk, baseRequest, expectedHost);
-        const promise = roles.getByOrganizationId();
+        it('gets the list of roles from the server', function() {
+          expect(request.get).to.be.calledWith(`${expectedHost}/roles`);
+        });
 
-        return expect(promise).to.be.rejectedWith(
-          'An organizationId is required for getting roles for an organization.'
-        );
+        it('formats the list of roles', function() {
+          return promise.then(() => {
+            expect(toCamelCase).to.be.calledWith(rolesFromTheServer);
+          });
+        });
+
+        it('returns a fulfilled promise with the roles', function() {
+          return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
+            expectedRoles
+          );
+        });
       });
     });
   });

--- a/src/coordinator/users.js
+++ b/src/coordinator/users.js
@@ -54,11 +54,13 @@ class Users {
    * @param {Object} sdk An instance of the SDK so the module can communicate with other modules
    * @param {Object} request An instance of the request module tied to this module's audience.
    * @param {string} baseUrl The base URL provided by the parent module
+   * @param {string} [organizationId] The organization ID to be used in tenant url requests
    */
-  constructor(sdk, request, baseUrl) {
+  constructor(sdk, request, baseUrl, organizationId = null) {
     this._baseUrl = baseUrl;
     this._request = request;
     this._sdk = sdk;
+    this._organizationId = organizationId;
   }
 
   /**
@@ -272,7 +274,8 @@ class Users {
   /**
    * Gets a list of users for a contxt organization
    *
-   * API Endpoint: '/organizations/:organizationId/users'
+   * Legacy API Endpoint: '/organizations/:organizationId/users'
+   * API Endpoint: '/users'
    * Method: GET
    *
    * @param {string} organizationId The ID of the organization
@@ -288,6 +291,12 @@ class Users {
    *   .catch((err) => console.log(err));
    */
   getByOrganizationId(organizationId) {
+    if (this._organizationId) {
+      return this._request
+        .get(`${this._baseUrl}/users`)
+        .then((orgUsers) => toCamelCase(orgUsers));
+    }
+
     if (!organizationId) {
       return Promise.reject(
         new Error(
@@ -305,7 +314,8 @@ class Users {
    * Creates a new contxt user, adds them to an organization, and
    * sends them an email invite link to do final account setup.
    *
-   * API Endpoint: '/organizations/:organizationId/users'
+   * Legacy API Endpoint: '/organizations/:organizationId/users'
+   * API Endpoint: '/users'
    * Method: POST
    *
    * Note: Only valid for web users using auth0WebAuth session type
@@ -336,6 +346,24 @@ class Users {
    *   .catch((err) => console.log(err));
    */
   invite(organizationId, user = {}) {
+    if (this._organizationId) {
+      const requiredFields = ['email', 'firstName', 'lastName', 'redirectUrl'];
+
+      for (let i = 0; requiredFields.length > i; i++) {
+        const field = requiredFields[i];
+
+        if (!user[field]) {
+          return Promise.reject(
+            new Error(`A ${field} is required to create a new user.`)
+          );
+        }
+      }
+
+      return this._request
+        .post(`${this._baseUrl}/users`, toSnakeCase(user))
+        .then((response) => toCamelCase(response));
+    }
+
     if (!organizationId) {
       return Promise.reject(
         new Error('An organization ID is required for inviting a new user')
@@ -365,7 +393,8 @@ class Users {
   /**
    * Removes a user from an organization
    *
-   * API Endpoint: '/organizations/:organizationId/users/:userId'
+   * Legacy API Endpoint: '/organizations/:organizationId/users/:userId'
+   * API Endpoint: '/users/:userId'
    * Method: DELETE
    *
    * @param {string} organizationId The ID of the organization
@@ -381,6 +410,18 @@ class Users {
    *   .catch((err) => console.log(err));
    */
   remove(organizationId, userId) {
+    if (this._organizationId) {
+      if (!userId) {
+        return Promise.reject(
+          new Error(
+            'A user ID is required for removing a user from an organization'
+          )
+        );
+      }
+
+      return this._request.delete(`${this._baseUrl}/users/${userId}`);
+    }
+
     if (!organizationId) {
       return Promise.reject(
         new Error(

--- a/src/coordinator/users.js
+++ b/src/coordinator/users.js
@@ -278,7 +278,7 @@ class Users {
    * API Endpoint: '/users'
    * Method: GET
    *
-   * @param {string} organizationId The ID of the organization
+   * @param {string} organizationId The ID of the organization, optional when using the tenant API and an organization ID has been set
    *
    * @returns {Promise}
    * @fulfill {ContxtUser[]} List of users for a contxt organization
@@ -320,7 +320,7 @@ class Users {
    *
    * Note: Only valid for web users using auth0WebAuth session type
    *
-   * @param {string} organizationId The ID of the organization
+   * @param {string} organizationId The ID of the organization, optional when using the tenant API and an organization ID has been set
    * @param {Object} user
    * @param {string} user.email The email address of the new user
    * @param {string} user.firstName The first name of the new user
@@ -397,7 +397,7 @@ class Users {
    * API Endpoint: '/users/:userId'
    * Method: DELETE
    *
-   * @param {string} organizationId The ID of the organization
+   * @param {string} organizationId The ID of the organization, optional when using the tenant API and an organization ID has been set
    * @param {string} userId The ID of the user
    *
    * @returns {Promise}

--- a/src/coordinator/users.spec.js
+++ b/src/coordinator/users.spec.js
@@ -31,7 +31,7 @@ describe('Coordinator/Users', function() {
   });
 
   describe('constructor', function() {
-    context('when organization ID is provided', function() {
+    context('when an organization ID is provided', function() {
       let organizationId;
       let users;
 
@@ -58,7 +58,7 @@ describe('Coordinator/Users', function() {
       });
     });
 
-    context('when organization ID is not provided', function() {
+    context('when an organization ID is not provided', function() {
       let users;
 
       beforeEach(function() {
@@ -77,7 +77,7 @@ describe('Coordinator/Users', function() {
         expect(users._sdk).to.deep.equal(baseSdk);
       });
 
-      it('sets the organization ID for the class instance', function() {
+      it('sets the organization ID for the class instance to null', function() {
         expect(users._organizationId).to.equal(null);
       });
     });
@@ -781,57 +781,56 @@ describe('Coordinator/Users', function() {
     });
 
     context('tenant API', function() {
-      context('when all the required parameters are provided', function() {
-        let organization;
-        let newUserPayload;
-        let newUserPayloadToServer;
-        let expectedNewUser;
-        let newUserFromServer;
-        let promise;
-        let request;
-        let toCamelCase;
-        let toSnakeCase;
+      let organization;
+      let newUserPayload;
+      let newUserPayloadToServer;
+      let expectedNewUser;
+      let newUserFromServer;
+      let promise;
+      let request;
+      let toCamelCase;
+      let toSnakeCase;
+      let users;
 
+      beforeEach(function() {
+        organization = fixture.build('organization');
+
+        expectedNewUser = fixture.build('contxtUser');
+        newUserFromServer = fixture.build('contxtUser', expectedNewUser, {
+          fromServer: true
+        });
+
+        newUserPayload = {
+          email: expectedNewUser.email,
+          firstName: expectedNewUser.firstName,
+          lastName: expectedNewUser.lastName,
+          redirectUrl: faker.internet.url()
+        };
+
+        newUserPayloadToServer = {
+          email: newUserPayload.email,
+          first_name: newUserPayload.firstName,
+          last_name: newUserPayload.lastName,
+          redirect_url: newUserPayload.redirectUrl
+        };
+
+        request = {
+          ...baseRequest,
+          post: sinon.stub().resolves(newUserFromServer)
+        };
+        toCamelCase = sinon
+          .stub(objectUtils, 'toCamelCase')
+          .callsFake(() => expectedNewUser);
+
+        toSnakeCase = sinon
+          .stub(objectUtils, 'toSnakeCase')
+          .callsFake(() => newUserPayloadToServer);
+
+        users = new Users(baseSdk, request, expectedHost, organization.id);
+      });
+
+      context('when all the parameters are provided', function() {
         beforeEach(function() {
-          organization = fixture.build('organization');
-
-          expectedNewUser = fixture.build('contxtUser');
-          newUserFromServer = fixture.build('contxtUser', expectedNewUser, {
-            fromServer: true
-          });
-
-          newUserPayload = {
-            email: expectedNewUser.email,
-            firstName: expectedNewUser.firstName,
-            lastName: expectedNewUser.lastName,
-            redirectUrl: faker.internet.url()
-          };
-
-          newUserPayloadToServer = {
-            email: newUserPayload.email,
-            first_name: newUserPayload.firstName,
-            last_name: newUserPayload.lastName,
-            redirect_url: newUserPayload.redirectUrl
-          };
-
-          request = {
-            ...baseRequest,
-            post: sinon.stub().resolves(newUserFromServer)
-          };
-          toCamelCase = sinon
-            .stub(objectUtils, 'toCamelCase')
-            .callsFake(() => expectedNewUser);
-
-          toSnakeCase = sinon
-            .stub(objectUtils, 'toSnakeCase')
-            .callsFake(() => newUserPayloadToServer);
-
-          const users = new Users(
-            baseSdk,
-            request,
-            expectedHost,
-            organization.id
-          );
           promise = users.invite(organization.id, newUserPayload);
         });
 
@@ -862,57 +861,8 @@ describe('Coordinator/Users', function() {
       });
 
       context('when the organization ID is not provided', function() {
-        let organization;
-        let newUserPayload;
-        let newUserPayloadToServer;
-        let expectedNewUser;
-        let newUserFromServer;
-        let promise;
-        let request;
-        let toCamelCase;
-        let toSnakeCase;
-
         beforeEach(function() {
-          organization = fixture.build('organization');
-
-          expectedNewUser = fixture.build('contxtUser');
-          newUserFromServer = fixture.build('contxtUser', expectedNewUser, {
-            fromServer: true
-          });
-
-          newUserPayload = {
-            email: expectedNewUser.email,
-            firstName: expectedNewUser.firstName,
-            lastName: expectedNewUser.lastName,
-            redirectUrl: faker.internet.url()
-          };
-
-          newUserPayloadToServer = {
-            email: newUserPayload.email,
-            first_name: newUserPayload.firstName,
-            last_name: newUserPayload.lastName,
-            redirect_url: newUserPayload.redirectUrl
-          };
-
-          request = {
-            ...baseRequest,
-            post: sinon.stub().resolves(newUserFromServer)
-          };
-          toCamelCase = sinon
-            .stub(objectUtils, 'toCamelCase')
-            .callsFake(() => expectedNewUser);
-
-          toSnakeCase = sinon
-            .stub(objectUtils, 'toSnakeCase')
-            .callsFake(() => newUserPayloadToServer);
-
-          const users = new Users(
-            baseSdk,
-            request,
-            expectedHost,
-            organization.id
-          );
-          promise = users.invite(organization.id, newUserPayload);
+          promise = users.invite(null, newUserPayload);
         });
 
         it('formats the user payload', function() {
@@ -1029,21 +979,20 @@ describe('Coordinator/Users', function() {
     });
 
     context('tenant API', function() {
-      context('when all required parameters are provided', function() {
-        let organization;
-        let user;
-        let promise;
+      let organization;
+      let user;
+      let users;
+      let promise;
 
+      beforeEach(function() {
+        organization = fixture.build('organization');
+        user = fixture.build('contxtUser');
+
+        users = new Users(baseSdk, baseRequest, expectedHost, organization.id);
+      });
+
+      context('when all parameters are provided', function() {
         beforeEach(function() {
-          organization = fixture.build('organization');
-          user = fixture.build('contxtUser');
-
-          const users = new Users(
-            baseSdk,
-            baseRequest,
-            expectedHost,
-            organization.id
-          );
           promise = users.remove(organization.id, user.id);
         });
 
@@ -1059,21 +1008,8 @@ describe('Coordinator/Users', function() {
       });
 
       context('when the organization ID is not provided', function() {
-        let organization;
-        let user;
-        let promise;
-
         beforeEach(function() {
-          organization = fixture.build('organization');
-          user = fixture.build('contxtUser');
-
-          const users = new Users(
-            baseSdk,
-            baseRequest,
-            expectedHost,
-            organization.id
-          );
-          promise = users.remove(organization.id, user.id);
+          promise = users.remove(null, user.id);
         });
 
         it('sends a request to remove the user from the organization', function() {
@@ -1096,7 +1032,7 @@ describe('Coordinator/Users', function() {
             expectedHost,
             organization.id
           );
-          const promise = users.remove(faker.random.uuid(), null);
+          const promise = users.remove(organization.id, null);
 
           return expect(promise).to.be.rejectedWith(
             'A user ID is required for removing a user from an organization'

--- a/src/coordinator/users.spec.js
+++ b/src/coordinator/users.spec.js
@@ -31,22 +31,55 @@ describe('Coordinator/Users', function() {
   });
 
   describe('constructor', function() {
-    let users;
+    context('when organization ID is provided', function() {
+      let organizationId;
+      let users;
 
-    beforeEach(function() {
-      users = new Users(baseSdk, baseRequest, expectedHost);
+      beforeEach(function() {
+        organizationId = fixture.build('organization').id;
+
+        users = new Users(baseSdk, baseRequest, expectedHost, organizationId);
+      });
+
+      it('sets a base url for the class instance', function() {
+        expect(users._baseUrl).to.equal(expectedHost);
+      });
+
+      it('appends the supplied request module to the class instance', function() {
+        expect(users._request).to.deep.equal(baseRequest);
+      });
+
+      it('appends the supplied sdk to the class instance', function() {
+        expect(users._sdk).to.deep.equal(baseSdk);
+      });
+
+      it('sets the organization ID for the class instance', function() {
+        expect(users._organizationId).to.equal(organizationId);
+      });
     });
 
-    it('sets a base url for the class instance', function() {
-      expect(users._baseUrl).to.equal(expectedHost);
-    });
+    context('when organization ID is not provided', function() {
+      let users;
 
-    it('appends the supplied request module to the class instance', function() {
-      expect(users._request).to.deep.equal(baseRequest);
-    });
+      beforeEach(function() {
+        users = new Users(baseSdk, baseRequest, expectedHost);
+      });
 
-    it('appends the supplied sdk to the class instance', function() {
-      expect(users._sdk).to.deep.equal(baseSdk);
+      it('sets a base url for the class instance', function() {
+        expect(users._baseUrl).to.equal(expectedHost);
+      });
+
+      it('appends the supplied request module to the class instance', function() {
+        expect(users._request).to.deep.equal(baseRequest);
+      });
+
+      it('appends the supplied sdk to the class instance', function() {
+        expect(users._sdk).to.deep.equal(baseSdk);
+      });
+
+      it('sets the organization ID for the class instance', function() {
+        expect(users._organizationId).to.equal(null);
+      });
     });
   });
 
@@ -479,13 +512,79 @@ describe('Coordinator/Users', function() {
   });
 
   describe('getByOrganizationId', function() {
-    context('the organization ID is provided', function() {
+    context('legacy API', function() {
+      context('the organization ID is provided', function() {
+        let expectedOrganizationId;
+        let expectedOrganizationUsers;
+        let organizationUsersFromServer;
+        let promise;
+        let request;
+        let toCamelCase;
+
+        beforeEach(function() {
+          expectedOrganizationId = faker.random.uuid();
+
+          expectedOrganizationUsers = fixture.buildList(
+            'contxtUser',
+            faker.random.number({ min: 1, max: 10 })
+          );
+
+          organizationUsersFromServer = expectedOrganizationUsers.map((user) =>
+            fixture.build('contxtUser', user, { fromServer: true })
+          );
+
+          request = {
+            ...baseRequest,
+            get: sinon.stub().resolves(organizationUsersFromServer)
+          };
+
+          toCamelCase = sinon
+            .stub(objectUtils, 'toCamelCase')
+            .returns(expectedOrganizationUsers);
+
+          const users = new Users(baseSdk, request, expectedHost);
+          promise = users.getByOrganizationId(expectedOrganizationId);
+        });
+
+        it('gets the user list from the server', function() {
+          expect(request.get).to.be.calledWith(
+            `${expectedHost}/organizations/${expectedOrganizationId}/users`
+          );
+        });
+
+        it('formats the list of organization users', function() {
+          return promise.then(() => {
+            expect(toCamelCase).to.be.calledWith(organizationUsersFromServer);
+          });
+        });
+
+        it('returns the list of users by requested organization', function() {
+          return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
+            expectedOrganizationUsers
+          );
+        });
+      });
+
+      context('the organization ID is not provided', function() {
+        it('throws an error', function() {
+          const users = new Users(baseSdk, baseRequest, expectedHost);
+          const promise = users.getByOrganizationId();
+
+          return expect(promise).to.be.rejectedWith(
+            'An organization ID is required for getting a list of users for an organization'
+          );
+        });
+      });
+    });
+
+    context('tenant API', function() {
       let expectedOrganizationId;
       let expectedOrganizationUsers;
       let organizationUsersFromServer;
       let promise;
       let request;
       let toCamelCase;
+      let users;
 
       beforeEach(function() {
         expectedOrganizationId = faker.random.uuid();
@@ -508,198 +607,501 @@ describe('Coordinator/Users', function() {
           .stub(objectUtils, 'toCamelCase')
           .returns(expectedOrganizationUsers);
 
-        const users = new Users(baseSdk, request, expectedHost);
-        promise = users.getByOrganizationId(expectedOrganizationId);
-      });
-
-      it('gets the user list from the server', function() {
-        expect(request.get).to.be.calledWith(
-          `${expectedHost}/organizations/${expectedOrganizationId}/users`
+        users = new Users(
+          baseSdk,
+          request,
+          expectedHost,
+          expectedOrganizationId
         );
       });
 
-      it('formats the list of organization users', function() {
-        return promise.then(() => {
-          expect(toCamelCase).to.be.calledWith(organizationUsersFromServer);
+      context('the organization ID is provided', function() {
+        beforeEach(function() {
+          promise = users.getByOrganizationId(expectedOrganizationId);
+        });
+
+        it('gets the user list from the server', function() {
+          expect(request.get).to.be.calledWith(`${expectedHost}/users`);
+        });
+
+        it('formats the list of organization users', function() {
+          return promise.then(() => {
+            expect(toCamelCase).to.be.calledWith(organizationUsersFromServer);
+          });
+        });
+
+        it('returns the list of users by requested organization', function() {
+          return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
+            expectedOrganizationUsers
+          );
         });
       });
 
-      it('returns the list of users by requested organization', function() {
-        return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
-          expectedOrganizationUsers
-        );
-      });
-    });
+      context('the organization ID is not provided', function() {
+        beforeEach(function() {
+          promise = users.getByOrganizationId();
+        });
 
-    context('the organization ID is not provided', function() {
-      it('throws an error', function() {
-        const users = new Users(baseSdk, baseRequest, expectedHost);
-        const promise = users.getByOrganizationId();
+        it('gets the user list from the server', function() {
+          expect(request.get).to.be.calledWith(`${expectedHost}/users`);
+        });
 
-        return expect(promise).to.be.rejectedWith(
-          'An organization ID is required for getting a list of users for an organization'
-        );
+        it('formats the list of organization users', function() {
+          return promise.then(() => {
+            expect(toCamelCase).to.be.calledWith(organizationUsersFromServer);
+          });
+        });
+
+        it('returns the list of users by requested organization', function() {
+          return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
+            expectedOrganizationUsers
+          );
+        });
       });
     });
   });
 
   describe('invite', function() {
-    context('when all the required parameters are provided', function() {
-      let organization;
-      let newUserPayload;
-      let newUserPayloadToServer;
-      let expectedNewUser;
-      let newUserFromServer;
-      let promise;
-      let request;
-      let toCamelCase;
-      let toSnakeCase;
+    context('legacy API', function() {
+      context('when all the required parameters are provided', function() {
+        let organization;
+        let newUserPayload;
+        let newUserPayloadToServer;
+        let expectedNewUser;
+        let newUserFromServer;
+        let promise;
+        let request;
+        let toCamelCase;
+        let toSnakeCase;
 
-      beforeEach(function() {
-        organization = fixture.build('contxtOrganization');
+        beforeEach(function() {
+          organization = fixture.build('contxtOrganization');
 
-        expectedNewUser = fixture.build('contxtUser');
-        newUserFromServer = fixture.build('contxtUser', expectedNewUser, {
-          fromServer: true
-        });
+          expectedNewUser = fixture.build('contxtUser');
+          newUserFromServer = fixture.build('contxtUser', expectedNewUser, {
+            fromServer: true
+          });
 
-        newUserPayload = {
-          email: expectedNewUser.email,
-          firstName: expectedNewUser.firstName,
-          lastName: expectedNewUser.lastName,
-          redirectUrl: faker.internet.url()
-        };
-
-        newUserPayloadToServer = {
-          email: newUserPayload.email,
-          first_name: newUserPayload.firstName,
-          last_name: newUserPayload.lastName,
-          redirect_url: newUserPayload.redirectUrl
-        };
-
-        request = {
-          ...baseRequest,
-          post: sinon.stub().resolves(newUserFromServer)
-        };
-        toCamelCase = sinon
-          .stub(objectUtils, 'toCamelCase')
-          .callsFake(() => expectedNewUser);
-
-        toSnakeCase = sinon
-          .stub(objectUtils, 'toSnakeCase')
-          .callsFake(() => newUserPayloadToServer);
-
-        const users = new Users(baseSdk, request, expectedHost);
-        promise = users.invite(organization.id, newUserPayload);
-      });
-
-      it('formats the user payload', function() {
-        return promise.then(() => {
-          expect(toSnakeCase).to.be.calledWith(newUserPayload);
-        });
-      });
-
-      it('posts the new user to the server', function() {
-        expect(request.post).to.be.calledWith(
-          `${expectedHost}/organizations/${organization.id}/users`,
-          newUserPayloadToServer
-        );
-      });
-
-      it('formats the user response', function() {
-        return promise.then(() => {
-          expect(toCamelCase).to.be.calledWith(newUserFromServer);
-        });
-      });
-
-      it('returns a fulfilled promise with the new user', function() {
-        return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
-          expectedNewUser
-        );
-      });
-    });
-
-    context('when the organization ID is not provided', function() {
-      it('throws an error', function() {
-        const users = new Users(baseSdk, baseRequest, expectedHost);
-        const promise = users.invite();
-
-        return expect(promise).to.be.rejectedWith(
-          'An organization ID is required for inviting a new user'
-        );
-      });
-    });
-
-    context('when there is missing required user information', function() {
-      const requiredFields = ['email', 'firstName', 'lastName', 'redirectUrl'];
-
-      requiredFields.forEach((field) => {
-        it(`it throws an error when ${field} is missing`, function() {
-          const newUserPayload = {
-            email: faker.internet.email(),
-            firstName: faker.name.firstName(),
-            lastName: faker.name.lastName(),
+          newUserPayload = {
+            email: expectedNewUser.email,
+            firstName: expectedNewUser.firstName,
+            lastName: expectedNewUser.lastName,
             redirectUrl: faker.internet.url()
           };
 
-          const users = new Users(baseSdk, baseRequest, expectedHost);
-          const promise = users.invite(
-            faker.random.uuid(),
-            omit(newUserPayload, [field])
+          newUserPayloadToServer = {
+            email: newUserPayload.email,
+            first_name: newUserPayload.firstName,
+            last_name: newUserPayload.lastName,
+            redirect_url: newUserPayload.redirectUrl
+          };
+
+          request = {
+            ...baseRequest,
+            post: sinon.stub().resolves(newUserFromServer)
+          };
+          toCamelCase = sinon
+            .stub(objectUtils, 'toCamelCase')
+            .callsFake(() => expectedNewUser);
+
+          toSnakeCase = sinon
+            .stub(objectUtils, 'toSnakeCase')
+            .callsFake(() => newUserPayloadToServer);
+
+          const users = new Users(baseSdk, request, expectedHost);
+          promise = users.invite(organization.id, newUserPayload);
+        });
+
+        it('formats the user payload', function() {
+          return promise.then(() => {
+            expect(toSnakeCase).to.be.calledWith(newUserPayload);
+          });
+        });
+
+        it('posts the new user to the server', function() {
+          expect(request.post).to.be.calledWith(
+            `${expectedHost}/organizations/${organization.id}/users`,
+            newUserPayloadToServer
           );
+        });
+
+        it('formats the user response', function() {
+          return promise.then(() => {
+            expect(toCamelCase).to.be.calledWith(newUserFromServer);
+          });
+        });
+
+        it('returns a fulfilled promise with the new user', function() {
+          return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
+            expectedNewUser
+          );
+        });
+      });
+
+      context('when the organization ID is not provided', function() {
+        it('throws an error', function() {
+          const users = new Users(baseSdk, baseRequest, expectedHost);
+          const promise = users.invite();
 
           return expect(promise).to.be.rejectedWith(
-            `A ${field} is required to create a new user.`
+            'An organization ID is required for inviting a new user'
           );
+        });
+      });
+
+      context('when there is missing required user information', function() {
+        const requiredFields = [
+          'email',
+          'firstName',
+          'lastName',
+          'redirectUrl'
+        ];
+
+        requiredFields.forEach((field) => {
+          it(`it throws an error when ${field} is missing`, function() {
+            const newUserPayload = {
+              email: faker.internet.email(),
+              firstName: faker.name.firstName(),
+              lastName: faker.name.lastName(),
+              redirectUrl: faker.internet.url()
+            };
+
+            const users = new Users(baseSdk, baseRequest, expectedHost);
+            const promise = users.invite(
+              faker.random.uuid(),
+              omit(newUserPayload, [field])
+            );
+
+            return expect(promise).to.be.rejectedWith(
+              `A ${field} is required to create a new user.`
+            );
+          });
+        });
+      });
+    });
+
+    context('tenant API', function() {
+      context('when all the required parameters are provided', function() {
+        let organization;
+        let newUserPayload;
+        let newUserPayloadToServer;
+        let expectedNewUser;
+        let newUserFromServer;
+        let promise;
+        let request;
+        let toCamelCase;
+        let toSnakeCase;
+
+        beforeEach(function() {
+          organization = fixture.build('organization');
+
+          expectedNewUser = fixture.build('contxtUser');
+          newUserFromServer = fixture.build('contxtUser', expectedNewUser, {
+            fromServer: true
+          });
+
+          newUserPayload = {
+            email: expectedNewUser.email,
+            firstName: expectedNewUser.firstName,
+            lastName: expectedNewUser.lastName,
+            redirectUrl: faker.internet.url()
+          };
+
+          newUserPayloadToServer = {
+            email: newUserPayload.email,
+            first_name: newUserPayload.firstName,
+            last_name: newUserPayload.lastName,
+            redirect_url: newUserPayload.redirectUrl
+          };
+
+          request = {
+            ...baseRequest,
+            post: sinon.stub().resolves(newUserFromServer)
+          };
+          toCamelCase = sinon
+            .stub(objectUtils, 'toCamelCase')
+            .callsFake(() => expectedNewUser);
+
+          toSnakeCase = sinon
+            .stub(objectUtils, 'toSnakeCase')
+            .callsFake(() => newUserPayloadToServer);
+
+          const users = new Users(
+            baseSdk,
+            request,
+            expectedHost,
+            organization.id
+          );
+          promise = users.invite(organization.id, newUserPayload);
+        });
+
+        it('formats the user payload', function() {
+          return promise.then(() => {
+            expect(toSnakeCase).to.be.calledWith(newUserPayload);
+          });
+        });
+
+        it('posts the new user to the server', function() {
+          expect(request.post).to.be.calledWith(
+            `${expectedHost}/users`,
+            newUserPayloadToServer
+          );
+        });
+
+        it('formats the user response', function() {
+          return promise.then(() => {
+            expect(toCamelCase).to.be.calledWith(newUserFromServer);
+          });
+        });
+
+        it('returns a fulfilled promise with the new user', function() {
+          return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
+            expectedNewUser
+          );
+        });
+      });
+
+      context('when the organization ID is not provided', function() {
+        let organization;
+        let newUserPayload;
+        let newUserPayloadToServer;
+        let expectedNewUser;
+        let newUserFromServer;
+        let promise;
+        let request;
+        let toCamelCase;
+        let toSnakeCase;
+
+        beforeEach(function() {
+          organization = fixture.build('organization');
+
+          expectedNewUser = fixture.build('contxtUser');
+          newUserFromServer = fixture.build('contxtUser', expectedNewUser, {
+            fromServer: true
+          });
+
+          newUserPayload = {
+            email: expectedNewUser.email,
+            firstName: expectedNewUser.firstName,
+            lastName: expectedNewUser.lastName,
+            redirectUrl: faker.internet.url()
+          };
+
+          newUserPayloadToServer = {
+            email: newUserPayload.email,
+            first_name: newUserPayload.firstName,
+            last_name: newUserPayload.lastName,
+            redirect_url: newUserPayload.redirectUrl
+          };
+
+          request = {
+            ...baseRequest,
+            post: sinon.stub().resolves(newUserFromServer)
+          };
+          toCamelCase = sinon
+            .stub(objectUtils, 'toCamelCase')
+            .callsFake(() => expectedNewUser);
+
+          toSnakeCase = sinon
+            .stub(objectUtils, 'toSnakeCase')
+            .callsFake(() => newUserPayloadToServer);
+
+          const users = new Users(
+            baseSdk,
+            request,
+            expectedHost,
+            organization.id
+          );
+          promise = users.invite(organization.id, newUserPayload);
+        });
+
+        it('formats the user payload', function() {
+          return promise.then(() => {
+            expect(toSnakeCase).to.be.calledWith(newUserPayload);
+          });
+        });
+
+        it('posts the new user to the server', function() {
+          expect(request.post).to.be.calledWith(
+            `${expectedHost}/users`,
+            newUserPayloadToServer
+          );
+        });
+
+        it('formats the user response', function() {
+          return promise.then(() => {
+            expect(toCamelCase).to.be.calledWith(newUserFromServer);
+          });
+        });
+
+        it('returns a fulfilled promise with the new user', function() {
+          return expect(promise).to.be.fulfilled.and.to.eventually.deep.equal(
+            expectedNewUser
+          );
+        });
+      });
+
+      context('when there is missing required user information', function() {
+        const requiredFields = [
+          'email',
+          'firstName',
+          'lastName',
+          'redirectUrl'
+        ];
+
+        requiredFields.forEach((field) => {
+          it(`it throws an error when ${field} is missing`, function() {
+            const organization = fixture.build('organization');
+            const newUserPayload = {
+              email: faker.internet.email(),
+              firstName: faker.name.firstName(),
+              lastName: faker.name.lastName(),
+              redirectUrl: faker.internet.url()
+            };
+
+            const users = new Users(
+              baseSdk,
+              baseRequest,
+              expectedHost,
+              organization.id
+            );
+            const promise = users.invite(
+              faker.random.uuid(),
+              omit(newUserPayload, [field])
+            );
+
+            return expect(promise).to.be.rejectedWith(
+              `A ${field} is required to create a new user.`
+            );
+          });
         });
       });
     });
   });
 
   describe('remove', function() {
-    context('when all required parameters are provided', function() {
-      let organization;
-      let user;
-      let promise;
+    context('legacy API', function() {
+      context('when all required parameters are provided', function() {
+        let organization;
+        let user;
+        let promise;
 
-      beforeEach(function() {
-        organization = fixture.build('contxtOrganization');
-        user = fixture.build('contxtUser');
+        beforeEach(function() {
+          organization = fixture.build('contxtOrganization');
+          user = fixture.build('contxtUser');
 
-        const users = new Users(baseSdk, baseRequest, expectedHost);
-        promise = users.remove(organization.id, user.id);
+          const users = new Users(baseSdk, baseRequest, expectedHost);
+          promise = users.remove(organization.id, user.id);
+        });
+
+        it('sends a request to remove the user from the organization', function() {
+          expect(baseRequest.delete).to.be.calledWith(
+            `${expectedHost}/organizations/${organization.id}/users/${user.id}`
+          );
+        });
+
+        it('returns a resolved promise', function() {
+          return expect(promise).to.be.fulfilled;
+        });
       });
 
-      it('sends a request to remove the user from the organization', function() {
-        expect(baseRequest.delete).to.be.calledWith(
-          `${expectedHost}/organizations/${organization.id}/users/${user.id}`
-        );
+      context('when the organization ID is not provided', function() {
+        it('throws an error', function() {
+          const users = new Users(baseSdk, baseRequest, expectedHost);
+          const promise = users.remove(null, faker.random.uuid());
+
+          return expect(promise).to.be.rejectedWith(
+            'An organization ID is required for removing a user from an organization'
+          );
+        });
       });
 
-      it('returns a resolved promise', function() {
-        return expect(promise).to.be.fulfilled;
+      context('when the user ID is not provided', function() {
+        it('throws an error', function() {
+          const users = new Users(baseSdk, baseRequest, expectedHost);
+          const promise = users.remove(faker.random.uuid(), null);
+
+          return expect(promise).to.be.rejectedWith(
+            'A user ID is required for removing a user from an organization'
+          );
+        });
       });
     });
 
-    context('when the organization ID is not provided', function() {
-      it('throws an error', function() {
-        const users = new Users(baseSdk, baseRequest, expectedHost);
-        const promise = users.remove(null, faker.random.uuid());
+    context('tenant API', function() {
+      context('when all required parameters are provided', function() {
+        let organization;
+        let user;
+        let promise;
 
-        return expect(promise).to.be.rejectedWith(
-          'An organization ID is required for removing a user from an organization'
-        );
+        beforeEach(function() {
+          organization = fixture.build('organization');
+          user = fixture.build('contxtUser');
+
+          const users = new Users(
+            baseSdk,
+            baseRequest,
+            expectedHost,
+            organization.id
+          );
+          promise = users.remove(organization.id, user.id);
+        });
+
+        it('sends a request to remove the user from the organization', function() {
+          expect(baseRequest.delete).to.be.calledWith(
+            `${expectedHost}/users/${user.id}`
+          );
+        });
+
+        it('returns a resolved promise', function() {
+          return expect(promise).to.be.fulfilled;
+        });
       });
-    });
 
-    context('when the user ID is not provided', function() {
-      it('throws an error', function() {
-        const users = new Users(baseSdk, baseRequest, expectedHost);
-        const promise = users.remove(faker.random.uuid(), null);
+      context('when the organization ID is not provided', function() {
+        let organization;
+        let user;
+        let promise;
 
-        return expect(promise).to.be.rejectedWith(
-          'A user ID is required for removing a user from an organization'
-        );
+        beforeEach(function() {
+          organization = fixture.build('organization');
+          user = fixture.build('contxtUser');
+
+          const users = new Users(
+            baseSdk,
+            baseRequest,
+            expectedHost,
+            organization.id
+          );
+          promise = users.remove(organization.id, user.id);
+        });
+
+        it('sends a request to remove the user from the organization', function() {
+          expect(baseRequest.delete).to.be.calledWith(
+            `${expectedHost}/users/${user.id}`
+          );
+        });
+
+        it('returns a resolved promise', function() {
+          return expect(promise).to.be.fulfilled;
+        });
+      });
+
+      context('when the user ID is not provided', function() {
+        it('throws an error', function() {
+          const organization = fixture.build('organization');
+          const users = new Users(
+            baseSdk,
+            baseRequest,
+            expectedHost,
+            organization.id
+          );
+          const promise = users.remove(faker.random.uuid(), null);
+
+          return expect(promise).to.be.rejectedWith(
+            'A user ID is required for removing a user from an organization'
+          );
+        });
       });
     });
   });


### PR DESCRIPTION
## Why?

https://lineagelogistics.atlassian.net/browse/MOB-3121

## What changed?
- added a `setOrganizationId` method to the base `coordinator` module
  - `contxtSdk.coordinator.setOrganizationId`
  - setting an organization id on the coordinator module will then re-instantiate the coordinator sub-modules to use the appropriate tenancy-base urls
  - setting the organization id to `null` will then reset all the urls to the legacy endpoints
- updated all the coordinator submodules to accept the selected organization id and use the new tenancy-base urls (stripping out `/organizations/:organizationId` where appropriate
- kept the function API's basically the same
- updated tests

#### NOTE: You will see some repeated code in some of the functions. This is intentional on my part. I wanted to keep the logic basically the same where I could so all the error codes/error handling/logic would function the exact same as before. It could be DRYer but I choose to repeat some code for now, with the understanding that later it will be deleted when we fully deprecate the legacy APIs

#### TESTS: There are a lot of changes because of white space, ignoring white space changes should help

#### CHANGELOG: I went with a minor version bump since there is no breaking change on the API surface. However, I could also see this being a major version bump. Let me know what you think