### PR TITLE
ci: add release step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,3 +20,40 @@ jobs:
         run: npm run lint
       - name: Run tests
         run: npm run test
+
+  release:
+    needs: tests
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - name: Bump version
+        uses: TriPSs/conventional-changelog-action@v3
+        id: version
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          git-user-name: "GitHub Actions"
+          git-user-email: "action@github.com"
+          preset: conventionalcommits
+          output-file: false
+      - name: Set new commit hash
+        run: echo "SHA=$(git rev-parse HEAD)" >> $GITHUB_ENV
+      - name: Create release
+        uses: actions/create-release@v1
+        if: steps.version.outputs.skipped == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.NIO_BOT_TOKEN }}
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          release_name: ${{ steps.version.outputs.tag }}
+          body: ${{ steps.version.outputs.clean_changelog }}
+          commitish: ${{ env.SHA }}
+      - name: Publish to NPM
+        if: steps.version.outputs.skipped == 'false'
+        env:
+          NPM_TOKEN: ${{ secrets.NIO_NPM_TOKEN }}
+        run: npm publish

--- a/README.md
+++ b/README.md
@@ -233,14 +233,4 @@ We use [jsdoc-to-markdown](https://github.com/jsdoc2md/jsdoc-to-markdown) for do
 
 ### Publishing
 
-There are certain steps that should be taken when publishing a release to NPM to avoid any issues or problems. After
-your pull request is approved and merged into `master`, follow the steps below.
-
-1.  Checkout `master` locally and perform a `git pull origin master` so your local repo is up to date with your merged changes.
-1.  Run `npm version x.x.x` in your terminal on `master` where the `x`'s are the new version numbers.
-    - This sets the new version in `package.json` and `package-lock.json` and also creates a new `git tag`.
-    - Example `npm version 0.30.1`
-1.  Perform a `git push --tags origin master` while on your local copy of `master`.
-1.  Perform an `npm publish` to publish the updated package to NPM.
-
-You've now successfully updated and published the package.
+New versions will be published automatically on merges to `main`. The changelog and version will be determined using [Conventional Commits](https://www.conventionalcommits.org/).


### PR DESCRIPTION
This uses [conventional commits](https://www.conventionalcommits.org/) to automate our release