### PR TITLE
ci: remove unnecessary if conditional in release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   tests:
@@ -25,7 +26,6 @@ jobs:
   release:
     needs: tests
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
ci: workflow already runs only when a push or a pr is merged into main

## Why?

## What changed?

- [ ] Did you update the CHANGELOG?
