### PR TITLE
Fixed some Coordinator.users methods to work with the access endpoints when an organizationId has been selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [v2.13.2](http://github.com/ndustrialio/contxt-sdk-js/tree/v2.13.1) (2020-09-02)
+
+**Fixed**
+
+- Fiex `Coordinator.users#activate`, `Coodinator.users#get`, and `Coorindator.users#sync` to work with the access endpoints when an orgaizationId has been selected
+
 ## [v2.13.1](http://github.com/ndustrialio/contxt-sdk-js/tree/v2.13.1) (2020-04-16)
 
 **Fixed**

--- a/docs/Users.md
+++ b/docs/Users.md
@@ -6,7 +6,7 @@ Module that provides access to contxt users
 **Kind**: global class  
 
 * [Users](#Users)
-    * [new Users(sdk, request, baseUrl, [organizationId])](#new_Users_new)
+    * [new Users(sdk, request, baseUrl, [tenantBaseUrl], [legacyBaseUrl], [organizationId])](#new_Users_new)
     * [.activate(userId, user)](#Users+activate) ⇒ <code>Promise</code>
     * [.addApplication(userId, applicationId)](#Users+addApplication) ⇒ <code>Promise</code>
     * [.addRole(userId, roleId)](#Users+addRole) ⇒ <code>Promise</code>
@@ -22,13 +22,15 @@ Module that provides access to contxt users
 
 <a name="new_Users_new"></a>
 
-### new Users(sdk, request, baseUrl, [organizationId])
+### new Users(sdk, request, baseUrl, [tenantBaseUrl], [legacyBaseUrl], [organizationId])
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
 | sdk | <code>Object</code> |  | An instance of the SDK so the module can communicate with other modules |
 | request | <code>Object</code> |  | An instance of the request module tied to this module's audience. |
 | baseUrl | <code>string</code> |  | The base URL provided by the parent module |
+| [tenantBaseUrl] | <code>string</code> | <code>null</code> | The tenant base URL provided by the parent module |
+| [legacyBaseUrl] | <code>string</code> | <code>null</code> | The legacy base URL provided by the parent module |
 | [organizationId] | <code>string</code> | <code>null</code> | The organization ID to be used in tenant url requests |
 
 <a name="Users+activate"></a>
@@ -36,7 +38,7 @@ Module that provides access to contxt users
 ### contxtSdk.coordinator.users.activate(userId, user) ⇒ <code>Promise</code>
 Activates a new user
 
-API Endpoint: '/users/:userId/activate'
+API Endpoint: '/:organizationId/users/:userId/activate'
 Method: POST
 
 Note: Only valid for web users using auth0WebAuth session type
@@ -69,7 +71,7 @@ contxtSdk.coordinator.users
 ### contxtSdk.coordinator.users.addApplication(userId, applicationId) ⇒ <code>Promise</code>
 Adds a application to a user
 
-API Endpoint: '/users/:userId/applications/:applicationId'
+API Endpoint: '/:organizationId/users/:userId/applications/:applicationId'
 Method: GET
 
 **Kind**: instance method of [<code>Users</code>](#Users)  
@@ -93,7 +95,7 @@ contxtSdk.coordinator.users
 ### contxtSdk.coordinator.users.addRole(userId, roleId) ⇒ <code>Promise</code>
 Adds a role to a user
 
-API Endpoint: '/users/:userId/roles/:roleId'
+API Endpoint: '/:organizationId/users/:userId/roles/:roleId'
 Method: POST
 
 **Kind**: instance method of [<code>Users</code>](#Users)  
@@ -117,7 +119,7 @@ contxtSdk.coordinator.users
 ### contxtSdk.coordinator.users.addStack(userId, stackId, accessType) ⇒ <code>Promise</code>
 Adds a stack to a user
 
-API Endpoint: '/users/:userId/stacks/:stackId'
+API Endpoint: '/:organizationId/users/:userId/stacks/:stackId'
 Method: POST
 
 **Kind**: instance method of [<code>Users</code>](#Users)  
@@ -166,7 +168,7 @@ contxtSdk.coordinator.users
 Gets a list of users for a contxt organization
 
 Legacy API Endpoint: '/organizations/:organizationId/users'
-API Endpoint: '/users'
+API Endpoint: '/:organizationId/users'
 Method: GET
 
 **Kind**: instance method of [<code>Users</code>](#Users)  
@@ -191,7 +193,7 @@ Creates a new contxt user, adds them to an organization, and
 sends them an email invite link to do final account setup.
 
 Legacy API Endpoint: '/organizations/:organizationId/users'
-API Endpoint: '/users'
+API Endpoint: '/:organizationId/users'
 Method: POST
 
 Note: Only valid for web users using auth0WebAuth session type
@@ -227,7 +229,7 @@ contxtSdk.coordinator.users
 Removes a user from an organization
 
 Legacy API Endpoint: '/organizations/:organizationId/users/:userId'
-API Endpoint: '/users/:userId'
+API Endpoint: '/:organizationId/users/:userId'
 Method: DELETE
 
 **Kind**: instance method of [<code>Users</code>](#Users)  
@@ -250,7 +252,7 @@ contxtSdk.coordinator.users
 ### contxtSdk.coordinator.users.removeApplication(userId, applicationId) ⇒ <code>Promise</code>
 Removes a application from a user
 
-API Endpoint: '/users/:userId/applications/:applicationId'
+API Endpoint: '/:organizationId/users/:userId/applications/:applicationId'
 Method: DELETE
 
 **Kind**: instance method of [<code>Users</code>](#Users)  
@@ -273,7 +275,7 @@ contxtSdk.coordinator.users
 ### contxtSdk.coordinator.users.removeRole(userId, roleId) ⇒ <code>Promise</code>
 Removes a role from a user
 
-API Endpoint: '/users/:userId/roles/:roleId'
+API Endpoint: '/:organizationId/users/:userId/roles/:roleId'
 Method: DELETE
 
 **Kind**: instance method of [<code>Users</code>](#Users)  
@@ -296,7 +298,7 @@ contxtSdk.coordinator.users
 ### contxtSdk.coordinator.users.removeStack(userId, stackId) ⇒ <code>Promise</code>
 Removes a stack from a user
 
-API Endpoint: '/users/:userId/stacks/:stackId'
+API Endpoint: '/:organizationId/users/:userId/stacks/:stackId'
 Method: DELETE
 
 **Kind**: instance method of [<code>Users</code>](#Users)  

--- a/src/coordinator/index.js
+++ b/src/coordinator/index.js
@@ -104,7 +104,9 @@ class Coordinator {
     this.users = new Users(
       this._sdk,
       this._request,
+      this._accessBaseUrl || this._baseUrl,
       this._accessTenantBaseUrl || this._baseUrl,
+      this._baseUrl,
       this._organizationId
     );
   }

--- a/src/coordinator/index.spec.js
+++ b/src/coordinator/index.spec.js
@@ -216,12 +216,18 @@ describe('Coordinator', function() {
         expect(coordinator.roles._organizationId).to.equal(organization.id);
       });
 
-      it('appends a new instance of Users to the class instance with the correct tenant base url', function() {
+      it('appends a new instance of Users to the class instance with the correct legacy, access, and tenant base urls', function() {
         expect(coordinator.users).to.be.an.instanceof(Users);
         expect(coordinator.users._baseUrl).to.equal(
+          `${baseSdk.config.audiences.coordinator.host}/access/v1`
+        );
+        expect(coordinator.users._tenantBaseUrl).to.equal(
           `${baseSdk.config.audiences.coordinator.host}/access/v1/${
             organization.id
           }`
+        );
+        expect(coordinator.users._legacyBaseUrl).to.equal(
+          `${baseSdk.config.audiences.coordinator.host}/v1`
         );
         expect(coordinator.users._organizationId).to.equal(organization.id);
       });
@@ -290,9 +296,15 @@ describe('Coordinator', function() {
         expect(coordinator.roles._organizationId).to.equal(null);
       });
 
-      it('appends a new instance of Users to the class instance with the legacy base url', function() {
+      it('appends a new instance of Users to the class instance with the legacy base url as the access, tenant, and legacy urls', function() {
         expect(coordinator.users).to.be.an.instanceof(Users);
         expect(coordinator.users._baseUrl).to.equal(
+          `${baseSdk.config.audiences.coordinator.host}/v1`
+        );
+        expect(coordinator.users._tenantBaseUrl).to.equal(
+          `${baseSdk.config.audiences.coordinator.host}/v1`
+        );
+        expect(coordinator.users._legacyBaseUrl).to.equal(
           `${baseSdk.config.audiences.coordinator.host}/v1`
         );
         expect(coordinator.users._organizationId).to.equal(null);

--- a/src/coordinator/users.js
+++ b/src/coordinator/users.js
@@ -54,13 +54,37 @@ class Users {
    * @param {Object} sdk An instance of the SDK so the module can communicate with other modules
    * @param {Object} request An instance of the request module tied to this module's audience.
    * @param {string} baseUrl The base URL provided by the parent module
+   * @param {string} [tenantBaseUrl] The tenant base URL provided by the parent module
+   * @param {string} [legacyBaseUrl] The legacy base URL provided by the parent module
    * @param {string} [organizationId] The organization ID to be used in tenant url requests
    */
-  constructor(sdk, request, baseUrl, organizationId = null) {
+  constructor(
+    sdk,
+    request,
+    baseUrl,
+    tenantBaseUrl = null,
+    legacyBaseUrl = null,
+    organizationId = null
+  ) {
     this._baseUrl = baseUrl;
+    this._tenantBaseUrl = tenantBaseUrl;
+    this._legacyBaseUrl = legacyBaseUrl;
     this._request = request;
     this._sdk = sdk;
     this._organizationId = organizationId;
+  }
+
+  _getBaseUrl(type) {
+    switch (type) {
+      case 'legacy':
+        return this._legacyBaseUrl || this._baseUrl;
+
+      case 'access':
+        return this._baseUrl;
+
+      default:
+        return this._tenantBaseUrl || this._baseUrl;
+    }
   }
 
   /**
@@ -112,7 +136,7 @@ class Users {
 
     // Uses axios directly instead of this.request to bypass authorization interceptors
     return axios.post(
-      `${this._baseUrl}/users/${userId}/activate`,
+      `${this._getBaseUrl('access')}/users/${userId}/activate`,
       toSnakeCase(user)
     );
   }
@@ -152,7 +176,9 @@ class Users {
     }
 
     return this._request
-      .post(`${this._baseUrl}/users/${userId}/applications/${applicationId}`)
+      .post(
+        `${this._getBaseUrl()}/users/${userId}/applications/${applicationId}`
+      )
       .then((response) => toCamelCase(response));
   }
 
@@ -189,7 +215,7 @@ class Users {
     }
 
     return this._request
-      .post(`${this._baseUrl}/users/${userId}/roles/${roleId}`)
+      .post(`${this._getBaseUrl()}/users/${userId}/roles/${roleId}`)
       .then((response) => toCamelCase(response));
   }
 
@@ -235,7 +261,7 @@ class Users {
     }
 
     return this._request
-      .post(`${this._baseUrl}/users/${userId}/stacks/${stackId}`, {
+      .post(`${this._getBaseUrl()}/users/${userId}/stacks/${stackId}`, {
         access_type: accessType
       })
       .then((response) => toCamelCase(response));
@@ -267,7 +293,7 @@ class Users {
     }
 
     return this._request
-      .get(`${this._baseUrl}/users/${userId}`)
+      .get(`${this._getBaseUrl('access')}/users/${userId}`)
       .then((user) => toCamelCase(user));
   }
 
@@ -293,7 +319,7 @@ class Users {
   getByOrganizationId(organizationId) {
     if (this._organizationId) {
       return this._request
-        .get(`${this._baseUrl}/users`)
+        .get(`${this._getBaseUrl()}/users`)
         .then((orgUsers) => toCamelCase(orgUsers));
     }
 
@@ -306,7 +332,9 @@ class Users {
     }
 
     return this._request
-      .get(`${this._baseUrl}/organizations/${organizationId}/users`)
+      .get(
+        `${this._getBaseUrl('legacy')}/organizations/${organizationId}/users`
+      )
       .then((orgUsers) => toCamelCase(orgUsers));
   }
 
@@ -360,7 +388,7 @@ class Users {
       }
 
       return this._request
-        .post(`${this._baseUrl}/users`, toSnakeCase(user))
+        .post(`${this._getBaseUrl()}/users`, toSnakeCase(user))
         .then((response) => toCamelCase(response));
     }
 
@@ -384,7 +412,7 @@ class Users {
 
     return this._request
       .post(
-        `${this._baseUrl}/organizations/${organizationId}/users`,
+        `${this._getBaseUrl('legacy')}/organizations/${organizationId}/users`,
         toSnakeCase(user)
       )
       .then((response) => toCamelCase(response));
@@ -419,7 +447,7 @@ class Users {
         );
       }
 
-      return this._request.delete(`${this._baseUrl}/users/${userId}`);
+      return this._request.delete(`${this._getBaseUrl()}/users/${userId}`);
     }
 
     if (!organizationId) {
@@ -439,7 +467,9 @@ class Users {
     }
 
     return this._request.delete(
-      `${this._baseUrl}/organizations/${organizationId}/users/${userId}`
+      `${this._getBaseUrl(
+        'legacy'
+      )}/organizations/${organizationId}/users/${userId}`
     );
   }
 
@@ -479,7 +509,7 @@ class Users {
     }
 
     return this._request.delete(
-      `${this._baseUrl}/users/${userId}/applications/${applicationId}`
+      `${this._getBaseUrl()}/users/${userId}/applications/${applicationId}`
     );
   }
 
@@ -515,7 +545,7 @@ class Users {
     }
 
     return this._request.delete(
-      `${this._baseUrl}/users/${userId}/roles/${roleId}`
+      `${this._getBaseUrl()}/users/${userId}/roles/${roleId}`
     );
   }
 
@@ -551,7 +581,7 @@ class Users {
     }
 
     return this._request.delete(
-      `${this._baseUrl}/users/${userId}/stacks/${stackId}`
+      `${this._getBaseUrl()}/users/${userId}/stacks/${stackId}`
     );
   }
 
@@ -579,7 +609,9 @@ class Users {
       );
     }
 
-    return this._request.get(`${this._baseUrl}/users/${userId}/sync`);
+    return this._request.get(
+      `${this._getBaseUrl('access')}/users/${userId}/sync`
+    );
   }
 }
 


### PR DESCRIPTION
## Why?

Some "user" endpoints only exist as legacy endpoints and as access endpoints. When setting an `organizationId` to use tenant URLs, they would try to use the tenant endpoints and get a 404.

## What changed?
- Started passing the access, tenant, and legacy base URLs from the Coodinator module into the child Users module
- Added a `_getBaseUrl` that accepts one of 'legacy', 'access', or an undefined/default value and returns the correct base URL regardless of if an `organizationId` has been set or not
- Updated all methods to use `_getBaseUrl` method

- [x] Did you update the CHANGELOG?
