### PR TITLE
fix: corrected how nionic errors are caught and passed through

### DIFF
--- a/src/nionic/index.js
+++ b/src/nionic/index.js
@@ -40,7 +40,7 @@ class Nionic {
     const url = `${this._baseUrl.replace('<tenant>', tenantId)}/graphql`;
     return this._request.post(url, options).then((resp) => {
       if (resp.errors) {
-        return Promise.reject(Error(resp.errors));
+        return Promise.reject(Error(JSON.stringify(resp.errors)));
       }
       return Promise.resolve(resp.data);
     });

--- a/src/nionic/index.js
+++ b/src/nionic/index.js
@@ -39,8 +39,8 @@ class Nionic {
     const tenantId = this._getTenantId(orgOrTenantId);
     const url = `${this._baseUrl.replace('<tenant>', tenantId)}/graphql`;
     return this._request.post(url, options).then((resp) => {
-      if (resp.data && resp.data.errors) {
-        return Promise.reject(Error(resp.data.errors));
+      if (resp.errors) {
+        return Promise.reject(Error(resp.errors));
       }
       return Promise.resolve(resp.data);
     });


### PR DESCRIPTION
## Why?

- `_query` function within nionic module was not incorrectly checking for errors in the response. 

## What changed?

- Updated logic checking for errors in nionic query requests and passed errors to rejected promise.

- [ ] Did you update the CHANGELOG?
