### PR TITLE
feat: Enable configurable Auth0 domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-## [v4.1.1](http://github.com/ndustrialio/contxt-sdk-js/tree/v4.1.0) (2021-02-05)
+## [v4.1.2](http://github.com/ndustrialio/contxt-sdk-js/tree/v4.1.2) (2021-02-12)
+
+**Changed**
+
+- Allows custom Auth0 domain to be passed via the configuration `config.auth.domain`
+
+## [v4.1.1](http://github.com/ndustrialio/contxt-sdk-js/tree/v4.1.1) (2021-02-05)
 
 **Fixed**
 

--- a/docs/Typedefs.md
+++ b/docs/Typedefs.md
@@ -1282,7 +1282,7 @@ User provided configuration options
 | auth | <code>Object</code> |  | User assigned configurations specific for their authentication methods |
 | [auth.authorizationPath] | <code>string</code> |  | Path Auth0WebAuth process should redirect to after a successful sign in attempt |
 | auth.clientId | <code>string</code> |  | Client Id provided by Auth0 for this application |
-| [auth.clientSecret] | <code>string</code> |  | Client secret provided by Auth0 for this application. This is optional for the auth0WebAuth SessionType, but required for the machineAuth SessionType * @property {string} auth.domain Auth0 domain used to authorization for this application |
+| [auth.clientSecret] | <code>string</code> |  | Client secret provided by Auth0 for this application. This is optional for the auth0WebAuth SessionType, but required for the machineAuth SessionType |
 | [auth.domain] | <code>string</code> |  | Auth0 domain for this application. This is an optional configuration that defaults to the production Auth0 tenant |
 | [auth.customModuleConfigs] | <code>Object.&lt;string, CustomAudience&gt;</code> |  | Custom environment setups for individual modules. Requires clientId/host or env |
 | [auth.env] | <code>string</code> | <code>&quot;&#x27;production&#x27;&quot;</code> | The environment that every module should use for their clientId and host |

--- a/docs/Typedefs.md
+++ b/docs/Typedefs.md
@@ -1282,7 +1282,8 @@ User provided configuration options
 | auth | <code>Object</code> |  | User assigned configurations specific for their authentication methods |
 | [auth.authorizationPath] | <code>string</code> |  | Path Auth0WebAuth process should redirect to after a successful sign in attempt |
 | auth.clientId | <code>string</code> |  | Client Id provided by Auth0 for this application |
-| [auth.clientSecret] | <code>string</code> |  | Client secret provided by Auth0 for this application. This is optional for the auth0WebAuth SessionType, but required for the machineAuth SessionType |
+| [auth.clientSecret] | <code>string</code> |  | Client secret provided by Auth0 for this application. This is optional for the auth0WebAuth SessionType, but required for the machineAuth SessionType * @property {string} auth.domain Auth0 domain used to authorization for this application |
+| [auth.domain] | <code>string</code> |  | Auth0 domain for this application. This is an optional configuration that defaults to the production Auth0 tenant |
 | [auth.customModuleConfigs] | <code>Object.&lt;string, CustomAudience&gt;</code> |  | Custom environment setups for individual modules. Requires clientId/host or env |
 | [auth.env] | <code>string</code> | <code>&quot;&#x27;production&#x27;&quot;</code> | The environment that every module should use for their clientId and host |
 | [auth.onAuthenticate] | <code>function</code> | <code>(auth0WebAuthSessionInfo) &#x3D;&gt; handleSuccessfulAuth(auth0WebAuthSessionInfo);</code> | An optional hook for handling a successful authentication request or overriding returned values. |

--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -1,5 +1,6 @@
 export default {
   auth: {
+    domain: 'ndustrial.auth0.com',
     authorizationPath: '/callback',
     tokenExpiresAtBufferMs: 5 * 60 * 1000 // 5 minutes
   },

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -65,7 +65,6 @@ import defaultConfigs from './defaults';
  * @property {string} auth.clientId Client Id provided by Auth0 for this application
  * @property {string} [auth.clientSecret] Client secret provided by Auth0 for this application. This
  * is optional for the auth0WebAuth SessionType, but required for the machineAuth SessionType
- * * @property {string} auth.domain Auth0 domain used to authorization for this application
  * @property {string} [auth.domain] Auth0 domain for this application. This is an optional configuration
  * that defaults to the production Auth0 tenant
  * @property {Object.<string, CustomAudience>} [auth.customModuleConfigs] Custom environment setups

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -65,6 +65,9 @@ import defaultConfigs from './defaults';
  * @property {string} auth.clientId Client Id provided by Auth0 for this application
  * @property {string} [auth.clientSecret] Client secret provided by Auth0 for this application. This
  * is optional for the auth0WebAuth SessionType, but required for the machineAuth SessionType
+ * * @property {string} auth.domain Auth0 domain used to authorization for this application
+ * @property {string} [auth.domain] Auth0 domain for this application. This is an optional configuration
+ * that defaults to the production Auth0 tenant
  * @property {Object.<string, CustomAudience>} [auth.customModuleConfigs] Custom environment setups
  * for individual modules. Requires clientId/host or env
  * @property {string} [auth.env = 'production'] The environment that every module should use for

--- a/src/sessionTypes/auth0WebAuth.js
+++ b/src/sessionTypes/auth0WebAuth.js
@@ -90,7 +90,7 @@ class Auth0WebAuth {
     this._auth0 = new auth0.WebAuth({
       audience: this._sdk.config.audiences.contxtAuth.clientId,
       clientID: this._sdk.config.auth.clientId,
-      domain: 'ndustrial.auth0.com',
+      domain: this._sdk.config.auth.domain,
       redirectUri: `${currentUrl.origin}${currentUrl.pathname}`,
       responseType: 'token',
       scope: 'email profile openid'

--- a/src/sessionTypes/auth0WebAuth.spec.js
+++ b/src/sessionTypes/auth0WebAuth.spec.js
@@ -20,6 +20,7 @@ describe('sessionTypes/Auth0WebAuth', function() {
           facilities: fixture.build('audience')
         },
         auth: {
+          domain: faker.internet.domainName(),
           authorizationPath: faker.hacker.noun(),
           clientId: faker.internet.password(),
           tokenExpiresAtBufferMs: faker.random.number()
@@ -108,7 +109,7 @@ describe('sessionTypes/Auth0WebAuth', function() {
         expect(webAuth).to.be.calledWith({
           audience: sdk.config.audiences.contxtAuth.clientId,
           clientID: sdk.config.auth.clientId,
-          domain: 'ndustrial.auth0.com',
+          domain: sdk.config.auth.domain,
           redirectUri: `${global.window.location}/${
             sdk.config.auth.authorizationPath
           }`,
@@ -142,6 +143,7 @@ describe('sessionTypes/Auth0WebAuth', function() {
         expectedOnRedirect = sinon.stub();
 
         sdk.config.auth.authorizationPath = expectedAuthorizationPath;
+        sdk.config.auth.domain = 'random.auth0.com';
         sdk.config.auth.onAuthenticate = expectedOnAuthenticate;
         sdk.config.auth.onRedirect = expectedOnRedirect;
 
@@ -161,6 +163,20 @@ describe('sessionTypes/Auth0WebAuth', function() {
         expect(redirectUri).to.match(
           new RegExp(`${expectedAuthorizationPath}$`)
         );
+      });
+
+      it('creates an auth0 WebAuth instance with the default settings', function() {
+        expect(webAuth).to.be.calledWithNew;
+        expect(webAuth).to.be.calledWith({
+          audience: sdk.config.audiences.contxtAuth.clientId,
+          clientID: sdk.config.auth.clientId,
+          domain: 'random.auth0.com',
+          redirectUri: `${global.window.location}/${
+            sdk.config.auth.authorizationPath
+          }`,
+          responseType: 'token',
+          scope: 'email profile openid'
+        });
       });
     });
 

--- a/src/sessionTypes/passwordGrantAuth.js
+++ b/src/sessionTypes/passwordGrantAuth.js
@@ -42,7 +42,7 @@ class PasswordGrantAuth {
     this._sessionInfo = {};
 
     this._auth0 = new auth0.Authentication({
-      domain: 'ndustrial.auth0.com',
+      domain: this._sdk.config.auth.domain,
       clientID: this._sdk.config.auth.clientId
     });
   }

--- a/src/sessionTypes/passwordGrantAuth.spec.js
+++ b/src/sessionTypes/passwordGrantAuth.spec.js
@@ -22,6 +22,7 @@ describe('sessionTypes/passwordGrantAuth', function() {
             facilities: fixture.build('audience')
           },
           auth: {
+            domain: faker.internet.domainName(),
             clientId: faker.internet.password()
           }
         }
@@ -38,7 +39,7 @@ describe('sessionTypes/passwordGrantAuth', function() {
     it('calls the auth0 Authentication constructor with the proper arguments', function() {
       expect(authentication).to.be.calledOnce;
       expect(authentication).to.be.calledWith({
-        domain: 'ndustrial.auth0.com',
+        domain: passwordGrantAuth._sdk.config.auth.domain,
         clientID: passwordGrantAuth._sdk.config.auth.clientId
       });
     });


### PR DESCRIPTION
## Why?

We need to be able to set the Auth0 tenant/domain from the consumer of the SDK.

## What changed?

Added configuration property with default value to specify the Auth0 domain.

- [X] Did you update the CHANGELOG?
