### PR TITLE
chore: bump auth0-js from ^9.28.0 to ^10.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,10 +6,10 @@
   "packages": {
     "": {
       "name": "@ndustrial/contxt-sdk",
-      "version": "5.7.3",
+      "version": "5.7.4",
       "license": "ISC",
       "dependencies": {
-        "auth0-js": "^9.28.0",
+        "auth0-js": "^10.2.0",
         "axios": "^1.10.0",
         "change-case": "^4.1.2",
         "core-js": "^3.39.0",
@@ -2798,16 +2798,16 @@
       }
     },
     "node_modules/auth0-js": {
-      "version": "9.32.0",
-      "resolved": "https://registry.npmjs.org/auth0-js/-/auth0-js-9.32.0.tgz",
-      "integrity": "sha512-Vbt8W1sI3VLEdhaRNNP6Uq0qD5KUWQ4iSFn0nv03Xn4npC8r7YRUrvFrA27CCXK+ZV5fjy0Ajr/ElZ7ed97ukA==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/auth0-js/-/auth0-js-10.2.0.tgz",
+      "integrity": "sha512-QgYRu33gBhE+d2wqs0jV6vbtpCRPQEBMpQ4vK8pPMC8cvuuRtGe+52tXS0VlQGA/vP5xmgwDY7DY6W735WgHnA==",
       "license": "MIT",
       "dependencies": {
         "base64-js": "^1.5.1",
         "idtoken-verifier": "^2.2.4",
-        "js-cookie": "^2.2.0",
+        "js-cookie": "^3.0.7",
         "minimist": "^1.2.5",
-        "qs": "^6.10.1",
+        "qs": "^6.15.2",
         "superagent": "^10.2.3",
         "url-join": "^4.0.1",
         "winchan": "^0.2.2"
@@ -5831,9 +5831,10 @@
       }
     },
     "node_modules/js-cookie": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
-      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.8.tgz",
+      "integrity": "sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==",
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     ]
   },
   "dependencies": {
-    "auth0-js": "^9.28.0",
+    "auth0-js": "^10.2.0",
     "axios": "^1.10.0",
     "change-case": "^4.1.2",
     "core-js": "^3.39.0",


### PR DESCRIPTION
## Why?

## What changed?

- [ ] Did you update the CHANGELOG?
