### PR TITLE
Adds onAuthenticate optional config param to auth0WebAuth session type

### DIFF
--- a/docs/Auth0WebAuth.md
+++ b/docs/Auth0WebAuth.md
@@ -54,6 +54,7 @@ const contxtSdk = new ContxtSdk({
   config: {
     auth: {
       clientId: '<client id>',
+      onAuthenticate: (auth0WebAuthSessionInfo) => handleSuccessfulAuth(auth0WebAuthSessionInfo),
       onRedirect: (pathname) => history.push(pathname)
     }
   },

--- a/docs/ContxtSdk.md
+++ b/docs/ContxtSdk.md
@@ -36,6 +36,7 @@ const contxtSdk = new ContxtSdk({
         }
       },
       env: 'staging',
+      onAuthenticate: (auth0WebAuthSessionInfo) => handleSuccessfulAuth(auth0WebAuthSessionInfo),
       onRedirect: (pathname) => history.push(pathname)
     }
   },

--- a/docs/Typedefs.md
+++ b/docs/Typedefs.md
@@ -191,7 +191,7 @@ A single audience used for authenticating and communicating with an individual A
 
 | Param | Type | Description |
 | --- | --- | --- |
-| config.clientId | <code>string</code> | Client Id provided by Auth0 for the environment you are   trying to communicate with |
+| config.clientId | <code>string</code> | Client Id provided by Auth0 for the environment you are trying to communicate with |
 | config.host | <code>string</code> | Hostname for the API that corresponds with the clientId provided |
 | [config.webSocket] | <code>string</code> | WebSocket URL for the API that corresponds with the clientId provided |
 
@@ -216,7 +216,7 @@ More information at [axios Interceptors](https://github.com/axios/axios#intercep
 
 | Param | Type | Description |
 | --- | --- | --- |
-| interceptor.fulfilled | <code>function</code> | A function that is run on every successful request or   response |
+| interceptor.fulfilled | <code>function</code> | A function that is run on every successful request or response |
 | interceptor.rejected | <code>function</code> | A function that is run on every failed request or response |
 
 <a name="ContxtApplication"></a>
@@ -707,8 +707,8 @@ for authenticating and communicating with an individual API and the external mod
 
 | Param | Type | Description |
 | --- | --- | --- |
-| config.clientId | <code>string</code> | Client Id provided by Auth0 for the environment you are   trying to communicate with. Can be a `null` value if the value is not needed. Some SessionType   adapters (currently, just the MachineAuth adapter) require a value other than `null` if the   built-in `request` module is used since they acquire contxt tokens based on a single clientId. |
-| config.host | <code>string</code> | Hostname for the API that corresponds with the clientId provided.   Can be a `null` value if the value is not needed. |
+| config.clientId | <code>string</code> | Client Id provided by Auth0 for the environment you are trying to communicate with. Can be a `null` value if the value is not needed. Some SessionType adapters (currently, just the MachineAuth adapter) require a value other than `null` if the built-in `request` module is used since they acquire contxt tokens based on a single clientId. |
+| config.host | <code>string</code> | Hostname for the API that corresponds with the clientId provided. Can be a `null` value if the value is not needed. |
 | config.module | <code>function</code> | The module that will be decorated into the SDK |
 
 <a name="Facility"></a>
@@ -1243,14 +1243,15 @@ User provided configuration options
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | auth | <code>Object</code> |  | User assigned configurations specific for their authentication methods |
-| [auth.authorizationPath] | <code>string</code> |  | Path Auth0WebAuth process should redirect to after a   successful sign in attempt |
+| [auth.authorizationPath] | <code>string</code> |  | Path Auth0WebAuth process should redirect to after a successful sign in attempt |
 | auth.clientId | <code>string</code> |  | Client Id provided by Auth0 for this application |
-| [auth.clientSecret] | <code>string</code> |  | Client secret provided by Auth0 for this application. This   is optional for the auth0WebAuth SessionType, but required for the machineAuth SessionType |
-| [auth.customModuleConfigs] | <code>Object.&lt;string, CustomAudience&gt;</code> |  | Custom environment setups   for individual modules. Requires clientId/host or env |
-| [auth.env] | <code>string</code> | <code>&quot;&#x27;production&#x27;&quot;</code> | The environment that every module should use for   their clientId and host |
-| [auth.onRedirect] | <code>function</code> | <code>(pathname) &#x3D;&gt; { window.location &#x3D; pathname; }</code> | A redirect   method used for navigating through Auth0 callbacks in Web applications |
-| [auth.tokenExpiresAtBufferMs] | <code>number</code> | <code>300000</code> | The time (in milliseconds) before a   token truly expires that we consider it expired (i.e. the token's expiresAt - this = calculated   expiresAt). Defaults to 5 minutes. |
-| [interceptors] | <code>Object</code> |  | Axios interceptors that can transform requests and responses.   More information at [axios Interceptors](https://github.com/axios/axios#interceptors) |
+| [auth.clientSecret] | <code>string</code> |  | Client secret provided by Auth0 for this application. This is optional for the auth0WebAuth SessionType, but required for the machineAuth SessionType |
+| [auth.customModuleConfigs] | <code>Object.&lt;string, CustomAudience&gt;</code> |  | Custom environment setups for individual modules. Requires clientId/host or env |
+| [auth.env] | <code>string</code> | <code>&quot;&#x27;production&#x27;&quot;</code> | The environment that every module should use for their clientId and host |
+| [auth.onAuthenticate] | <code>function</code> | <code>(auth0WebAuthSessionInfo) &#x3D;&gt; handleSuccessfulAuth(auth0WebAuthSessionInfo);</code> | An optional hook for handling a successful authentication request or overriding returned values. |
+| [auth.onRedirect] | <code>function</code> | <code>(pathname) &#x3D;&gt; { window.location &#x3D; pathname; }</code> | A redirect method used for navigating through Auth0 callbacks in Web applications |
+| [auth.tokenExpiresAtBufferMs] | <code>number</code> | <code>300000</code> | The time (in milliseconds) before a token truly expires that we consider it expired (i.e. the token's expiresAt - this = calculated expiresAt). Defaults to 5 minutes. |
+| [interceptors] | <code>Object</code> |  | Axios interceptors that can transform requests and responses. More information at [axios Interceptors](https://github.com/axios/axios#interceptors) |
 | [interceptors.request] | [<code>Array.&lt;AxiosInterceptor&gt;</code>](#AxiosInterceptor) |  | Interceptors that act on every request |
 | [intercepotrs.response] | [<code>Array.&lt;AxiosInterceptor&gt;</code>](#AxiosInterceptor) |  | Intereptors that act on every response |
 

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -6,7 +6,7 @@ import defaultConfigs from './defaults';
  *
  * @typedef {Object} Audience
  * @param {string} config.clientId Client Id provided by Auth0 for the environment you are
- *   trying to communicate with
+ * trying to communicate with
  * @param {string} config.host Hostname for the API that corresponds with the clientId provided
  * @param {string} [config.webSocket] WebSocket URL for the API that corresponds with the clientId provided
  */
@@ -37,11 +37,11 @@ import defaultConfigs from './defaults';
  *
  * @typedef {Object} ExternalModule
  * @param {string} config.clientId Client Id provided by Auth0 for the environment you are
- *   trying to communicate with. Can be a `null` value if the value is not needed. Some SessionType
- *   adapters (currently, just the MachineAuth adapter) require a value other than `null` if the
- *   built-in `request` module is used since they acquire contxt tokens based on a single clientId.
+ * trying to communicate with. Can be a `null` value if the value is not needed. Some SessionType
+ * adapters (currently, just the MachineAuth adapter) require a value other than `null` if the
+ * built-in `request` module is used since they acquire contxt tokens based on a single clientId.
  * @param {string} config.host Hostname for the API that corresponds with the clientId provided.
- *   Can be a `null` value if the value is not needed.
+ * Can be a `null` value if the value is not needed.
  * @param {function} config.module The module that will be decorated into the SDK
  */
 
@@ -51,7 +51,7 @@ import defaultConfigs from './defaults';
  *
  * @typedef {Object} AxiosInterceptor
  * @param {function} interceptor.fulfilled A function that is run on every successful request or
- *   response
+ * response
  * @param {function} interceptor.rejected A function that is run on every failed request or response
  */
 
@@ -61,21 +61,23 @@ import defaultConfigs from './defaults';
  * @typedef {Object} UserConfig
  * @property {Object} auth User assigned configurations specific for their authentication methods
  * @property {string} [auth.authorizationPath] Path Auth0WebAuth process should redirect to after a
- *   successful sign in attempt
+ * successful sign in attempt
  * @property {string} auth.clientId Client Id provided by Auth0 for this application
  * @property {string} [auth.clientSecret] Client secret provided by Auth0 for this application. This
- *   is optional for the auth0WebAuth SessionType, but required for the machineAuth SessionType
+ * is optional for the auth0WebAuth SessionType, but required for the machineAuth SessionType
  * @property {Object.<string, CustomAudience>} [auth.customModuleConfigs] Custom environment setups
- *   for individual modules. Requires clientId/host or env
+ * for individual modules. Requires clientId/host or env
  * @property {string} [auth.env = 'production'] The environment that every module should use for
- *   their clientId and host
+ * their clientId and host
+ * @property {function} [auth.onAuthenticate = (auth0WebAuthSessionInfo) => handleSuccessfulAuth(auth0WebAuthSessionInfo); ] An optional
+ * hook for handling a successful authentication request or overriding returned values.
  * @property {function} [auth.onRedirect = (pathname) => { window.location = pathname; }] A redirect
- *   method used for navigating through Auth0 callbacks in Web applications
+ * method used for navigating through Auth0 callbacks in Web applications
  * @property {number} [auth.tokenExpiresAtBufferMs = 300000] The time (in milliseconds) before a
- *   token truly expires that we consider it expired (i.e. the token's expiresAt - this = calculated
- *   expiresAt). Defaults to 5 minutes.
+ * token truly expires that we consider it expired (i.e. the token's expiresAt - this = calculated
+ * expiresAt). Defaults to 5 minutes.
  * @property {Object} [interceptors] Axios interceptors that can transform requests and responses.
- *   More information at {@link https://github.com/axios/axios#interceptors axios Interceptors}
+ * More information at {@link https://github.com/axios/axios#interceptors axios Interceptors}
  * @property {AxiosInterceptor[]} [interceptors.request] Interceptors that act on every request
  * @property {AxiosInterceptor[]} [intercepotrs.response] Intereptors that act on every response
  */

--- a/src/index.js
+++ b/src/index.js
@@ -50,6 +50,7 @@ import * as sessionTypes from './sessionTypes';
  *         }
  *       },
  *       env: 'staging',
+ *       onAuthenticate: (auth0WebAuthSessionInfo) => handleSuccessfulAuth(auth0WebAuthSessionInfo),
  *       onRedirect: (pathname) => history.push(pathname)
  *     }
  *   },

--- a/src/sessionTypes/auth0WebAuth.js
+++ b/src/sessionTypes/auth0WebAuth.js
@@ -75,6 +75,8 @@ class Auth0WebAuth {
       throw new Error('clientId is required for the WebAuth config');
     }
 
+    this._onAuthenticate =
+      this._sdk.config.auth.onAuthenticate || this._defaultOnAuthenticate;
     this._onRedirect =
       this._sdk.config.auth.onRedirect || this._defaultOnRedirect;
     this._sessionInfo = this._getStoredSession();
@@ -205,6 +207,7 @@ class Auth0WebAuth {
    */
   handleAuthentication() {
     return this._parseHash()
+      .then(this._onAuthenticate)
       .then((authResult) => {
         this._storeSession(authResult);
         this._scheduleSessionRefresh();
@@ -305,6 +308,16 @@ class Auth0WebAuth {
    */
   _defaultOnRedirect(pathname) {
     window.location = pathname;
+  }
+
+  /**
+   * Default method used for intercepting a successful authentication result. Overridden
+   * by `onAuthenticate` in the auth config
+   *
+   * @private
+   */
+  _defaultOnAuthenticate(authResult) {
+    return authResult;
   }
 
   /**

--- a/src/sessionTypes/auth0WebAuth.js
+++ b/src/sessionTypes/auth0WebAuth.js
@@ -47,6 +47,7 @@ import URL from 'url-parse';
  *   config: {
  *     auth: {
  *       clientId: '<client id>',
+ *       onAuthenticate: (auth0WebAuthSessionInfo) => handleSuccessfulAuth(auth0WebAuthSessionInfo),
  *       onRedirect: (pathname) => history.push(pathname)
  *     }
  *   },

--- a/support/fixtures/factories/authResults.js
+++ b/support/fixtures/factories/authResults.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const factory = require('rosie').Factory;
+const faker = require('faker');
+
+factory.define('Auth0WebAuthSessionInfo').attrs({
+  accessToken: () => faker.random.uuid(),
+  expiresAt: () => sometimeSoon(2, 24)
+});
+
+factory.define('MachineAuthSessionInfo').attrs({
+  apiToken: () => faker.random.uuid(),
+  expiresAt: () => sometimeSoon(2, 24)
+});
+
+const sometimeSoon = (minHours, maxHours) => {
+  const hoursToMs = (hours) => hours * 60 * 60 * 1000;
+
+  const range = {
+    min: hoursToMs(minHours),
+    max: hoursToMs(maxHours)
+  };
+
+  const date = new Date();
+
+  let future = date.getTime();
+  future += faker.random.number(range);
+  date.setTime(future);
+
+  return date;
+};


### PR DESCRIPTION
## Why?
[Auth Issues](https://lineagelogistics.atlassian.net/browse/MOB-3701)

An application is throwing errors because it's attempting to log out after the user session has already expired. The application is checking the `expires_at` value to determine if the session actually needs to be closed, however, the `expires_at` timestamp describes the expiration time of the Auth0 access token (24 hours) and not the Okta saml session (2 hours). 

It's not possible to change the Auth0 access token expiration for just one particular app and it's not possible to change the Okta expiration time. Instead, a mechanism is needed to override the `expires_at` value prior to the session being saved to localStorage. 

## What changed?

- Added a function `onAuthenticate` 

```js
 const contxtSdk = new ContxtSdk({
   config: {
     auth: {
       clientId: '<client id>',
       onAuthenticate: (auth0WebAuthSessionInfo) => {

            // force expiration timestamp to be 2 hours from now
            auth0WebAuthSessionInfo.expiresIn = 7600; // 2 hours in seconds

            return auth0WebAuthSessionInfo;
       }
     }
   },
   sessionType: 'auth0WebAuth'
 });
```