### PR TITLE
Util function exports break sinon.spy/stub

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@ndustrial/contxt-sdk",
-      "version": "5.0.0",
+      "version": "5.1.0",
       "license": "ISC",
       "dependencies": {
         "auth0-js": "^9.14.2",

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import Iot from './iot';
 import Nionic from './nionic';
 import Request from './request';
 import * as sessionTypes from './sessionTypes';
+import { toSnakeCase, toCamelCase } from './utils/objects';
 
 /**
  * An adapter that allows the SDK to authenticate with different services and manage various tokens.
@@ -197,4 +198,4 @@ class ContxtSdk {
 }
 
 export default ContxtSdk;
-export { toSnakeCase, toCamelCase } from './utils/objects';
+export { toSnakeCase, toCamelCase };


### PR DESCRIPTION
## Why?

Directly exporting named exports from a file was causing the built version to have the named exports defined as getter properties on the sdk class instead of regular exported functions. This wasn't an issue normally, but when a consumer attempted to stub/spy these functions with sinon, it would fail. Importing the functions explicity, then exporting them separately causes the built index.js file to export the functions normally.

## What changed?

Changed to importing and exporting util functions in separate steps instead of all at once.

- [ ] Did you update the CHANGELOG?
