### PR TITLE
feat: peek messages on a subscription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [v5.3.1](http://github.com/ndustrialio/contxt-sdk-js/tree/v4.3.1) (2022-03-17)
+
+**Changed**
+
+- exposed `peek` operation on message bus channel for a given subscription
+
+## [v5.3.0](http://github.com/ndustrialio/contxt-sdk-js/tree/v4.3.1) (2022-03-17)
+
+**Changed**
+
+- add auto-ack flag on message bus client constructor
+
 ## [v4.3.1](http://github.com/ndustrialio/contxt-sdk-js/tree/v4.3.1) (2022-03-17)
 
 **Changed**

--- a/src/bus/channels.js
+++ b/src/bus/channels.js
@@ -231,6 +231,60 @@ class Channels {
       toSnakeCase(update)
     );
   }
+
+  /**
+   * Peeks messages from a channel subscription
+   *
+   * API Endpoint: '/organizations/:organizationId/services/:serviceId/channels/:channelId/peek/:subscription'
+   * Method: GET
+   *
+   * @param {string} organizationId UUID of the organization
+   * @param {string} serviceId ID of the service
+   * @param {string} channelId UUID of the channel
+   * @param {string} subscription name of the subscription
+   * @param {number} messagePos the number of messages to peek
+   *
+   * @returns {Promise}
+   * @fulfill {MessageBusChannel} Information about an event
+   * @reject {Error}
+   *
+   * @example
+   * contxtSdk.bus.channels
+   *   .peek(
+   *     '875afddd-091c-4385-bc21-0edf38804d27',
+   *     'ab123service',
+   *     '175afdec-291c-4385-bc21-0edf38804d21',
+   *     'test-subscription'
+   *   )
+   *   .then((channel) => console.log(channel))
+   *   .catch((err) => console.log(err));
+   */
+  peek(organizationId, serviceId, channelId, subscription, messagePos) {
+    let errorMsg;
+
+    if (!organizationId) {
+      errorMsg = 'An organizationId is required to peek a message bus channel subscription.';
+    } else if (!serviceId) {
+      errorMsg = 'A serviceId is required to peek a message bus channel subscription.';
+    } else if (!channelId) {
+      errorMsg = 'A channelId is required to peek a message bus channel subscription.';
+    } else if (!subscription) {
+      errorMsg = 'A subscription name is required to peek a message bus channel subscription.';
+    }
+
+    if (errorMsg) {
+      return Promise.reject(new Error(errorMsg));
+    }
+
+    return this._request
+      .get(
+        `${
+          this._baseUrl
+        }/organizations/${organizationId}/services/${serviceId}/channels/${channelId}/peek/${subscription}`,
+        { params: { messagePos } }
+      )
+      .then((response) => toCamelCase(response));
+  }
 }
 
 export default Channels;


### PR DESCRIPTION
## Why?

[CONTXT-4543 Peek feature in contxt-sdk-js](https://ndustrialio.atlassian.net/browse/CONTXT-4543)

## What changed?

- added a function to call the peek route recently added to the MB API

- [x] Did you update the CHANGELOG?
