### PR TITLE
Updated docs and examples

### DIFF
--- a/docs/Auth0WebAuth.md
+++ b/docs/Auth0WebAuth.md
@@ -50,7 +50,7 @@ enabled in Auth0.
 import ContxtSdk from '@ndustrial/contxt-sdk';
 import history from '../services/history';
 
-const contxtSdk = new ContxtSDK({
+const contxtSdk = new ContxtSdk({
   config: {
     auth: {
       clientId: '<client id>',

--- a/docs/MachineAuth.md
+++ b/docs/MachineAuth.md
@@ -25,7 +25,7 @@ which are obtained from Auth0.
 ```js
 const ContxtSdk = require('@ndustrial/contxt-sdk');
 
-const contxtSdk = new ContxtSDK({
+const contxtSdk = new ContxtSdk({
   config: {
     auth: {
       clientId: '<client id>',

--- a/src/sessionTypes/auth0WebAuth.js
+++ b/src/sessionTypes/auth0WebAuth.js
@@ -43,7 +43,7 @@ import URL from 'url-parse';
  * import ContxtSdk from '@ndustrial/contxt-sdk';
  * import history from '../services/history';
  *
- * const contxtSdk = new ContxtSDK({
+ * const contxtSdk = new ContxtSdk({
  *   config: {
  *     auth: {
  *       clientId: '<client id>',

--- a/src/sessionTypes/machineAuth.js
+++ b/src/sessionTypes/machineAuth.js
@@ -18,7 +18,7 @@ import axios from 'axios';
  * @example
  * const ContxtSdk = require('@ndustrial/contxt-sdk');
  *
- * const contxtSdk = new ContxtSDK({
+ * const contxtSdk = new ContxtSdk({
  *   config: {
  *     auth: {
  *       clientId: '<client id>',


### PR DESCRIPTION
## Why?
There were places in the docs/examples where the ContxtSdk import did not match what was being invoked.

## What changed?
Changed `new ContxtSDK` to `new ContxtSdk` since `ContxtSdk` was actually being imported