### PR TITLE
feat(dependabot-vulnerability-scan): Create Jira issues automatically

### DIFF
--- a/.github/workflows/dependabot-alerts-to-jira.yaml
+++ b/.github/workflows/dependabot-alerts-to-jira.yaml
@@ -2,7 +2,7 @@ name: Dependabot Alerts → Jira (scheduled)
 
 on:
   schedule:
-- cron: '3 9 * * 1-5'
+    - cron: '3 9 * * 1-5'
   workflow_dispatch: {}
 
 permissions:


### PR DESCRIPTION
## Why?
- [CONTXT-12249 -- Automate Jira ticket creation for Github Dependabot issues](https://ndustrialio.atlassian.net/browse/CONTXT-12249)
- Create Jira issues automatically from from dependabot security alerts

## What changed?
- Added Workflow file to dispatch github action that checks dependabot for security alerts and then automatically creates the Jira issues for them
