### PR TITLE
feat: message bus onClose, onError callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [v4.3.2](http://github.com/ndustrialio/contxt-sdk-js/tree/v4.3.2) (2023-01-31)
+
+**Changed**
+
+- adds onClose and onError callbacks to Message Bus connect.
+
 ## [v4.3.1](http://github.com/ndustrialio/contxt-sdk-js/tree/v4.3.1) (2022-03-17)
 
 **Changed**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 **Changed**
 
-- adds onClose and onError callbacks to Message Bus connect.
+- adds onClose and onError callbacks to Message Bus connect
+- custom message bus error callbacks are no longer overwritten
 - adds app and contxt lib version as API requests User-Agent header
 
 ## [v5.4.0](http://github.com/ndustrialio/contxt-sdk-js/tree/v5.4.0) (2022-03-17)

--- a/src/bus/index.js
+++ b/src/bus/index.js
@@ -142,6 +142,9 @@ class Bus {
           });
 
           ws.addEventListener("error", (errorEvent) => {
+            if (!this._webSockets[organizationId]) {
+              reject(errorEvent)
+            }
             if (onError) {
               try {
                 onError(organizationId, errorEvent);

--- a/src/bus/index.js
+++ b/src/bus/index.js
@@ -113,7 +113,7 @@ class Bus {
             resolve(this._webSockets[organizationId]);
           };
 
-          ws.onclose = (event) => {
+          ws.addEventListener("close", (event) => {
             this._webSockets[organizationId] = null;
             if (onClose) {
               try {
@@ -122,9 +122,9 @@ class Bus {
                 console.log('Message Bus Error calling onClose callback: ', ex)
               }
             }
-          };
+          });
 
-          ws.onerror = (errorEvent) => {
+          ws.addEventListener("error", (errorEvent) => {
             if (onError) {
               try {
                 onError(organizationId, errorEvent);
@@ -138,7 +138,7 @@ class Bus {
             } catch (ex) {
               console.log('Message Bus Error rejecting with error: ', ex)
             }
-          };
+          });
         })
         .catch((err) => {
           reject(err);

--- a/src/bus/index.js
+++ b/src/bus/index.js
@@ -73,9 +73,9 @@ class Bus {
    * @reject {errorEvent} The error event
    *
    * @example
-   * contxtSdk.bus.connect('4f0e51c6-728b-4892-9863-6d002e61204d', (evt) => {
+   * contxtSdk.bus.connect('4f0e51c6-728b-4892-9863-6d002e61204d', (orgId, evt) => {
    *   console.log(`connection closed: ${evt}`);
-   * }, (evt) => {
+   * }, (orgId, evt) => {
    *   console.log(`connection error: ${evt}`);
    * })
    *   .then((webSocket) => {

--- a/src/bus/index.js
+++ b/src/bus/index.js
@@ -119,7 +119,7 @@ class Bus {
               try {
                 onClose(organizationId, event);
               } catch (ex) {
-                // TODO log this
+                console.log('Message Bus Error calling onClose callback: ', ex)
               }
             }
           };
@@ -129,14 +129,14 @@ class Bus {
               try {
                 onError(organizationId, errorEvent);
               } catch (ex) {
-                // TODO log this
+                console.log('Message Bus Error calling onError callback: ', ex)
               }
             }
             // the rejection callback may not be valid any more, in the event that this was connected first, and therefore resolve was called
             try {
               reject(errorEvent);
             } catch (ex) {
-              // TODO log this
+              console.log('Message Bus Error rejecting with error: ', ex)
             }
           };
         })

--- a/src/bus/index.js
+++ b/src/bus/index.js
@@ -132,12 +132,6 @@ class Bus {
                 console.log('Message Bus Error calling onError callback: ', ex)
               }
             }
-            // the rejection callback may not be valid any more, in the event that this was connected first, and therefore resolve was called
-            try {
-              reject(errorEvent);
-            } catch (ex) {
-              console.log('Message Bus Error rejecting with error: ', ex)
-            }
           });
         })
         .catch((err) => {

--- a/src/bus/index.js
+++ b/src/bus/index.js
@@ -142,7 +142,9 @@ class Bus {
           });
 
           ws.addEventListener("error", (errorEvent) => {
-            if (!this._webSockets[organizationId]) {
+            const connected = this._webSockets[organizationId] != null;
+            this._webSockets[organizationId] = null;
+            if (!connected) {
               reject(errorEvent)
             }
             if (onError) {

--- a/src/bus/index.spec.js
+++ b/src/bus/index.spec.js
@@ -3,6 +3,14 @@ import proxyquire from 'proxyquire';
 import Channels from './channels';
 import WebSocketConnection from './webSocketConnection';
 
+function testOnClose(evt) {
+  console.log(`onClose called with: ${evt}`);
+}
+
+function testOnError(evt) {
+  console.log(`onError called with: ${evt}`);
+}
+
 describe('Bus', function() {
   let baseRequest;
   let baseSdk;
@@ -163,7 +171,10 @@ describe('Bus', function() {
             bus = new Bus(sdk, baseRequest);
             bus._baseWebSocketUrl = expectedHost;
 
-            promise = bus.connect(expectedOrganization.id);
+            promise = bus.connect(
+              expectedOrganization.id,
+              testOnClose
+            );
           });
 
           afterEach(function() {
@@ -192,6 +203,12 @@ describe('Bus', function() {
             beforeEach(function() {
               return promise.then(() => {
                 server.close();
+              });
+            });
+
+            it('calls the onClose callback', function() {
+              return promise.then(() => {
+                expect(testOnClose).to.be.called();
               });
             });
 
@@ -262,7 +279,11 @@ describe('Bus', function() {
               const bus = new Bus(sdk, baseRequest);
               bus._baseWebSocketUrl = expectedHost;
 
-              promise = bus.connect(expectedOrganization.id);
+              promise = bus.connect(
+                expectedOrganization.id,
+                testOnClose,
+                testOnError
+              );
             });
 
             afterEach(function() {
@@ -284,6 +305,12 @@ describe('Bus', function() {
             it('rejects with an error event', function() {
               return promise.catch((event) => {
                 expect(event.type).to.equal('error');
+              });
+            });
+
+            it('calls the onError callback', function() {
+              return promise.then(() => {
+                expect(testOnError).to.be.called();
               });
             });
           }

--- a/src/bus/index.spec.js
+++ b/src/bus/index.spec.js
@@ -145,6 +145,7 @@ describe('Bus', function() {
           let sdk;
           let server;
           let testOnClose;
+          let testOnClose2;
 
           beforeEach(function() {
             expectedApiToken = faker.internet.password();
@@ -162,6 +163,7 @@ describe('Bus', function() {
             );
 
             testOnClose = sinon.stub();
+            testOnClose2 = sinon.stub();
 
             bus = new Bus(sdk, baseRequest);
             bus._baseWebSocketUrl = expectedHost;
@@ -197,6 +199,8 @@ describe('Bus', function() {
           context('when the connection closes', function() {
             beforeEach(function() {
               return promise.then(() => {
+                const ws = bus._webSockets[expectedOrganization.id];
+                ws._webSocket.addEventListener("close", testOnClose2);
                 server.close();
               });
             });
@@ -204,6 +208,7 @@ describe('Bus', function() {
             it('calls the onClose callback', function() {
               return promise.then(() => {
                 expect(testOnClose).to.have.been.calledOnce;
+                expect(testOnClose2).to.have.been.calledOnce;
               });
             });
 

--- a/src/bus/webSocketConnection.js
+++ b/src/bus/webSocketConnection.js
@@ -36,7 +36,7 @@ class WebSocketConnection {
     this._webSocket = webSocket;
 
     if (this._webSocket) {
-      this._webSocket.onerror = this._onError;
+      this._webSocket.addEventListener("error", this._onError);
       this._webSocket.onmessage = this._onMessage;
     }
   }

--- a/src/request.js
+++ b/src/request.js
@@ -1,5 +1,7 @@
 import axios from 'axios';
 
+const { name: sdkName, version: sdkVersion } = require('../package.json');
+
 class Request {
   /**
    * @param {Object} sdk An instance of the SDK so the module can communicate with other modules
@@ -141,6 +143,7 @@ class Request {
       .getCurrentApiToken(this._audienceName)
       .then((apiToken) => {
         config.headers.common.Authorization = `Bearer ${apiToken}`;
+        config.headers.common['User-Agent'] = `${process.env.npm_package_name}/${process.env.npm_package_version} (${sdkName}/${sdkVersion})`;
 
         return config;
       });

--- a/src/request.js
+++ b/src/request.js
@@ -1,7 +1,15 @@
 import axios from 'axios';
 
-const { name: sdkName, version: sdkVersion } = require('../package.json');
+function loadSdkInfo() {
+  try {
+    const { name: sdkName, version: sdkVersion } = require('../package.json');
+    return { sdkName, sdkVersion };
+  } catch (e) {
+    return { sdkName: "@ndustrial/contxt-sdk", sdkVersion: "5.5.0+" };
+  }
+}
 
+const { sdkName, sdkVersion } = loadSdkInfo();
 class Request {
   /**
    * @param {Object} sdk An instance of the SDK so the module can communicate with other modules


### PR DESCRIPTION
## Why?
so that the user code can know when the connection is gone and then decide what to do

## What changed?
added optional callback functions to the connect function

- [x] Did you update the CHANGELOG?
