### PR TITLE
Adds getTriggeredEventsByFacility to events module

### DIFF
--- a/docs/Events.md
+++ b/docs/Events.md
@@ -13,6 +13,7 @@ of, information about different events
     * [.get(eventId)](#Events+get) ⇒ <code>Promise</code>
     * [.getEventTypesByClientId(clientId, [paginationOptions])](#Events+getEventTypesByClientId) ⇒ <code>Promise</code>
     * [.getEventsByTypeId(eventTypeId, [latest])](#Events+getEventsByTypeId) ⇒ <code>Promise</code>
+    * [.getTriggeredEventsByFacilityId(facilityId, [triggeredEventFilters])](#Events+getTriggeredEventsByFacilityId) ⇒ <code>Promise</code>
     * [.getUserInfo(userId)](#Events+getUserInfo) ⇒ <code>Promise</code>
     * [.subscribeUser(userId, eventId, subscribeOpts)](#Events+subscribeUser) ⇒ <code>Promise</code>
     * [.unsubscribeUser(userId, userEventSubscriptionId)](#Events+unsubscribeUser) ⇒ <code>Promise</code>
@@ -165,6 +166,25 @@ contxtSdk.events
   .then((events) => console.log(events))
   .catch((err) => console.log(err));
 ```
+<a name="Events+getTriggeredEventsByFacilityId"></a>
+
+### contxtSdk.events.getTriggeredEventsByFacilityId(facilityId, [triggeredEventFilters]) ⇒ <code>Promise</code>
+Gets a paginated list of triggered events for a given facility.
+
+**Kind**: instance method of [<code>Events</code>](#Events)  
+**Fulfill**: [<code>TriggeredEventsFromServer</code>](./Typedefs.md#TriggeredEventsFromServer) Triggered Events from server  
+**Reject**: <code>Error</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| facilityId | <code>Number</code> | The ID of the facility |
+| [triggeredEventFilters] | <code>Object</code> |  |
+| [triggeredEventFilters.eventTypeId] | <code>boolean</code> | Will filter records by a particular event type ID |
+| [triggeredEventFilters.limit] | <code>number</code> | Maximum number of records to return per query |
+| [triggeredEventFilters.offset] | <code>number</code> | How many records from the first record to start the query |
+| [triggeredEventFilters.orderBy] | <code>string</code> | The triggered field to sort the response records by in ascending order |
+| [triggeredEventFilters.reverseOrder] | <code>boolean</code> | If true, results will be sorted in descending order |
+
 <a name="Events+getUserInfo"></a>
 
 ### contxtSdk.events.getUserInfo(userId) ⇒ <code>Promise</code>

--- a/docs/README.md
+++ b/docs/README.md
@@ -303,6 +303,10 @@ Can authenticate with a service like Auth0 and then with Contxt or can communica
 with Contxt. The adapter must implement required methods, but most methods are optional. Some of
 the optional methods are documented below.</p>
 </dd>
+<dt><a href="./Typedefs.md#TriggeredEvent">TriggeredEvent</a> : <code>Object</code></dt>
+<dd></dd>
+<dt><a href="./Typedefs.md#TriggeredEventsFromServer">TriggeredEventsFromServer</a> : <code>Object</code></dt>
+<dd></dd>
 <dt><a href="./Typedefs.md#UserConfig">UserConfig</a> : <code>Object</code></dt>
 <dd><p>User provided configuration options</p>
 </dd>

--- a/docs/Typedefs.md
+++ b/docs/Typedefs.md
@@ -1145,6 +1145,38 @@ the optional methods are documented below.
 | [logIn] | <code>function</code> | Is used by front-end code in the Auth0 reference implementation to   start the sign in process |
 | [logOut] | <code>function</code> | Is used by the front-end code in the Auth0 reference implementation   to sign the user out |
 
+<a name="TriggeredEvent"></a>
+
+## TriggeredEvent : <code>Object</code>
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| createdAt | <code>string</code> | ISO 8601 Extended Format date/time string |
+| data | <code>string</code> | A stringified JSON object containing additional data about the Triggered Event |
+| deletedAt | <code>string</code> | ISO 8601 Extended Format date/time string |
+| eventId | <code>string</code> |  |
+| id | <code>string</code> |  |
+| isPublic | <code>boolean</code> | Whether or not the event |
+| ownerId | <code>string</code> | The Contxt entity who owns the event |
+| triggerEndAt | <code>string</code> | ISO 8601 Extended Format date/time string |
+| triggerStartAt | <code>string</code> | ISO 8601 Extended Format date/time string |
+| updatedAt | <code>string</code> | ISO 8601 Extended Format date/time string |
+
+<a name="TriggeredEventsFromServer"></a>
+
+## TriggeredEventsFromServer : <code>Object</code>
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| _metadata | <code>Object</code> | Metadata about the pagination settings |
+| _metadata.offset | <code>number</code> | Offset of records in subsequent queries |
+| _metadata.totalRecords | <code>number</code> | Total number of records found |
+| records | [<code>Array.&lt;TriggeredEvent&gt;</code>](#TriggeredEvent) |  |
+
 <a name="UserConfig"></a>
 
 ## UserConfig : <code>Object</code>

--- a/docs/Typedefs.md
+++ b/docs/Typedefs.md
@@ -1154,13 +1154,13 @@ the optional methods are documented below.
 | Name | Type | Description |
 | --- | --- | --- |
 | createdAt | <code>string</code> | ISO 8601 Extended Format date/time string |
-| data | <code>string</code> | A stringified JSON object containing additional data about the Triggered Event |
+| [data] | <code>string</code> | A stringified JSON object containing additional data about the Triggered Event |
 | [deletedAt] | <code>string</code> | ISO 8601 Extended Format date/time string |
 | eventId | <code>string</code> |  |
 | id | <code>string</code> |  |
 | [isPublic] | <code>boolean</code> | Whether or not the event |
-| ownerId | <code>string</code> | The Contxt entity who owns the event |
-| triggerEndAt | <code>string</code> | ISO 8601 Extended Format date/time string |
+| [ownerId] | <code>string</code> | The Contxt entity who owns the event |
+| [triggerEndAt] | <code>string</code> | ISO 8601 Extended Format date/time string |
 | triggerStartAt | <code>string</code> | ISO 8601 Extended Format date/time string |
 | updatedAt | <code>string</code> | ISO 8601 Extended Format date/time string |
 

--- a/docs/Typedefs.md
+++ b/docs/Typedefs.md
@@ -1155,10 +1155,10 @@ the optional methods are documented below.
 | --- | --- | --- |
 | createdAt | <code>string</code> | ISO 8601 Extended Format date/time string |
 | data | <code>string</code> | A stringified JSON object containing additional data about the Triggered Event |
-| deletedAt | <code>string</code> | ISO 8601 Extended Format date/time string |
+| [deletedAt] | <code>string</code> | ISO 8601 Extended Format date/time string |
 | eventId | <code>string</code> |  |
 | id | <code>string</code> |  |
-| isPublic | <code>boolean</code> | Whether or not the event |
+| [isPublic] | <code>boolean</code> | Whether or not the event |
 | ownerId | <code>string</code> | The Contxt entity who owns the event |
 | triggerEndAt | <code>string</code> | ISO 8601 Extended Format date/time string |
 | triggerStartAt | <code>string</code> | ISO 8601 Extended Format date/time string |

--- a/src/events/index.js
+++ b/src/events/index.js
@@ -105,6 +105,28 @@ import { formatPaginatedDataFromServer } from '../utils/pagination';
  */
 
 /**
+ * @typedef {Object} TriggeredEventsFromServer
+ * @property {Object} _metadata Metadata about the pagination settings
+ * @property {number} _metadata.offset Offset of records in subsequent queries
+ * @property {number} _metadata.totalRecords Total number of records found
+ * @property {TriggeredEvent[]} records
+ */
+
+/**
+ * @typedef {Object} TriggeredEvent
+ * @property {string} createdAt ISO 8601 Extended Format date/time string
+ * @property {string} data A stringified JSON object containing additional data about the Triggered Event
+ * @property {string} deletedAt ISO 8601 Extended Format date/time string
+ * @property {string} eventId
+ * @property {string} id
+ * @property {boolean} isPublic Whether or not the event
+ * @property {string} ownerId The Contxt entity who owns the event
+ * @property {string} triggerEndAt ISO 8601 Extended Format date/time string
+ * @property {string} triggerStartAt ISO 8601 Extended Format date/time string
+ * @property {string} updatedAt ISO 8601 Extended Format date/time string
+ */
+
+/**
  * Module that provides access to, and the manipulation
  * of, information about different events
  *
@@ -301,6 +323,35 @@ class Events {
     return this._request
       .get(`${this._baseUrl}/types/${eventTypeId}/events`, {
         params: toSnakeCase(eventFilters)
+      })
+      .then((events) => formatPaginatedDataFromServer(events));
+  }
+
+  /**
+   * Gets a paginated list of triggered events for a given facility.
+   * @param {Number} facilityId The ID of the facility
+   * @param {Object} [triggeredEventFilters]
+   * @param {boolean} [triggeredEventFilters.eventTypeId] Will filter records by a particular event type ID
+   * @param {number} [triggeredEventFilters.limit] Maximum number of records to return per query
+   * @param {number} [triggeredEventFilters.offset] How many records from the first record to start the query
+   * @param {string} [triggeredEventFilters.orderBy] The triggered field to sort the response records by in ascending order
+   * @param {boolean} [triggeredEventFilters.reverseOrder] If true, results will be sorted in descending order
+   *
+   * @returns {Promise}
+   * @fulfill {TriggeredEventsFromServer} Triggered Events from server
+   * @reject {Error}
+   *
+   */
+  getTriggeredEventsByFacilityId(facilityId, triggeredEventFilters = {}) {
+    if (!facilityId) {
+      return Promise.reject(
+        new Error('A facility ID is required for getting triggered events')
+      );
+    }
+
+    return this._request
+      .get(`${this._baseUrl}/facilities/${facilityId}/triggered-events`, {
+        params: toSnakeCase(triggeredEventFilters)
       })
       .then((events) => formatPaginatedDataFromServer(events));
   }

--- a/src/events/index.js
+++ b/src/events/index.js
@@ -115,13 +115,13 @@ import { formatPaginatedDataFromServer } from '../utils/pagination';
 /**
  * @typedef {Object} TriggeredEvent
  * @property {string} createdAt ISO 8601 Extended Format date/time string
- * @property {string} data A stringified JSON object containing additional data about the Triggered Event
+ * @property {string} [data] A stringified JSON object containing additional data about the Triggered Event
  * @property {string} [deletedAt] ISO 8601 Extended Format date/time string
  * @property {string} eventId
  * @property {string} id
  * @property {boolean} [isPublic] Whether or not the event
- * @property {string} ownerId The Contxt entity who owns the event
- * @property {string} triggerEndAt ISO 8601 Extended Format date/time string
+ * @property {string} [ownerId] The Contxt entity who owns the event
+ * @property {string} [triggerEndAt] ISO 8601 Extended Format date/time string
  * @property {string} triggerStartAt ISO 8601 Extended Format date/time string
  * @property {string} updatedAt ISO 8601 Extended Format date/time string
  */

--- a/src/events/index.js
+++ b/src/events/index.js
@@ -116,10 +116,10 @@ import { formatPaginatedDataFromServer } from '../utils/pagination';
  * @typedef {Object} TriggeredEvent
  * @property {string} createdAt ISO 8601 Extended Format date/time string
  * @property {string} data A stringified JSON object containing additional data about the Triggered Event
- * @property {string} deletedAt ISO 8601 Extended Format date/time string
+ * @property {string} [deletedAt] ISO 8601 Extended Format date/time string
  * @property {string} eventId
  * @property {string} id
- * @property {boolean} isPublic Whether or not the event
+ * @property {boolean} [isPublic] Whether or not the event
  * @property {string} ownerId The Contxt entity who owns the event
  * @property {string} triggerEndAt ISO 8601 Extended Format date/time string
  * @property {string} triggerStartAt ISO 8601 Extended Format date/time string

--- a/support/fixtures/factories/triggeredEvent.js
+++ b/support/fixtures/factories/triggeredEvent.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const factory = require('rosie').Factory;
+const faker = require('faker');
+
+factory
+  .define('triggeredEvent')
+  .option('fromServer', false)
+  .attrs({
+    createdAt: () => faker.date.past().toISOString(),
+    data: () => faker.hacker.phrase(),
+    deletedAt: () => faker.date.recent().toISOString(),
+    eventId: () => faker.random.uuid(),
+    id: () => faker.random.uuid(),
+    isPublic: () => faker.random.boolean(),
+    ownerId: () => faker.random.uuid(),
+    triggerEndAt: () => faker.date.recent().toISOString(),
+    triggerStartAt: () => faker.date.recent().toISOString(),
+    updatedAt: () => faker.date.recent().toISOString()
+  })
+  .after((triggeredEvent, options) => {
+    if (options.fromServer) {
+      triggeredEvent.created_at = triggeredEvent.createdAt;
+      delete triggeredEvent.createdAt;
+
+      triggeredEvent.deleted_at = triggeredEvent.deletedAt;
+      delete triggeredEvent.deletedAt;
+
+      triggeredEvent.is_public = triggeredEvent.isPublic;
+      delete triggeredEvent.isPublic;
+
+      triggeredEvent.owner_id = triggeredEvent.ownerId;
+      delete triggeredEvent.ownerId;
+
+      triggeredEvent.trigger_end_at = triggeredEvent.triggerEndAt;
+      delete triggeredEvent.triggerEndAt;
+
+      triggeredEvent.trigger_start_at = triggeredEvent.triggerStartAt;
+      delete triggeredEvent.triggerStartAt;
+
+      triggeredEvent.updated_at = triggeredEvent.updatedAt;
+      delete triggeredEvent.updatedAt;
+    }
+  });


### PR DESCRIPTION
## Why?
- Adds a new function to get "Triggered Events" from the Events API, filtered by Facility ID. This is needed for nSight 2.0 Facility Overview page to show an Event Feed for the Facility.

## What changed?
- Added new function
- Added tests