### PR TITLE
Exposing feed types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [v2.12.0](http://github.com/ndustrialio/contxt-sdk-js/tree/v2.12.0) (2020-03-13)
+
+**Added**
+
+- Added `FeedTypes#getAll` to fetch all feed types
+
 ## [v2.11.2](http://github.com/ndustrialio/contxt-sdk-js/tree/v2.11.2) (2020-03-11)
 
 **Updated**

--- a/docs/FeedTypes.md
+++ b/docs/FeedTypes.md
@@ -7,7 +7,7 @@ Module that provides access to feed type information
 
 * [FeedTypes](#FeedTypes)
     * [new FeedTypes(sdk, request, baseUrl)](#new_FeedTypes_new)
-    * [.getAll([paginationOptions])](#FeedTypes+getAll) ⇒ <code>Promise</code>
+    * [.getAll()](#FeedTypes+getAll) ⇒ <code>Promise</code>
 
 <a name="new_FeedTypes_new"></a>
 
@@ -21,20 +21,15 @@ Module that provides access to feed type information
 
 <a name="FeedTypes+getAll"></a>
 
-### contxtSdk.iot.feedTypes.getAll([paginationOptions]) ⇒ <code>Promise</code>
+### contxtSdk.iot.feedTypes.getAll() ⇒ <code>Promise</code>
 Get a listing of all feed types
 
 API Endpoint: '/feeds/types'
 Method: GET
 
 **Kind**: instance method of [<code>FeedTypes</code>](#FeedTypes)  
-**Fulfill**: <code>FeedTypesFromServer</code> Information about the feed types  
+**Fulfill**: <code>FeedType[]</code> A list of feed types  
 **Reject**: <code>Error</code>  
-
-| Param | Type |
-| --- | --- |
-| [paginationOptions] | [<code>PaginationOptions</code>](./Typedefs.md#PaginationOptions) | 
-
 **Example**  
 ```js
 contxtSdk.iot.feedTypes

--- a/docs/FeedTypes.md
+++ b/docs/FeedTypes.md
@@ -1,0 +1,44 @@
+<a name="FeedTypes"></a>
+
+## FeedTypes
+Module that provides access to feed type information
+
+**Kind**: global class  
+
+* [FeedTypes](#FeedTypes)
+    * [new FeedTypes(sdk, request, baseUrl)](#new_FeedTypes_new)
+    * [.getAll([paginationOptions])](#FeedTypes+getAll) ⇒ <code>Promise</code>
+
+<a name="new_FeedTypes_new"></a>
+
+### new FeedTypes(sdk, request, baseUrl)
+
+| Param | Type | Description |
+| --- | --- | --- |
+| sdk | <code>Object</code> | An instance of the SDK so the module can communicate   with other modules |
+| request | <code>Object</code> | An instance of the request module tied to this   module's audience |
+| baseUrl | <code>string</code> | The base URL provided by the parent module |
+
+<a name="FeedTypes+getAll"></a>
+
+### contxtSdk.iot.feedTypes.getAll([paginationOptions]) ⇒ <code>Promise</code>
+Get a listing of all feed types
+
+API Endpoint: '/feeds/types'
+Method: GET
+
+**Kind**: instance method of [<code>FeedTypes</code>](#FeedTypes)  
+**Fulfill**: <code>FeedTypesFromServer</code> Information about the feed types  
+**Reject**: <code>Error</code>  
+
+| Param | Type |
+| --- | --- |
+| [paginationOptions] | [<code>PaginationOptions</code>](./Typedefs.md#PaginationOptions) | 
+
+**Example**  
+```js
+contxtSdk.iot.feedTypes
+  .getAll()
+  .then((feedTypes) => console.log(feedTypes))
+  .catch((err) => console.log(err));
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -80,6 +80,9 @@ of, information about different facilities</p>
 <dd><p>Module that provides access to facility groupings, and helps manage
 the relationship between those groupings and facilities</p>
 </dd>
+<dt><a href="./FeedTypes.md">FeedTypes</a></dt>
+<dd><p>Module that provides access to feed type information</p>
+</dd>
 <dt><a href="./Feeds.md">Feeds</a></dt>
 <dd><p>Module that provides access to feed information</p>
 </dd>
@@ -256,6 +259,8 @@ for authenticating and communicating with an individual API and the external mod
 <dt><a href="./Typedefs.md#FacilityStatusFromServer">FacilityStatusFromServer</a> : <code>Object</code></dt>
 <dd></dd>
 <dt><a href="./Typedefs.md#Feed">Feed</a> : <code>Object</code></dt>
+<dd></dd>
+<dt><a href="./Typedefs.md#FeedType">FeedType</a> : <code>Object</code></dt>
 <dd></dd>
 <dt><a href="./Typedefs.md#FieldCategoriesFromServer">FieldCategoriesFromServer</a> : <code>Object</code></dt>
 <dd></dd>

--- a/docs/Typedefs.md
+++ b/docs/Typedefs.md
@@ -867,10 +867,10 @@ for authenticating and communicating with an individual API and the external mod
 | Name | Type | Description |
 | --- | --- | --- |
 | createdAt | <code>String</code> |  |
-| downAfter | <code>String</code> |  |
+| downAfter | <code>String</code> | Time (in seconds) threshold to receive data before a feed is considered down |
 | id | <code>String</code> | UUID |
 | troubleshootingUrl | <code>String</code> |  |
-| type | <code>String</code> |  |
+| type | <code>String</code> | The name of the feed type |
 | updatedAt | <code>String</code> |  |
 
 <a name="FieldCategoriesFromServer"></a>

--- a/docs/Typedefs.md
+++ b/docs/Typedefs.md
@@ -858,6 +858,21 @@ for authenticating and communicating with an individual API and the external mod
 | token | <code>String</code> |  |
 | updatedAt | <code>String</code> | ISO 8601 Extended Format date/time string |
 
+<a name="FeedType"></a>
+
+## FeedType : <code>Object</code>
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| createdAt | <code>String</code> |  |
+| downAfter | <code>String</code> |  |
+| id | <code>String</code> | UUID |
+| troubleshootingUrl | <code>String</code> |  |
+| type | <code>String</code> |  |
+| updatedAt | <code>String</code> |  |
+
 <a name="FieldCategoriesFromServer"></a>
 
 ## FieldCategoriesFromServer : <code>Object</code>

--- a/src/iot/feedTypes.js
+++ b/src/iot/feedTypes.js
@@ -1,3 +1,5 @@
+import { toCamelCase } from '../utils/objects';
+
 /**
  * @typedef {Object} FeedType
  * @property {String} createdAt
@@ -46,7 +48,9 @@ class FeedTypes {
    *   .catch((err) => console.log(err));
    */
   getAll() {
-    return this._request.get(`${this._baseUrl}/feeds/types`);
+    return this._request
+      .get(`${this._baseUrl}/feeds/types`)
+      .then((feedTypes) => toCamelCase(feedTypes));
   }
 }
 

--- a/src/iot/feedTypes.js
+++ b/src/iot/feedTypes.js
@@ -1,0 +1,53 @@
+/**
+ * @typedef {Object} FeedType
+ * @property {String} createdAt
+ * @property {String} downAfter
+ * @property {String} id UUID
+ * @property {String} troubleshootingUrl
+ * @property {String} type
+ * @property {String} updatedAt
+ */
+
+/**
+ * Module that provides access to feed type information
+ *
+ * @typicalname contxtSdk.iot.feedTypes
+ */
+class FeedTypes {
+  /**
+   * @param {Object} sdk An instance of the SDK so the module can communicate
+   *   with other modules
+   * @param {Object} request An instance of the request module tied to this
+   *   module's audience
+   * @param {string} baseUrl The base URL provided by the parent module
+   */
+  constructor(sdk, request, baseUrl) {
+    this._baseUrl = baseUrl;
+    this._request = request;
+    this._sdk = sdk;
+  }
+
+  /**
+   * Get a listing of all feed types
+   *
+   * API Endpoint: '/feeds/types'
+   * Method: GET
+   *
+   * @param {PaginationOptions} [paginationOptions]
+   *
+   * @returns {Promise}
+   * @fulfill {FeedTypesFromServer} Information about the feed types
+   * @reject {Error}
+   *
+   * @example
+   * contxtSdk.iot.feedTypes
+   *   .getAll()
+   *   .then((feedTypes) => console.log(feedTypes))
+   *   .catch((err) => console.log(err));
+   */
+  getAll() {
+    return this._request.get(`${this._baseUrl}/feeds/types`);
+  }
+}
+
+export default FeedTypes;

--- a/src/iot/feedTypes.js
+++ b/src/iot/feedTypes.js
@@ -3,10 +3,10 @@ import { toCamelCase } from '../utils/objects';
 /**
  * @typedef {Object} FeedType
  * @property {String} createdAt
- * @property {String} downAfter
+ * @property {String} downAfter Time (in seconds) threshold to receive data before a feed is considered down
  * @property {String} id UUID
  * @property {String} troubleshootingUrl
- * @property {String} type
+ * @property {String} type The name of the feed type
  * @property {String} updatedAt
  */
 
@@ -35,10 +35,8 @@ class FeedTypes {
    * API Endpoint: '/feeds/types'
    * Method: GET
    *
-   * @param {PaginationOptions} [paginationOptions]
-   *
    * @returns {Promise}
-   * @fulfill {FeedTypesFromServer} Information about the feed types
+   * @fulfill {FeedType[]} A list of feed types
    * @reject {Error}
    *
    * @example

--- a/src/iot/feedTypes.spec.js
+++ b/src/iot/feedTypes.spec.js
@@ -8,14 +8,14 @@ describe('Iot/FeedTypes', function() {
   let expectedFeedTypes;
 
   beforeEach(function() {
-    expectedFeedTypes = fixture.buildList(
-      'feedType',
-      3,
-      {},
-      { fromServer: true }
+    expectedFeedTypes = fixture.buildList('feedType', 3);
+
+    const serverFeedTypes = expectedFeedTypes.map((feedType) =>
+      fixture.build('feedType', feedType, { fromServer: true })
     );
+
     baseRequest = {
-      get: sinon.stub().resolves(expectedFeedTypes)
+      get: sinon.stub().resolves(serverFeedTypes)
     };
     baseSdk = {
       config: {
@@ -38,19 +38,10 @@ describe('Iot/FeedTypes', function() {
       return feedTypes.getAll().then((feedTypes) => {
         expect(feedTypes.length).to.equal(expectedFeedTypes.length);
         expectedFeedTypes.forEach((expectedFeedType) => {
-          expect(
-            feedTypes.findIndex((feed) => feed.id === expectedFeedType.id)
-          ).to.not.equal(-1);
-        });
-      });
-    });
-
-    it('returns camel-cased properties', function() {
-      return feedTypes.getAll().then((feedTypes) => {
-        feedTypes.forEach((feedType) => {
-          Object.keys(feedType).forEach((key) => {
-            expect(key).to.not.contain('_');
-          });
+          const outputFeedType = feedTypes.find(
+            (feedType) => feedType.id === expectedFeedType.id
+          );
+          expect(outputFeedType).to.deep.equal(expectedFeedType);
         });
       });
     });

--- a/src/iot/feedTypes.spec.js
+++ b/src/iot/feedTypes.spec.js
@@ -1,0 +1,58 @@
+import FeedTypes from './feedTypes';
+
+describe('Iot/FeedTypes', function() {
+  let baseRequest;
+  let baseSdk;
+  let expectedHost;
+  let feedTypes;
+  let expectedFeedTypes;
+
+  beforeEach(function() {
+    expectedFeedTypes = fixture.buildList(
+      'feedType',
+      3,
+      {},
+      { fromServer: true }
+    );
+    baseRequest = {
+      get: sinon.stub().resolves(expectedFeedTypes)
+    };
+    baseSdk = {
+      config: {
+        audiences: {
+          iot: fixture.build('audience')
+        }
+      }
+    };
+    expectedHost = faker.internet.url();
+
+    feedTypes = new FeedTypes(baseSdk, baseRequest, expectedHost);
+  });
+
+  afterEach(function() {
+    sinon.restore();
+  });
+
+  describe('getAll', function() {
+    it('returns feed types', function() {
+      return feedTypes.getAll().then((feedTypes) => {
+        expect(feedTypes.length).to.equal(expectedFeedTypes.length);
+        expectedFeedTypes.forEach((expectedFeedType) => {
+          expect(
+            feedTypes.findIndex((feed) => feed.id === expectedFeedType.id)
+          ).to.not.equal(-1);
+        });
+      });
+    });
+
+    it('returns camel-cased properties', function() {
+      return feedTypes.getAll().then((feedTypes) => {
+        feedTypes.forEach((feedType) => {
+          Object.keys(feedType).forEach((key) => {
+            expect(key).to.not.contain('_');
+          });
+        });
+      });
+    });
+  });
+});

--- a/src/iot/index.js
+++ b/src/iot/index.js
@@ -1,4 +1,5 @@
 import Feeds from './feeds';
+import FeedTypes from './feedTypes';
 import FieldCategories from './fieldCategories';
 import FieldGroupings from './fieldGroupings';
 import Fields from './fields';
@@ -24,6 +25,7 @@ class Iot {
     this._sdk = sdk;
 
     this.feeds = new Feeds(sdk, request, baseUrl);
+    this.feedTypes = new FeedTypes(sdk, request, baseUrl);
     this.fields = new Fields(sdk, request, baseUrl);
     this.outputs = new Outputs(sdk, request, baseUrl);
     this.fieldCategories = new FieldCategories(sdk, request, baseUrl);

--- a/src/iot/index.spec.js
+++ b/src/iot/index.spec.js
@@ -1,6 +1,7 @@
 import Fields from './fields';
 import Iot from './index';
 import Outputs from './outputs';
+import FeedTypes from './feedTypes';
 
 describe('Iot', function() {
   let baseRequest;
@@ -51,6 +52,10 @@ describe('Iot', function() {
 
     it('appends an instance of Outputs to the class instance', function() {
       expect(iot.outputs).to.be.an.instanceof(Outputs);
+    });
+
+    it('appends the supplied FeedTypes module to the class instance', function() {
+      expect(iot.feedTypes).to.be.an.instanceOf(FeedTypes);
     });
   });
 });

--- a/support/fixtures/factories/feedType.js
+++ b/support/fixtures/factories/feedType.js
@@ -10,6 +10,7 @@ factory
   .attrs({
     createdAt: () => faker.date.past().toISOString(),
     downAfter: () => faker.random.number({ min: 1000, max: 9999 }),
+    troubleshootingUrl: () => faker.internet.url(),
     type: () => faker.hacker.noun(),
     updatedAt: () => faker.date.recent().toISOString()
   })
@@ -22,6 +23,9 @@ factory
 
       feedType.down_after = feedType.downAfter;
       delete feedType.downAfter;
+
+      feedType.troubleshooting_url = feedType.troubleshootingUrl;
+      delete feedType.troubleshootingUrl;
 
       feedType.updated_at = feedType.updatedAt;
       delete feedType.updatedAt;


### PR DESCRIPTION
## Why?
To access the troubleshooting url on the feed type

## What changed?
Exposed a getAll endpoint for feeds
