### PR TITLE
Feature/asset framework list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [v2.3.0](http://github.com/ndustrialio/contxt-sdk-js/tree/v2.3.0) (2019-09-09)
+
+**Added**
+
+- Updated `Asset#getAllByOrganizationId`
+  - Added `options.includeTypeDescendents`, included descendents of the requested assetTypeId
+  - Added `options.includeMetricsId`, include the latest metrics value based on the id provided
+
 ## [v2.5.0](https://github.com/ndustrialio/contxt-sdk-js/pull/132) (2019-12-18)
 
 **Added**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [v2.3.0](http://github.com/ndustrialio/contxt-sdk-js/tree/v2.3.0) (2019-09-09)
+## [v2.6.0](http://github.com/ndustrialio/contxt-sdk-js/tree/v2.6.0) (2019-12-23)
 
 **Added**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
-## [v2.6.0](http://github.com/ndustrialio/contxt-sdk-js/tree/v2.6.0) (2019-12-23)
+## [v2.6.0](http://github.com/ndustrialio/contxt-sdk-js/tree/v2.6.0) (2019-12-27)
 
 **Added**
 
 - Updated `Asset#getAllByOrganizationId`
   - Added `options.includeTypeDescendents`, included descendents of the requested assetTypeId
-  - Added `options.includeMetricsId`, include the latest metrics value based on the id provided
+  - Added `options.includeMetricId`, include the latest metrics value based on the id provided
 
 ## [v2.5.0](https://github.com/ndustrialio/contxt-sdk-js/pull/132) (2019-12-18)
 

--- a/docs/Assets.md
+++ b/docs/Assets.md
@@ -140,6 +140,8 @@ Method: GET
 | [options.assetTypeId] | <code>string</code> | UUID of the asset type to use for filtering |
 | [options.limit] | <code>Number</code> | Maximum number of records to return per query |
 | [options.offset] | <code>Number</code> | How many records from the first record to start |
+| [options.includeTypeDescendents] | <code>boolean</code> | When true will look for all asset types that are descendendents from options.assetTypeId |
+| [options.includeMetricsId] | <code>boolean</code> | If asset has an associated metric value the latest metric will be returned. |
 
 **Example**  
 ```js

--- a/docs/Assets.md
+++ b/docs/Assets.md
@@ -141,7 +141,7 @@ Method: GET
 | [options.limit] | <code>Number</code> | Maximum number of records to return per query |
 | [options.offset] | <code>Number</code> | How many records from the first record to start |
 | [options.includeTypeDescendents] | <code>boolean</code> | When true will look for all asset types that are descendendents from options.assetTypeId |
-| [options.includeMetricsId] | <code>boolean</code> | If asset has an associated metric value the latest metric will be returned. |
+| [options.includeMetricId] | <code>string</code> | If asset has an associated metric value the latest metric will be returned. |
 
 **Example**  
 ```js

--- a/src/assets/index.js
+++ b/src/assets/index.js
@@ -187,7 +187,7 @@ class Assets {
    * @param {Number} [options.limit] Maximum number of records to return per query
    * @param {Number} [options.offset] How many records from the first record to start
    * @param {boolean} [options.includeTypeDescendents] When true will look for all asset types that are descendendents from options.assetTypeId
-   * @param {boolean} [options.includeMetricsId] If asset has an associated metric value the latest metric will be returned.
+   * @param {string} [options.includeMetricId] If asset has an associated metric value the latest metric will be returned.
    *
    * @returns {Promise}
    * @fulfill {AssetsFromServer}

--- a/src/assets/index.js
+++ b/src/assets/index.js
@@ -186,6 +186,8 @@ class Assets {
    * @param {string} [options.assetTypeId] UUID of the asset type to use for filtering
    * @param {Number} [options.limit] Maximum number of records to return per query
    * @param {Number} [options.offset] How many records from the first record to start
+   * @param {boolean} [options.includeTypeDescendents] When true will look for all asset types that are descendendents from options.assetTypeId
+   * @param {boolean} [options.includeMetricsId] If asset has an associated metric value the latest metric will be returned.
    *
    * @returns {Promise}
    * @fulfill {AssetsFromServer}


### PR DESCRIPTION
## Why?

For the health endpoints, we need to show the latest health status, and include anything that is a descendent from integrations asset_type.

## What changed?

When fetching assets, we now have more options to expand the payload.  Including metrics, and typ descendents