### PR TITLE
Bugfix/organization endpoints

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,5 @@
 ## Why?
 
-
 ## What changed?
+
+- [ ] Did you update the CHANGELOG?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [v2.13.1](http://github.com/ndustrialio/contxt-sdk-js/tree/v2.13.1) (2020-04-16)
+
+**Fixed**
+
+- Fixed `Coordinator.organizations#getAll` to work with the access endpoints when an organizationId has been selected
+
 ## [v2.12.0](http://github.com/ndustrialio/contxt-sdk-js/tree/v2.12.0) (2020-03-13)
 
 **Added**

--- a/src/coordinator/index.js
+++ b/src/coordinator/index.js
@@ -24,6 +24,7 @@ class Coordinator {
     this._sdk = sdk;
 
     this._accessBaseUrl = null;
+    this._accessTenantBaseUrl = null;
     this._deployBaseUrl = null;
     this._organizationId = null;
 
@@ -49,6 +50,10 @@ class Coordinator {
     this._organizationId = organizationId;
 
     this._accessBaseUrl = this._organizationId
+      ? `${this._sdk.config.audiences.coordinator.host}/access/v1`
+      : null;
+
+    this._accessTenantBaseUrl = this._organizationId
       ? `${this._sdk.config.audiences.coordinator.host}/access/v1/${
           this._organizationId
         }`
@@ -87,19 +92,19 @@ class Coordinator {
     this.permissions = new Permissions(
       this._sdk,
       this._request,
-      this._accessBaseUrl || this._baseUrl,
+      this._accessTenantBaseUrl || this._baseUrl,
       this._organizationId
     );
     this.roles = new Roles(
       this._sdk,
       this._request,
-      this._accessBaseUrl || this._baseUrl,
+      this._accessTenantBaseUrl || this._baseUrl,
       this._organizationId
     );
     this.users = new Users(
       this._sdk,
       this._request,
-      this._accessBaseUrl || this._baseUrl,
+      this._accessTenantBaseUrl || this._baseUrl,
       this._organizationId
     );
   }

--- a/src/coordinator/index.spec.js
+++ b/src/coordinator/index.spec.js
@@ -237,6 +237,7 @@ describe('Coordinator', function() {
       });
 
       it('sets the access and deploy base urls on the class instance to null', function() {
+        expect(coordinator._accessBaseUrl).to.equal(null);
         expect(coordinator._accessTenantBaseUrl).to.equal(null);
         expect(coordinator._deployBaseUrl).to.equal(null);
       });

--- a/src/coordinator/index.spec.js
+++ b/src/coordinator/index.spec.js
@@ -52,6 +52,10 @@ describe('Coordinator', function() {
       expect(coordinator._accessBaseUrl).to.equal(null);
     });
 
+    it('sets the access tenant base url to null', function() {
+      expect(coordinator._accessTenantBaseUrl).to.equal(null);
+    });
+
     it('sets the deploy base url to null', function() {
       expect(coordinator._deployBaseUrl).to.equal(null);
     });
@@ -134,6 +138,9 @@ describe('Coordinator', function() {
 
       it('sets the access and deploy base urls to the class instance', function() {
         expect(coordinator._accessBaseUrl).to.equal(
+          `${baseSdk.config.audiences.coordinator.host}/access/v1`
+        );
+        expect(coordinator._accessTenantBaseUrl).to.equal(
           `${baseSdk.config.audiences.coordinator.host}/access/v1/${
             organization.id
           }`
@@ -180,9 +187,7 @@ describe('Coordinator', function() {
       it('appends a new instance of Organizations to the class instance with the correct tenant base url', function() {
         expect(coordinator.organizations).to.be.an.instanceof(Organizations);
         expect(coordinator.organizations._baseUrl).to.equal(
-          `${baseSdk.config.audiences.coordinator.host}/access/v1/${
-            organization.id
-          }`
+          `${baseSdk.config.audiences.coordinator.host}/access/v1`
         );
         expect(coordinator.organizations._organizationId).to.equal(
           organization.id
@@ -232,7 +237,7 @@ describe('Coordinator', function() {
       });
 
       it('sets the access and deploy base urls on the class instance to null', function() {
-        expect(coordinator._accessBaseUrl).to.equal(null);
+        expect(coordinator._accessTenantBaseUrl).to.equal(null);
         expect(coordinator._deployBaseUrl).to.equal(null);
       });
 

--- a/src/coordinator/organizations.js
+++ b/src/coordinator/organizations.js
@@ -50,7 +50,7 @@ class Organizations {
   get(organizationId) {
     if (this._organizationId) {
       return this._request
-        .get(`${this._baseUrl}`)
+        .get(`${this._baseUrl}/${this._organizationId}`)
         .then((org) => toCamelCase(org));
     }
 

--- a/src/coordinator/organizations.spec.js
+++ b/src/coordinator/organizations.spec.js
@@ -207,7 +207,9 @@ describe('Coordinator/Organizations', function() {
         });
 
         it('gets the organization from the server and does not use the organization ID provided', function() {
-          expect(request.get).to.be.calledWith(`${expectedHost}`);
+          expect(request.get).to.be.calledWith(
+            `${expectedHost}/${expectedOrganizationId}`
+          );
         });
 
         it('formats the organization object', function() {
@@ -231,7 +233,9 @@ describe('Coordinator/Organizations', function() {
         });
 
         it('gets the organization from the server', function() {
-          expect(request.get).to.be.calledWith(`${expectedHost}`);
+          expect(request.get).to.be.calledWith(
+            `${expectedHost}/${expectedOrganizationId}`
+          );
         });
 
         it('formats the organization object', function() {


### PR DESCRIPTION
## Why?

The access endpoints are a little different depending on whether you are getting all organizations or just a single organization

When getting all organizations the endpoint is `/access/v1/organizations`
When getting a single organization the endpoint is `/access/v1/:organizationId`

These need to be handled a little differently

## What changed?
- Updated the organization methods on coordinator to differentiate between getting a single organization or getting all organizations
- Fixed/updated tests
- Updated the `CHANGELOG.md`
  - It hasn't been updated in a while
  - The current release is `v.2.13.0`
- Changed the pull request template so we hopefully don't fall behind on changelog updates