### PR TITLE
Adds Feeds#getStatusForFacility function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [v2.10.0](http://github.com/ndustrialio/contxt-sdk-js/tree/v2.10.0) (2020-02-05)
+
+**Added**
+
+- Added `Feeds#getStatusForFacility` to fetch feed status for every feed in a given facility.
+
 ## [v2.9.0](http://github.com/ndustrialio/contxt-sdk-js/tree/v2.9.0) (2020-02-01)
 
 **Added**

--- a/docs/Feeds.md
+++ b/docs/Feeds.md
@@ -8,6 +8,7 @@ Module that provides access to feed information
 * [Feeds](#Feeds)
     * [new Feeds(sdk, request, baseUrl)](#new_Feeds_new)
     * [.getByFacilityId(facilityId)](#Feeds+getByFacilityId) ⇒ <code>Promise</code>
+    * [.getStatusForFacility(facilityId)](#Feeds+getStatusForFacility) ⇒ <code>Promise</code>
 
 <a name="new_Feeds_new"></a>
 
@@ -33,12 +34,35 @@ Method: GET
 
 | Param | Type |
 | --- | --- |
-| facilityId | <code>number</code> | 
+| facilityId | <code>Number</code> | 
 
 **Example**  
 ```js
 contxtSdk.iot.feeds
   .getByFacilityId(facilityId)
   .then((feeds) => console.log(feeds))
+  .catch((err) => console.log(err));
+```
+<a name="Feeds+getStatusForFacility"></a>
+
+### contxtSdk.iot.feeds.getStatusForFacility(facilityId) ⇒ <code>Promise</code>
+Gets current Feed and Grouping status for a given Facility
+
+API Endpoint: '/facilities/:facilityId/status'
+Method: GET
+
+**Kind**: instance method of [<code>Feeds</code>](#Feeds)  
+**Fulfill**: [<code>FacilityStatusFromServer</code>](./Typedefs.md#FacilityStatusFromServer) Information about the Facility feed status  
+**Reject**: <code>Error</code>  
+
+| Param | Type |
+| --- | --- |
+| facilityId | <code>Number</code> | 
+
+**Example**  
+```js
+contxtSdk.iot.feeds
+  .getStatusForFacility(563)
+  .then((status) => console.log(status.feeds))
   .catch((err) => console.log(err));
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -245,9 +245,15 @@ for authenticating and communicating with an individual API and the external mod
 </dd>
 <dt><a href="./Typedefs.md#Facility">Facility</a> : <code>Object</code></dt>
 <dd></dd>
+<dt><a href="./Typedefs.md#FacilityFeedStatus">FacilityFeedStatus</a> : <code>Object</code></dt>
+<dd></dd>
 <dt><a href="./Typedefs.md#FacilityGrouping">FacilityGrouping</a> : <code>Object</code></dt>
 <dd></dd>
 <dt><a href="./Typedefs.md#FacilityGroupingFacility">FacilityGroupingFacility</a> : <code>Object</code></dt>
+<dd></dd>
+<dt><a href="./Typedefs.md#FacilityGroupingStatus">FacilityGroupingStatus</a> : <code>Object</code></dt>
+<dd></dd>
+<dt><a href="./Typedefs.md#FacilityStatusFromServer">FacilityStatusFromServer</a> : <code>Object</code></dt>
 <dd></dd>
 <dt><a href="./Typedefs.md#Feed">Feed</a> : <code>Object</code></dt>
 <dd></dd>

--- a/docs/Typedefs.md
+++ b/docs/Typedefs.md
@@ -743,6 +743,19 @@ for authenticating and communicating with an individual API and the external mod
 | [weatherLocationId] | <code>number</code> |  |
 | [zip] | <code>string</code> | US Zip Code |
 
+<a name="FacilityFeedStatus"></a>
+
+## FacilityFeedStatus : <code>Object</code>
+**Kind**: global typedef  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| groupings | [<code>Array.&lt;FacilityGroupingStatus&gt;</code>](#FacilityGroupingStatus) | An array of field groupings associated with the feed |
+| id | <code>Number</code> |  |
+| key | <code>String</code> | The unique key for the feed |
+| status | <code>String</code> | The most recent status of the feed, e.g. "Healthy" |
+| updatedAt | <code>string</code> | ISO 8601 Extended Format date/time string |
+
 <a name="FacilityGrouping"></a>
 
 ## FacilityGrouping : <code>Object</code>
@@ -773,6 +786,28 @@ for authenticating and communicating with an individual API and the external mod
 | facilityId | <code>number</code> |  |
 | id | <code>string</code> | UUID |
 | updatedAt | <code>string</code> | ISO 8601 Extended Format date/time string |
+
+<a name="FacilityGroupingStatus"></a>
+
+## FacilityGroupingStatus : <code>Object</code>
+**Kind**: global typedef  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| id | <code>String</code> | UUID |
+| label | <code>String</code> | The human readable name of the field grouping |
+| status | <code>String</code> | The most recent status of the field grouping |
+| updatedAt | <code>string</code> | ISO 8601 Extended Format date/time string |
+
+<a name="FacilityStatusFromServer"></a>
+
+## FacilityStatusFromServer : <code>Object</code>
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type |
+| --- | --- |
+| feeds | [<code>Array.&lt;FacilityFeedStatus&gt;</code>](#FacilityFeedStatus) | 
 
 <a name="Feed"></a>
 

--- a/docs/Typedefs.md
+++ b/docs/Typedefs.md
@@ -751,9 +751,13 @@ for authenticating and communicating with an individual API and the external mod
 | Param | Type | Description |
 | --- | --- | --- |
 | groupings | [<code>Array.&lt;FacilityGroupingStatus&gt;</code>](#FacilityGroupingStatus) | An array of field groupings associated with the feed |
+| feedType | <code>Object</code> |  |
+| feedType.id | <code>Number</code> |  |
+| feedType.type | <code>String</code> | The human readable type of the feed, e.g. "egauge" |
 | id | <code>Number</code> |  |
 | key | <code>String</code> | The unique key for the feed |
 | status | <code>String</code> | The most recent status of the feed, e.g. "Healthy" |
+| statusEventId | <code>String</code> | UUID of the feed status event |
 | updatedAt | <code>string</code> | ISO 8601 Extended Format date/time string |
 
 <a name="FacilityGrouping"></a>

--- a/src/iot/feeds.js
+++ b/src/iot/feeds.js
@@ -42,9 +42,13 @@ import { toCamelCase, toSnakeCase } from '../utils/objects';
 /**
  * @typedef {Object} FacilityFeedStatus
  * @param {FacilityGroupingStatus[]} groupings An array of field groupings associated with the feed
+ * @param {Object} feedType
+ * @param {Number} feedType.id
+ * @param {String} feedType.type The human readable type of the feed, e.g. "egauge"
  * @param {Number} id
  * @param {String} key The unique key for the feed
  * @param {String} status The most recent status of the feed, e.g. "Healthy"
+ * @param {String} statusEventId UUID of the feed status event
  * @param {string} updatedAt ISO 8601 Extended Format date/time string
  */
 

--- a/src/iot/feeds.js
+++ b/src/iot/feeds.js
@@ -40,6 +40,28 @@ import { toCamelCase, toSnakeCase } from '../utils/objects';
  */
 
 /**
+ * @typedef {Object} FacilityFeedStatus
+ * @param {FacilityGroupingStatus[]} groupings An array of field groupings associated with the feed
+ * @param {Number} id
+ * @param {String} key The unique key for the feed
+ * @param {String} status The most recent status of the feed, e.g. "Healthy"
+ * @param {string} updatedAt ISO 8601 Extended Format date/time string
+ */
+
+/**
+ * @typedef {Object} FacilityGroupingStatus
+ * @param {String} id UUID
+ * @param {String} label The human readable name of the field grouping
+ * @param {String} status The most recent status of the field grouping
+ * @param {string} updatedAt ISO 8601 Extended Format date/time string
+ */
+
+/**
+ * @typedef {Object} FacilityStatusFromServer
+ * @property {FacilityFeedStatus[]} feeds
+ */
+
+/**
  * Module that provides access to feed information
  *
  * @typicalname contxtSdk.iot.feeds
@@ -64,7 +86,7 @@ class Feeds {
    * API Endpoint: '/feeds'
    * Method: GET
    *
-   * @param {number} facilityId
+   * @param {Number} facilityId
    *
    * @returns {Promise}
    * @fulfill {Feeds[]} Information about the feeds that are assigned to specific facility
@@ -76,16 +98,47 @@ class Feeds {
    *   .then((feeds) => console.log(feeds))
    *   .catch((err) => console.log(err));
    */
-
   getByFacilityId(facilityId) {
     if (!facilityId) {
-      return Promise.reject(new Error('A facilityId is required get feeds.'));
+      return Promise.reject(
+        new Error('A facilityId is required to get feeds.')
+      );
     }
 
     return this._request
       .get(`${this._baseUrl}/feeds`, {
         params: toSnakeCase({ facilityId })
       })
+      .then((response) => toCamelCase(response));
+  }
+
+  /**
+   * Gets current Feed and Grouping status for a given Facility
+   *
+   * API Endpoint: '/facilities/:facilityId/status'
+   * Method: GET
+   *
+   * @param {Number} facilityId
+   *
+   * @returns {Promise}
+   * @fulfill {FacilityStatusFromServer} Information about the Facility feed status
+   * @reject {Error}
+   *
+   * @example
+   * contxtSdk.iot.feeds
+   *   .getStatusForFacility(563)
+   *   .then((status) => console.log(status.feeds))
+   *   .catch((err) => console.log(err));
+   */
+  getStatusForFacility(facilityId) {
+    if (!facilityId) {
+      return Promise.reject(
+        new Error('A facilityId is required to get facility feed status.')
+      );
+    }
+
+    return this._request
+      .get(`${this._baseUrl}/facilities/${facilityId}/status`)
       .then((response) => toCamelCase(response));
   }
 }

--- a/support/fixtures/factories/fieldGroupingStatus.js
+++ b/support/fixtures/factories/fieldGroupingStatus.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const factory = require('rosie').Factory;
+const faker = require('faker');
+
+factory
+  .define('fieldGroupingStatus')
+  .option('fromServer', false)
+  .attrs({
+    id: () => faker.random.uuid(),
+    label: () => faker.commerce.productName(),
+    status: () => faker.random.arrayElement(['Active', 'Out-of-Date']),
+    updatedAt: () => faker.date.recent().toISOString()
+  })
+  .after((fieldGroupingStatus, options) => {
+    if (options.fromServer) {
+      fieldGroupingStatus.updated_at = fieldGroupingStatus.updatedAt;
+      delete fieldGroupingStatus.updatedAt;
+    }
+  });


### PR DESCRIPTION
## Why?
- Needed to add a new function to SDK in order to properly fetch a Facility's Feeds, current status, and current status of every grouping belonging to those Feeds. https://ndustrialio.atlassian.net/browse/NC2-671
- (This is Related to new API endpoint: https://github.com/ndustrialio/realtime-data-api-service/pull/78)

## What changed?
- Added new function
- Added docs/tests
- Updated CHANGELOG.md
