### PR TITLE
fix: bump eslint compat to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@babel/eslint-parser": "^7.25.9",
         "@babel/preset-env": "^7.26.0",
         "@babel/register": "^7.25.9",
-        "@eslint/compat": "^1.2.2",
+        "@eslint/compat": "^1.3.1",
         "babel-plugin-istanbul": "^7.0.0",
         "chai": "^4.1.2",
         "chai-as-promised": "^7.1.1",
@@ -1723,16 +1723,16 @@
       }
     },
     "node_modules/@eslint/compat": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-1.2.4.tgz",
-      "integrity": "sha512-S8ZdQj/N69YAtuqFt7653jwcvuUj131+6qGLUyDqfDg1OIoBQ66OCuXC473YQfO2AaxITTutiRQiDwoo7ZLYyg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-1.3.1.tgz",
+      "integrity": "sha512-k8MHony59I5EPic6EQTCNOuPoVBnoYXkP+20xvwFjN7t0qI3ImyvyBgg+hIVPwC8JaxVjjUZld+cLfBLFDLucg==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "peerDependencies": {
-        "eslint": "^9.10.0"
+        "eslint": "^8.40 || 9"
       },
       "peerDependenciesMeta": {
         "eslint": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@babel/eslint-parser": "^7.25.9",
     "@babel/preset-env": "^7.26.0",
     "@babel/register": "^7.25.9",
-    "@eslint/compat": "^1.2.2",
+    "@eslint/compat": "^1.3.1",
     "babel-plugin-istanbul": "^7.0.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",


### PR DESCRIPTION
chore: mark this as a fix to trigger package publish

## Why?

## What changed?

- [ ] Did you update the CHANGELOG?
