### PR TITLE
Excluded orderBy and reverseOrder from snake case conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [v2.11.2](http://github.com/ndustrialio/contxt-sdk-js/tree/v2.11.2) (2020-03-11)
+
+**Updated**
+
+- Excluded `orderBy` and `reverseOrder` from snake case conversion for the `getTriggeredEventsByFacilityId` call
+
 ## [v2.11.1](http://github.com/ndustrialio/contxt-sdk-js/tree/v2.11.1) (2020-02-28)
 
 **Updated**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 **Updated**
 
-- Excluded `orderBy` and `reverseOrder` from snake case conversion for the `getTriggeredEventsByFacilityId` call
+- Excluded `orderBy` and `reverseOrder` from snake case conversion for the `Events#getTriggeredEventsByFacilityId` call
 
 ## [v2.11.1](http://github.com/ndustrialio/contxt-sdk-js/tree/v2.11.1) (2020-02-28)
 

--- a/src/events/index.js
+++ b/src/events/index.js
@@ -351,7 +351,10 @@ class Events {
 
     return this._request
       .get(`${this._baseUrl}/facilities/${facilityId}/triggered-events`, {
-        params: toSnakeCase(triggeredEventFilters)
+        params: toSnakeCase(triggeredEventFilters, {
+          deep: true,
+          excludeTransform: ['orderBy', 'reverseOrder']
+        })
       })
       .then((events) => formatPaginatedDataFromServer(events));
   }

--- a/src/events/index.spec.js
+++ b/src/events/index.spec.js
@@ -493,7 +493,10 @@ describe('Events', function() {
 
       it('formats the pagination options', function() {
         return promise.then(() => {
-          expect(toSnakeCase).to.be.calledWith(paginationOptionsBeforeFormat);
+          expect(toSnakeCase).to.be.calledWith(paginationOptionsBeforeFormat, {
+            deep: true,
+            excludeTransform: ['orderBy', 'reverseOrder']
+          });
         });
       });
 


### PR DESCRIPTION
## Why?
The query params were unintentionally being excluded from the request

## What changed?
Excluded orderBy and reverseOrder from snake case conversion