### PR TITLE
Adds additional optional param to subscribeUser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [v2.8.1](http://github.com/ndustrialio/contxt-sdk-js/tree/v2.8.1) (2020-01-30)
+
+**Added**
+
+- Added an additional parameter, `subscribeOpts` to `Events#subscribeUser`.
+
 ## [v2.8.0](http://github.com/ndustrialio/contxt-sdk-js/tree/v2.8.0) (2020-01-29)
 
 **Added**

--- a/docs/Events.md
+++ b/docs/Events.md
@@ -14,7 +14,7 @@ of, information about different events
     * [.getEventTypesByClientId(clientId, [paginationOptions])](#Events+getEventTypesByClientId) ⇒ <code>Promise</code>
     * [.getEventsByTypeId(eventTypeId, [latest])](#Events+getEventsByTypeId) ⇒ <code>Promise</code>
     * [.getUserInfo(userId)](#Events+getUserInfo) ⇒ <code>Promise</code>
-    * [.subscribeUser(userId, eventId)](#Events+subscribeUser) ⇒ <code>Promise</code>
+    * [.subscribeUser(userId, eventId, subscribeOpts)](#Events+subscribeUser) ⇒ <code>Promise</code>
     * [.unsubscribeUser(userId, userEventSubscriptionId)](#Events+unsubscribeUser) ⇒ <code>Promise</code>
     * [.update(eventId, update)](#Events+update) ⇒ <code>Promise</code>
     * [.createEventType(eventType)](#Events+createEventType) ⇒ <code>Promise</code>
@@ -190,7 +190,7 @@ contxtSdk.events
 ```
 <a name="Events+subscribeUser"></a>
 
-### contxtSdk.events.subscribeUser(userId, eventId) ⇒ <code>Promise</code>
+### contxtSdk.events.subscribeUser(userId, eventId, subscribeOpts) ⇒ <code>Promise</code>
 Subscribes an user to an event
 
 API Endpoint: '/users/:userId/events/:event_id'
@@ -204,6 +204,7 @@ Method: POST
 | --- | --- | --- |
 | userId | <code>string</code> | The ID of the user |
 | eventId | <code>string</code> | The ID of the event |
+| subscribeOpts | <code>Object</code> | Optional parameters to provide when subscribing the user |
 
 **Example**  
 ```js

--- a/src/events/index.js
+++ b/src/events/index.js
@@ -343,6 +343,7 @@ class Events {
    *
    * @param {string} userId The ID of the user
    * @param {string} eventId The ID of the event
+   * @param {Object} subscribeOpts Optional parameters to provide when subscribing the user
    *
    * @returns {Promise}
    * @fulfill {UserEventSubscription} The newly created user event
@@ -354,7 +355,7 @@ class Events {
    *   .then((userEvent) => console.log(userEvent))
    *   .catch((err) => console.log(err));
    */
-  subscribeUser(userId, eventId) {
+  subscribeUser(userId, eventId, subscribeOpts = {}) {
     if (!userId) {
       return Promise.reject(
         new Error('A user ID is required for subscribing a user to an event')
@@ -368,7 +369,10 @@ class Events {
     }
 
     return this._request
-      .post(`${this._baseUrl}/users/${userId}/events/${eventId}`)
+      .post(
+        `${this._baseUrl}/users/${userId}/events/${eventId}`,
+        toSnakeCase(subscribeOpts)
+      )
       .then((response) => toCamelCase(response));
   }
 


### PR DESCRIPTION
## Why?
The user subscription endpoint accepts additional body parameters, but the SDK function would not allow them. nSight 2.0 needs ability to provide some additional parameters.

## What changed?
- Updated the function to accept an optional `subscribeOpts` parameter, which is provided as body parameters when making the API request
- Updated tests