### PR TITLE
feat: add auto-ack flag on message bus client constructor

### DIFF
--- a/src/bus/index.js
+++ b/src/bus/index.js
@@ -36,6 +36,20 @@ import WebSocketConnection from './webSocketConnection';
  */
 
 /**
+ * Configuration object for the Bus
+ *
+ * @typedef {Object} BusConfig
+ * @property {boolean} autoAcknowledge
+ */
+
+/**
+ * @type {BusConfig}
+ */
+const defaultBusConfig = {
+  autoAcknowledge: true
+};
+
+/**
  * Module that provides access to the message bus. This is for Node
  * environments. Documentation for browser environments is found under
  * `BrowserBus`.
@@ -46,8 +60,9 @@ class Bus {
   /**
    * @param {Object} sdk An instance of the SDK so the module can communicate with other modules
    * @param {Object} request An instance of the request module tied to this module's audience.
+   * @param {BusConfig} config A config object for the Bus instance
    */
-  constructor(sdk, request) {
+  constructor(sdk, request, config) {
     const baseUrl = `${sdk.config.audiences.bus.host}`;
     const baseWebSocketUrl = `${sdk.config.audiences.bus.webSocket}`;
 
@@ -56,6 +71,7 @@ class Bus {
     this._request = request;
     this._sdk = sdk;
     this._webSockets = {};
+    this._config = Object.assign({}, defaultBusConfig, config);
 
     this.channels = new Channels(sdk, request, baseUrl);
   }
@@ -101,7 +117,8 @@ class Bus {
           ws.onopen = (event) => {
             this._webSockets[organizationId] = new WebSocketConnection(
               ws,
-              organizationId
+              organizationId,
+              this._config.autoAcknowledge
             );
 
             resolve(this._webSockets[organizationId]);

--- a/src/bus/index.spec.js
+++ b/src/bus/index.spec.js
@@ -290,6 +290,48 @@ describe('Bus', function() {
         );
       }
     );
+
+    context('when providing custom config', function() {
+      let bus;
+      let expectedApiToken;
+      let promise;
+      let sdk;
+      let server;
+      let busConfig
+
+      beforeEach(function() {
+        expectedApiToken = faker.internet.password();
+
+        sdk = {
+          ...baseSdk,
+          auth: {
+            ...baseSdk.auth,
+            getCurrentApiToken: sinon.stub().resolves(expectedApiToken)
+          }
+        };
+
+        server = new Server(
+          `${expectedHost}/organizations/${expectedOrganization.id}/stream`
+        );
+
+        busConfig = { autoAcknowledge: false };
+        bus = new Bus(sdk, baseRequest, busConfig);
+        bus._baseWebSocketUrl = expectedHost;
+
+        promise = bus.connect(expectedOrganization.id);
+      });
+
+      afterEach(function() {
+        server.stop();
+      });
+
+      it('passes the auto-acknowledge flag to the WebSocketConnection', function() {
+        return promise.then((resolvedWebSocket) => {
+          expect(resolvedWebSocket._autoAck).to.equal(busConfig.autoAcknowledge);
+        });
+      });
+
+    });
   });
 
   describe('getWebSocketConnection', function() {

--- a/src/bus/webSocketConnection.js
+++ b/src/bus/webSocketConnection.js
@@ -29,11 +29,13 @@ class WebSocketConnection {
   /**
    * @param {WebSocket} webSocket A WebSocket connection to the message bus
    * @param {string} organizationId UUID corresponding with an organization
+   * @param {boolean} autoAcknowledge Whether the messages should be ACK'd explicitly or not
    */
-  constructor(webSocket, organizationId) {
+  constructor(webSocket, organizationId, autoAcknowledge = true) {
     this._messageHandlers = {};
     this._organizationId = organizationId;
     this._webSocket = webSocket;
+    this._autoAck = autoAcknowledge;
 
     if (this._webSocket) {
       this._webSocket.onerror = this._onError;
@@ -282,20 +284,24 @@ class WebSocketConnection {
 
             if (error) {
               return resolve(errorHandler(error));
-            } else {
-              try {
-                const ack = once(() => {
-                  return this._acknowledge(result.id);
-                });
+            }
 
-                return resolve(
-                  Promise.resolve(handler(result.body, ack)).then((res) => {
+            try {
+              const ack = once(() => {
+                return this._acknowledge(result.id);
+              });
+
+              return resolve(
+                Promise.resolve(handler(result.body, ack)).then((res) => {
+                  if (this._autoAck) {
                     return ack().then(() => res);
-                  })
-                );
-              } catch (throwable) {
-                return reject(throwable);
-              }
+                  }
+
+                  return res;
+                })
+              );
+            } catch (throwable) {
+              return reject(throwable);
             }
           });
         };

--- a/src/bus/webSocketConnection.spec.js
+++ b/src/bus/webSocketConnection.spec.js
@@ -1755,6 +1755,51 @@ describe('Bus/WebSocketConnection', function() {
               });
           });
         });
+
+        context('and the client does not auto-ack', function() {
+          let errorHandler;
+
+          beforeEach(function() {
+            handler = sinon.stub().returns(null);
+            errorHandler = sinon.stub().returns(null);
+
+            ws = new WebSocketConnection(
+              expectedWebSocket,
+              expectedOrganization.id,
+              false
+            );
+
+            promise = ws.subscribe(
+              serviceId,
+              channel,
+              group,
+              handler,
+              errorHandler
+            );
+
+            jsonRpcId = Object.keys(ws._messageHandlers)[0];
+
+            ws._messageHandlers[jsonRpcId]({
+              result: {
+                subscription
+              }
+            });
+          });
+
+          it('doesn\'t call the ack function', function() {
+            return promise
+              .then(() => {
+                return ws._messageHandlers[subscription]({
+                  result: {
+                    error: message
+                  }
+                });
+              })
+              .catch(() => {
+                expect(acknowledge).to.not.be.called;
+              });
+          });
+        });
       });
 
       context('without a group', function() {

--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -7,5 +7,8 @@ export default {
   interceptors: {
     request: [],
     response: []
+  },
+  bus: {
+    autoAcknowledge: true
   }
 };

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -116,6 +116,11 @@ class Config {
       ...defaultConfigs.interceptors,
       ...userConfig.interceptors
     };
+
+    this.bus = {
+      ...defaultConfigs.bus,
+      ...userConfig.bus
+    };
   }
 
   addDynamicAudience(audienceName, { clientId, host }) {

--- a/src/index.js
+++ b/src/index.js
@@ -78,7 +78,7 @@ class ContxtSdk {
     this.config = new Config(config, externalModules);
 
     this.auth = this._createAuthSession(sessionType);
-    this.bus = new Bus(this, this._createRequest('bus'));
+    this.bus = new Bus(this, this._createRequest('bus'), this.config.bus);
     this.coordinator = new Coordinator(
       this,
       this._createRequest('coordinator')

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -76,6 +76,15 @@ describe('ContxtSdk', function() {
       expect(contxtSdk.bus).to.be.an.instanceof(Bus);
     });
 
+    it('passes bus config to the bus constructor', function() {
+      contxtSdk = new ContxtSdk({
+        config: {...baseConfig, bus: {autoAcknowledge: false}},
+        externalModules: expectedExternalModules,
+        sessionType: expectedAuthSessionType
+      });
+      expect(contxtSdk.bus._config).to.deep.equal({autoAcknowledge: false});
+    });
+
     it('sets an instance of Config', function() {
       expect(contxtSdk.config).to.be.an.instanceof(Config);
     });


### PR DESCRIPTION
## Why?

[SUP-3901](https://ndustrialio.atlassian.net/browse/SUP-3901)

To not acknowledge messages by default.

## What changed?

- Adds an `autoAck` flag on the `WebSocketConnection` constructor
- Adds a new config object on the `Bus` constructor
- Adds a new SDK config section for `bus` configs

```json
{
    "bus": {
        "autoAcknowledge": true
    }
}
```


[SUP-3901]: https://ndustrialio.atlassian.net/browse/SUP-3901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ