### PR TITLE
fix: only set request User-Agent in Node mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [v5.6.0](http://github.com/ndustrialio/contxt-sdk-js/tree/v5.6.0) (2023-07-24)
+
+**Changed**
+
+- only set custom User-Agent request header in Node mode
+
 ## [v5.5.0](http://github.com/ndustrialio/contxt-sdk-js/tree/v5.5.0) (2023-06-14)
 
 **Changed**

--- a/src/request.js
+++ b/src/request.js
@@ -151,7 +151,7 @@ class Request {
       .getCurrentApiToken(this._audienceName)
       .then((apiToken) => {
         config.headers.common.Authorization = `Bearer ${apiToken}`;
-        if (typeof process === 'object') {
+        if (typeof window === 'undefined' && process.env.npm_package_name !== undefined) {
           config.headers.common['User-Agent'] = `${process.env.npm_package_name}/${process.env.npm_package_version} (${sdkName}/${sdkVersion})`;
         }
 

--- a/src/request.js
+++ b/src/request.js
@@ -151,7 +151,9 @@ class Request {
       .getCurrentApiToken(this._audienceName)
       .then((apiToken) => {
         config.headers.common.Authorization = `Bearer ${apiToken}`;
-        config.headers.common['User-Agent'] = `${process.env.npm_package_name}/${process.env.npm_package_version} (${sdkName}/${sdkVersion})`;
+        if (typeof process === 'object') {
+          config.headers.common['User-Agent'] = `${process.env.npm_package_name}/${process.env.npm_package_version} (${sdkName}/${sdkVersion})`;
+        }
 
         return config;
       });


### PR DESCRIPTION
## Why?

CONTXT-5111 - Nsight is intermittently throwing errors resulting in blank pages

## What changed?

- Only set a custom User-Agent header when running in Node (ie. not in browser)

- [x] Did you update the CHANGELOG?
