### PR TITLE
feat: Allow arbitrary query

### DIFF
--- a/src/nionic/index.js
+++ b/src/nionic/index.js
@@ -50,6 +50,10 @@ class Nionic {
     });
   }
 
+  executeQuery(orgOrTenantId, query, variables = {}) {
+    return this._query(orgOrTenantId, { query, variables });
+  }
+
   getAllFacilities(orgOrTenantId) {
     return this._query(orgOrTenantId, {
       query: `


### PR DESCRIPTION
This leaves the org mapping to one spot, but allows a downstream user to pass the query they desire (this is why GraphQL isn't meant for SDKs 😉 )