### PR TITLE
Add options to bypass the seamless sso in auth0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [v2.11.0](http://github.com/ndustrialio/contxt-sdk-js/tree/v2.11.0) (2020-02-21)
+## [v2.11.0](http://github.com/ndustrialio/contxt-sdk-js/tree/v2.11.0) (2020-02-24)
 
 **Added**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [v2.8.0](http://github.com/ndustrialio/contxt-sdk-js/tree/v2.8.0) (2020-02-21)
+
+**Added**
+
+- Added the ability to force the login prompt on login. This will be useful for applications who need a Single Logout between Auth0 and an external IdP
+
 ## [v2.7.0](http://github.com/ndustrialio/contxt-sdk-js/tree/v2.7.0) (2020-01-28)
 
 **Added**

--- a/docs/Auth0WebAuth.md
+++ b/docs/Auth0WebAuth.md
@@ -26,7 +26,7 @@ enabled in Auth0.
     * [.getProfile()](#Auth0WebAuth+getProfile) ⇒ <code>Promise</code>
     * [.handleAuthentication()](#Auth0WebAuth+handleAuthentication) ⇒ <code>Promise</code>
     * [.isAuthenticated()](#Auth0WebAuth+isAuthenticated) ⇒ <code>boolean</code>
-    * [.logIn()](#Auth0WebAuth+logIn)
+    * [.logIn(options)](#Auth0WebAuth+logIn)
     * [.logOut(options)](#Auth0WebAuth+logOut)
 
 <a name="new_Auth0WebAuth_new"></a>
@@ -116,10 +116,16 @@ Tells caller if the current user is authenticated.
 **Kind**: instance method of [<code>Auth0WebAuth</code>](#Auth0WebAuth)  
 <a name="Auth0WebAuth+logIn"></a>
 
-### contxtSdk.auth.logIn()
+### contxtSdk.auth.logIn(options)
 Starts the Auth0 log in process
 
 **Kind**: instance method of [<code>Auth0WebAuth</code>](#Auth0WebAuth)  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| options | <code>Object</code> |  |  |
+| [options.forceLogin] | <code>Boolean</code> | <code>false</code> | When true will bypass any sso settings in the authorization provider |
+
 <a name="Auth0WebAuth+logOut"></a>
 
 ### contxtSdk.auth.logOut(options)

--- a/src/sessionTypes/auth0WebAuth.js
+++ b/src/sessionTypes/auth0WebAuth.js
@@ -236,9 +236,17 @@ class Auth0WebAuth {
 
   /**
    * Starts the Auth0 log in process
+   *
+   * @param {Object} options
+   * @param {Boolean} [options.forceLogin = false] When true will bypass any sso settings in the authorization provider
    */
-  logIn() {
-    this._auth0.authorize();
+  logIn(options = {}) {
+    let authOptions = {};
+
+    if (options.forceLogin) {
+      authOptions.prompt = 'login';
+    }
+    this._auth0.authorize(authOptions);
   }
 
   /**

--- a/src/sessionTypes/auth0WebAuth.spec.js
+++ b/src/sessionTypes/auth0WebAuth.spec.js
@@ -717,16 +717,21 @@ describe('sessionTypes/Auth0WebAuth', function() {
     });
   });
 
-  describe('logIn', function() {
+  describe.only('logIn', function() {
     let auth0WebAuth;
 
     beforeEach(function() {
       auth0WebAuth = new Auth0WebAuth(sdk);
-      auth0WebAuth.logIn();
     });
 
     it('begins to authorize an auth0 WebAuth session', function() {
+      auth0WebAuth.logIn();
       expect(webAuthSession.authorize).to.be.calledOnce;
+    });
+
+    it('can force login by passing prompt=login', function() {
+      auth0WebAuth.logIn({ forceLogin: true });
+      expect(webAuthSession.authorize).to.be.calledWith({ prompt: 'login' });
     });
   });
 

--- a/src/sessionTypes/auth0WebAuth.spec.js
+++ b/src/sessionTypes/auth0WebAuth.spec.js
@@ -717,7 +717,7 @@ describe('sessionTypes/Auth0WebAuth', function() {
     });
   });
 
-  describe.only('logIn', function() {
+  describe('logIn', function() {
     let auth0WebAuth;
 
     beforeEach(function() {


### PR DESCRIPTION
## Why?

When an application needs to ensure users are logged out of the originating provider with "federated=true", this won't happen if they were logged back in with seamless sso.  So to prevent logging back in with seamless sso, they need to be able to force the login.

## What changed?

Added a new option `forceLogin` to the login method for auth0.  This will in turn call auth0.authorize with `prompt:login`

The intention is that when users need to have federated logout, they will also use the forceLogin.
